### PR TITLE
wave6: Section.paragraphIndexes for O(1) sectionAnchored

### DIFF
--- a/app/src/compare/diffLeases.test.ts
+++ b/app/src/compare/diffLeases.test.ts
@@ -7,7 +7,13 @@ function para(text: string, page = 1): Paragraph {
 }
 
 function section(heading: string, paragraphs: Paragraph[], number: string | null = null): Section {
-  return { heading, number, paragraphs, startPage: paragraphs[0]?.page ?? 1 };
+  return {
+    heading,
+    number,
+    paragraphs,
+    paragraphIndexes: paragraphs.map((_, i) => i),
+    startPage: paragraphs[0]?.page ?? 1,
+  };
 }
 
 function doc(sections: Section[]): LeaseDocument {

--- a/app/src/parser/sections.ts
+++ b/app/src/parser/sections.ts
@@ -28,7 +28,9 @@ export function detectSections(paragraphs: Paragraph[]): Section[] {
   const sections: Section[] = [];
   let current: Section | null = null;
 
-  for (const para of paragraphs) {
+  for (let i = 0; i < paragraphs.length; i++) {
+    const para = paragraphs[i];
+    if (!para) continue;
     const heading = matchHeading(para.text);
     if (heading) {
       if (current) sections.push(current);
@@ -36,6 +38,7 @@ export function detectSections(paragraphs: Paragraph[]): Section[] {
         heading: heading.heading,
         number: heading.number,
         paragraphs: [],
+        paragraphIndexes: [],
         startPage: para.page,
       };
       continue;
@@ -46,10 +49,12 @@ export function detectSections(paragraphs: Paragraph[]): Section[] {
         heading: 'Preamble',
         number: null,
         paragraphs: [],
+        paragraphIndexes: [],
         startPage: para.page,
       };
     }
     current.paragraphs.push(para);
+    current.paragraphIndexes.push(i);
   }
 
   if (current) sections.push(current);

--- a/app/src/parser/types.ts
+++ b/app/src/parser/types.ts
@@ -32,6 +32,14 @@ export interface Section {
   heading: string;
   number: string | null;
   paragraphs: Paragraph[];
+  /**
+   * Indices into `LeaseDocument.paragraphs` for each entry in `paragraphs`,
+   * in the same order. Added so consumers (e.g. `runSectionAnchored`) can
+   * locate a section paragraph in the master array in O(1) instead of via
+   * `indexOf`. Kept alongside the `paragraphs` refs to avoid churning UI
+   * call sites that still use the refs.
+   */
+  paragraphIndexes: number[];
   startPage: number;
 }
 

--- a/app/src/rules/matchers.ts
+++ b/app/src/rules/matchers.ts
@@ -123,18 +123,26 @@ function runSectionAnchored(
   compiled?: CompiledMatcherCache,
 ): RuleMatch[] {
   const heading = compiled?.headingRegex ?? new RegExp(matcher.headingPattern, 'i');
-  const allowed = new Set<Paragraph>();
+  // Collect the master-paragraph indexes for every section whose heading
+  // matches. Sections now track these directly (see parser/types.ts), so
+  // we no longer need `doc.paragraphs.indexOf(para)` — each leaf hit's
+  // filtered index maps straight into an originalIndex via array lookup.
+  const originalIndexes: number[] = [];
+  const filtered: Paragraph[] = [];
   for (const section of doc.sections) {
-    if (heading.test(section.heading)) {
-      for (const para of section.paragraphs) allowed.add(para);
+    if (!heading.test(section.heading)) continue;
+    for (let i = 0; i < section.paragraphs.length; i++) {
+      const para = section.paragraphs[i];
+      const idx = section.paragraphIndexes[i];
+      if (!para || idx === undefined) continue;
+      filtered.push(para);
+      originalIndexes.push(idx);
     }
   }
-  const filtered = doc.paragraphs.filter((p) => allowed.has(p));
   if (filtered.length === 0) return [];
   const leafHits = runLeaf(matcher.child, filtered, compiled?.child);
   return leafHits.map((hit) => {
-    const para = filtered[hit.paragraphIndex];
-    const originalIndex = para ? doc.paragraphs.indexOf(para) : hit.paragraphIndex;
+    const originalIndex = originalIndexes[hit.paragraphIndex] ?? hit.paragraphIndex;
     return { ...hit, paragraphIndex: originalIndex };
   });
 }


### PR DESCRIPTION
## Summary
- Track paragraph indexes on Section so sectionAnchored is O(1)

## Commits
- e42a709 refactor(parser): Section tracks paragraphIndexes; O(1) sectionAnchored

Auto-imported during local-worktree consolidation; review at leisure.