### PR TITLE
wave6: stream PDF pages via AsyncIterable

### DIFF
--- a/app/src/App.panels.test.tsx
+++ b/app/src/App.panels.test.tsx
@@ -20,7 +20,14 @@ vi.mock('./ocr/runOcr', () => ({
 vi.mock('./ui/renderPdfPages', () => ({
   loadPdfjs: vi.fn(async () => ({})),
   renderPageToCanvas: vi.fn(async () => {}),
-  renderPdfPages: vi.fn(async () => {}),
+  renderPdfPages: vi.fn(
+    (): AsyncIterable<{ pageIndex: number }> => ({
+      // Empty async iterator: no pages to yield; Promise-style consumers (e.g.
+      // `for await (…)` in PdfViewer) complete immediately.
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async *[Symbol.asyncIterator]() {},
+    }),
+  ),
 }));
 
 import { App } from './App';

--- a/app/src/ui/PdfViewer.tsx
+++ b/app/src/ui/PdfViewer.tsx
@@ -26,12 +26,24 @@ export function PdfViewer({
     const canvases = canvasRefs.current.slice(0, pageCount);
     const controller = new AbortController();
     // pdf.js detaches the ArrayBuffer during load, so each render call
-    // gets its own copy.
-    renderPdfPages(copyBytes(bytes), canvases, { signal: controller.signal }).catch((err: unknown) => {
-      const name = (err as { name?: string })?.name;
-      if (name === 'AbortError' || name === 'RenderingCancelledException') return;
-      console.error('[PdfViewer] render failed:', err);
+    // gets its own copy. `renderPdfPages` streams: each iteration corresponds
+    // to a single page finishing. First-paint latency is ~1 page, not N.
+    const iterable = renderPdfPages(copyBytes(bytes), canvases, {
+      signal: controller.signal,
     });
+    void (async () => {
+      try {
+        for await (const _page of iterable) {
+          // Canvas already painted inside renderPdfPages; nothing to do per
+          // page today. Hook placeholder for future per-page reactions.
+          void _page;
+        }
+      } catch (err: unknown) {
+        const name = (err as { name?: string })?.name;
+        if (name === 'AbortError' || name === 'RenderingCancelledException') return;
+        console.error('[PdfViewer] render failed:', err);
+      }
+    })();
     return (): void => {
       controller.abort();
     };

--- a/app/src/ui/renderPdfPages.test.ts
+++ b/app/src/ui/renderPdfPages.test.ts
@@ -3,8 +3,8 @@ import { renderPdfPages } from './renderPdfPages';
 import { makePdf } from '../parser/testFixtures';
 
 // jsdom returns null from canvas.getContext('2d') (with a single "not
-// implemented" warning). renderPdfPages treats that as "nothing to render on"
-// and `continue`s past the pdf.js render call, which lets us exercise the
+// implemented" warning). renderPdfPages treats that as "nothing to paint on"
+// and yields the page slot immediately, which lets us exercise the
 // AbortSignal lifecycle without needing a real canvas backend.
 function stubCanvas(): HTMLCanvasElement {
   const canvas = document.createElement('canvas');
@@ -16,31 +16,42 @@ async function makeSmallPdf(): Promise<Uint8Array> {
   return makePdf([{ blocks: [{ text: 'hello', x: 72, y: 72 }] }]);
 }
 
-describe('renderPdfPages (AbortSignal)', () => {
-  it('resolves successfully on the golden path', async () => {
+async function drain(
+  iter: AsyncIterable<{ pageIndex: number }>,
+): Promise<number[]> {
+  const seen: number[] = [];
+  for await (const p of iter) seen.push(p.pageIndex);
+  return seen;
+}
+
+describe('renderPdfPages (AsyncIterable + AbortSignal)', () => {
+  it('iterates to completion on the golden path', async () => {
     const bytes = await makeSmallPdf();
     const canvas = stubCanvas();
     const controller = new AbortController();
-    await expect(
+    const pages = await drain(
       renderPdfPages(new Uint8Array(bytes), [canvas], { signal: controller.signal }),
-    ).resolves.toBeUndefined();
+    );
+    expect(pages).toEqual([0]);
   });
 
-  it('rejects with AbortError when the signal is already aborted', async () => {
+  it('throws AbortError when the signal is already aborted', async () => {
     const bytes = await makeSmallPdf();
     const canvas = stubCanvas();
     const controller = new AbortController();
     controller.abort();
     await expect(
-      renderPdfPages(new Uint8Array(bytes), [canvas], { signal: controller.signal }),
+      drain(renderPdfPages(new Uint8Array(bytes), [canvas], { signal: controller.signal })),
     ).rejects.toMatchObject({ name: 'AbortError' });
   });
 
-  it('rejects with AbortError when aborted between load and render', async () => {
+  it('throws AbortError when aborted between load and render', async () => {
     const bytes = await makeSmallPdf();
     const canvas = stubCanvas();
     const controller = new AbortController();
-    const p = renderPdfPages(new Uint8Array(bytes), [canvas], { signal: controller.signal });
+    const p = drain(
+      renderPdfPages(new Uint8Array(bytes), [canvas], { signal: controller.signal }),
+    );
     // Abort synchronously after kickoff; the next `signal.aborted` check after
     // any internal await (loadPdfjs / getDocument / getPage) will throw.
     controller.abort();
@@ -51,17 +62,136 @@ describe('renderPdfPages (AbortSignal)', () => {
     const bytes = await makeSmallPdf();
     const canvas = stubCanvas();
     const controller = new AbortController();
-    await renderPdfPages(new Uint8Array(bytes), [canvas], { signal: controller.signal });
+    await drain(
+      renderPdfPages(new Uint8Array(bytes), [canvas], { signal: controller.signal }),
+    );
     expect(() => controller.abort()).not.toThrow();
     // A second call after abort should still fail fast rather than leaking.
     await expect(
-      renderPdfPages(new Uint8Array(bytes), [canvas], { signal: controller.signal }),
+      drain(renderPdfPages(new Uint8Array(bytes), [canvas], { signal: controller.signal })),
     ).rejects.toMatchObject({ name: 'AbortError' });
   });
 
   it('works without any signal option', async () => {
     const bytes = await makeSmallPdf();
     const canvas = stubCanvas();
-    await expect(renderPdfPages(new Uint8Array(bytes), [canvas])).resolves.toBeUndefined();
+    const pages = await drain(renderPdfPages(new Uint8Array(bytes), [canvas]));
+    expect(pages).toEqual([0]);
+  });
+});
+
+// Streaming-specific tests use the `pdfjsForTests` seam to drive pdf.js
+// with deterministic timing. Each test builds a stub that records getPage
+// invocations and lets us delay / abort between pages.
+function fakePage(): {
+  getViewport: () => { width: number; height: number };
+  render: () => { promise: Promise<void>; cancel: () => void };
+} {
+  return {
+    getViewport: () => ({ width: 10, height: 10 }),
+    render: () => ({ promise: Promise.resolve(), cancel: () => {} }),
+  };
+}
+
+function makeFakePdfjs(
+  numPages: number,
+  onGetPage: (n: number) => Promise<void>,
+): { getDocument: (arg: unknown) => { promise: Promise<unknown>; destroy: () => Promise<void> } } {
+  return {
+    getDocument: () => ({
+      promise: Promise.resolve({
+        numPages,
+        getPage: async (n: number) => {
+          await onGetPage(n);
+          return fakePage();
+        },
+      }),
+      destroy: async () => {},
+    }),
+  };
+}
+
+describe('renderPdfPages streaming semantics', () => {
+  it('yields page 1 before page 2 getPage resolves', async () => {
+    const calls: string[] = [];
+    let resolvePage2: () => void = () => {};
+    const page2Gate = new Promise<void>((resolve) => {
+      resolvePage2 = resolve;
+    });
+
+    const pdfjs = makeFakePdfjs(2, async (n) => {
+      calls.push(`getPage:${n}`);
+      if (n === 2) await page2Gate;
+    });
+
+    const c1 = stubCanvas();
+    const c2 = stubCanvas();
+    const iter = renderPdfPages(new Uint8Array([1, 2, 3]), [c1, c2], {
+      pdfjsForTests: async () => pdfjs as never,
+    })[Symbol.asyncIterator]();
+
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+    expect(first.value).toEqual({ pageIndex: 0 });
+    // page 1 observable to caller — page 2's getPage is outstanding, not awaited.
+    expect(calls).toEqual(['getPage:1']);
+
+    resolvePage2();
+    const second = await iter.next();
+    expect(second.value).toEqual({ pageIndex: 1 });
+    const third = await iter.next();
+    expect(third.done).toBe(true);
+    expect(calls).toEqual(['getPage:1', 'getPage:2']);
+  });
+
+  it('abort mid-stream ends iteration and skips remaining getPage calls', async () => {
+    const calls: string[] = [];
+    const pdfjs = makeFakePdfjs(3, async (n) => {
+      calls.push(`getPage:${n}`);
+    });
+
+    const controller = new AbortController();
+    const iter = renderPdfPages(
+      new Uint8Array([1, 2, 3]),
+      [stubCanvas(), stubCanvas(), stubCanvas()],
+      {
+        signal: controller.signal,
+        pdfjsForTests: async () => pdfjs as never,
+      },
+    )[Symbol.asyncIterator]();
+
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+    expect(calls).toEqual(['getPage:1']);
+
+    controller.abort();
+    await expect(iter.next()).rejects.toMatchObject({ name: 'AbortError' });
+
+    // After the AbortError, iteration has ended and no further getPage fired.
+    expect(calls).toEqual(['getPage:1']);
+  });
+
+  it('iterator.return() ends iteration cleanly without starting the next page', async () => {
+    const calls: string[] = [];
+    const pdfjs = makeFakePdfjs(3, async (n) => {
+      calls.push(`getPage:${n}`);
+    });
+
+    const iter = renderPdfPages(
+      new Uint8Array([1, 2, 3]),
+      [stubCanvas(), stubCanvas(), stubCanvas()],
+      { pdfjsForTests: async () => pdfjs as never },
+    )[Symbol.asyncIterator]();
+
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+    expect(calls).toEqual(['getPage:1']);
+
+    const ret = await iter.return?.();
+    expect(ret).toEqual({ value: undefined, done: true });
+    // Subsequent next() is a clean done.
+    const after = await iter.next();
+    expect(after.done).toBe(true);
+    expect(calls).toEqual(['getPage:1']);
   });
 });

--- a/app/src/ui/renderPdfPages.ts
+++ b/app/src/ui/renderPdfPages.ts
@@ -1,3 +1,11 @@
+// API choice: `renderPdfPages` returns an `AsyncIterable<RenderedPage>` so the
+// caller observes each page the moment it finishes rendering. Chose the async
+// iterable over a callback because the iteration boundary is a natural
+// cancellation point (AbortError propagates through `return()`) and because
+// tests can await each page individually without resorting to deferred
+// promises. The canvas-paint work itself still happens inside this module so
+// callers only need a for-await-of loop.
+
 type PdfjsModule = typeof import('pdfjs-dist/legacy/build/pdf.mjs');
 let pdfjsPromise: Promise<PdfjsModule> | null = null;
 
@@ -34,6 +42,17 @@ export async function renderPageToCanvas(
 
 export interface RenderPdfPagesOptions {
   signal?: AbortSignal;
+  /**
+   * Test seam: if provided, used in place of `loadPdfjs()`. Not for production
+   * callers. Kept on the public options type so Vitest can inject a stub
+   * module without having to monkey-patch the module cache.
+   */
+  pdfjsForTests?: () => Promise<Pick<PdfjsModule, 'getDocument'>>;
+}
+
+export interface RenderedPage {
+  /** Zero-based index into the `canvases` array that was just painted. */
+  pageIndex: number;
 }
 
 function makeAbortError(): DOMException {
@@ -41,24 +60,52 @@ function makeAbortError(): DOMException {
 }
 
 /**
- * Render the given pdf bytes into `canvases` (one per page). Resolves when
- * rendering completes. If `options.signal` aborts mid-flight, the returned
- * promise rejects with a `DOMException` whose `name === 'AbortError'`. If the
- * signal aborts after rendering has already resolved it is a no-op.
+ * Stream-render the given pdf bytes into `canvases` (one per page). Returns an
+ * `AsyncIterable` that yields once per page, in order, the moment that page's
+ * canvas is painted. The caller can consume the iterable to react per-page
+ * (e.g. hide a spinner) or simply `for await` to completion.
  *
- * Note: pdf.js transfers ownership of the ArrayBuffer underlying `bytes`;
- * callers must pass a copy (see `copyBytes` in `parser/copyBytes.ts`).
+ * Abort semantics: if `options.signal` aborts mid-stream the iterator rejects
+ * with a `DOMException` whose `name === 'AbortError'`. In-flight `getPage` /
+ * render calls are cancelled and no further pages are fetched. Aborting after
+ * the iterator has completed is a no-op.
+ *
+ * pdf.js detaches the ArrayBuffer underlying `bytes`; callers must pass a copy
+ * (see `copyBytes` in `parser/copyBytes.ts`).
  */
 export function renderPdfPages(
   bytes: Uint8Array,
   canvases: Array<HTMLCanvasElement | null>,
   options: RenderPdfPagesOptions = {},
-): Promise<void> {
-  const { signal } = options;
-  const tasks: Array<{ cancel: () => void }> = [];
+): AsyncIterable<RenderedPage> {
+  const { signal, pdfjsForTests } = options;
+  return {
+    [Symbol.asyncIterator](): AsyncIterator<RenderedPage> {
+      return createIterator(bytes, canvases, signal, pdfjsForTests);
+    },
+  };
+}
+
+function createIterator(
+  bytes: Uint8Array,
+  canvases: Array<HTMLCanvasElement | null>,
+  signal: AbortSignal | undefined,
+  pdfjsForTests: (() => Promise<Pick<PdfjsModule, 'getDocument'>>) | undefined,
+): AsyncIterator<RenderedPage> {
+  const renderTasks: Array<{ cancel: () => void }> = [];
+  let loadingTask:
+    | {
+        promise: Promise<import('pdfjs-dist/legacy/build/pdf.mjs').PDFDocumentProxy>;
+        destroy: () => Promise<void>;
+      }
+    | null = null;
+  let doc: import('pdfjs-dist/legacy/build/pdf.mjs').PDFDocumentProxy | null = null;
+  let initPromise: Promise<void> | null = null;
+  let i = 0;
+  let done = false;
 
   const onAbort = (): void => {
-    for (const t of tasks) {
+    for (const t of renderTasks) {
       try {
         t.cancel();
       } catch {
@@ -68,42 +115,86 @@ export function renderPdfPages(
   };
   if (signal) signal.addEventListener('abort', onAbort);
 
-  const run = async (): Promise<void> => {
+  const cleanup = (): void => {
+    if (done) return;
+    done = true;
+    if (signal) signal.removeEventListener('abort', onAbort);
+    // Fire-and-forget destroy; pdf.js tolerates it and the test env doesn't
+    // care about the returned promise.
+    if (loadingTask) {
+      loadingTask.destroy().catch(() => {});
+    }
+  };
+
+  const init = async (): Promise<void> => {
+    if (signal?.aborted) throw makeAbortError();
+    const pdfjs = pdfjsForTests ? await pdfjsForTests() : await loadPdfjs();
+    if (signal?.aborted) throw makeAbortError();
+    loadingTask = pdfjs.getDocument({ data: bytes, isEvalSupported: false });
+    doc = await loadingTask.promise;
+    if (signal?.aborted) throw makeAbortError();
+  };
+
+  const targetScale = devicePixelScale();
+
+  const next = async (): Promise<IteratorResult<RenderedPage>> => {
+    if (done) return { value: undefined, done: true };
     try {
-      if (signal?.aborted) throw makeAbortError();
-      const pdfjs = await loadPdfjs();
-      if (signal?.aborted) throw makeAbortError();
-      const loadingTask = pdfjs.getDocument({ data: bytes, isEvalSupported: false });
-      const doc = await loadingTask.promise;
-      if (signal?.aborted) throw makeAbortError();
+      if (!initPromise) initPromise = init();
+      await initPromise;
 
-      const targetScale = devicePixelScale();
-      for (let i = 0; i < canvases.length; i++) {
+      // Skip trailing nulls / out-of-range entries until we find one to render
+      // or exhaust the canvas list.
+      while (i < canvases.length) {
         if (signal?.aborted) throw makeAbortError();
-        const canvas = canvases[i];
+        const idx = i;
+        const canvas = canvases[idx];
+        i += 1;
         if (!canvas) continue;
-        if (i + 1 > doc.numPages) break;
+        if (!doc || idx + 1 > doc.numPages) {
+          cleanup();
+          return { value: undefined, done: true };
+        }
 
-        const page = await doc.getPage(i + 1);
+        const page = await doc.getPage(idx + 1);
         if (signal?.aborted) throw makeAbortError();
         const viewport = page.getViewport({ scale: targetScale });
         const ctx = canvas.getContext('2d');
-        if (!ctx) continue;
+        if (!ctx) {
+          // No 2d context (e.g. jsdom); skip painting but still report the
+          // slot as "done" so consumers can advance.
+          return { value: { pageIndex: idx }, done: false };
+        }
         canvas.width = viewport.width;
         canvas.height = viewport.height;
         canvas.style.width = `${viewport.width / targetScale}px`;
         canvas.style.height = `${viewport.height / targetScale}px`;
 
         const task = page.render({ canvasContext: ctx, viewport });
-        tasks.push(task);
+        renderTasks.push(task);
         await task.promise;
+        if (signal?.aborted) throw makeAbortError();
+        return { value: { pageIndex: idx }, done: false };
       }
-    } finally {
-      if (signal) signal.removeEventListener('abort', onAbort);
+
+      cleanup();
+      return { value: undefined, done: true };
+    } catch (err) {
+      cleanup();
+      throw err;
     }
   };
 
-  return run();
+  const returnFn = async (): Promise<IteratorResult<RenderedPage>> => {
+    onAbort();
+    cleanup();
+    return { value: undefined, done: true };
+  };
+
+  return {
+    next,
+    return: returnFn,
+  };
 }
 
 function devicePixelScale(): number {


### PR DESCRIPTION
## Summary
- Refactor renderPdfPages from batch resolve to AsyncIterable streaming
- Update PdfViewer to consume the streaming iterator

## Commits
- c1801c5 feat(render): stream PDF pages via AsyncIterable instead of batch resolve
- 7ee4fc6 feat(viewer): consume streaming renderPdfPages iterator in PdfViewer

Auto-imported during local-worktree consolidation; review at leisure.