### PR TITLE
wave7-D-subagent: full App.tsx decomp + reanalyze guard

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,6 +1,28 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { ChangeEvent } from 'react';
 import { usePipeline } from './App/usePipeline';
+import { usePackManager } from './App/usePackManager';
+import { useAnnotations } from './App/useAnnotations';
+import { useRedlineState } from './App/useRedlineState';
+import { useVersionHistory } from './App/useVersionHistory';
+import { useSideLetter } from './App/useSideLetter';
+import { useCounterOffers } from './App/useCounterOffers';
+import { useSigningKey } from './App/useSigningKey';
+import { useReanalyzeOnRulesChange } from './App/useReanalyzeOnRulesChange';
+import {
+  buildIcsBytes,
+  clearAllFlow,
+  downloadBlob,
+  downloadBlobBytes,
+  downloadHandoffZip,
+  exportEncryptedArchiveFlow,
+  exportFindingsAsHtml,
+  exportFindingsAsJson,
+  friendlyError,
+  importEncryptedArchiveFlow,
+  readFileBytes,
+  stripPdfExt,
+} from './App/appHelpers';
 import { FindingsPanel } from './ui/FindingsPanel';
 import { LibraryPanel } from './ui/LibraryPanel';
 import { PdfViewer } from './ui/PdfViewer';
@@ -11,37 +33,15 @@ import { TemplateMatchesPanel } from './ui/TemplateMatchesPanel';
 import { LeaseFactsPanel } from './ui/LeaseFactsPanel';
 import { extractLeaseFacts } from './facts/extractFacts';
 import { WorkflowPanel } from './ui/WorkflowPanel';
-import { buildIcs, type IcsDateInput } from './workflow/buildIcs';
 import { buildSummary, copyToClipboard } from './workflow/copySummary';
-import { buildHandoffZip } from './workflow/buildHandoffZip';
-import { bulkImport, type BulkResult, type BulkSummary } from './workflow/bulkImport';
-import type { LeaseFacts } from './facts/types';
 import { PackManagerPanel } from './ui/PackManagerPanel';
-import {
-  deleteInstalledPack,
-  listInstalledPacks,
-  saveInstalledPack,
-  setPackEnabled,
-  getPackEnabled,
-  getSelectedJurisdictions,
-  setSelectedJurisdictions,
-  getSeverityOverrides,
-  setSeverityOverride,
-} from './rules/packStorage';
-import { validatePackFile, type RulePackFile } from './rules/packSchema';
-import { resolveActiveRules } from './rules/activePack';
-import { RULE_PACK_V1 } from './rules/packV1';
-import { JURISDICTION_OPTIONS, filterByJurisdiction } from './rules/jurisdictions';
-import { applySeverityOverrides } from './rules/severityOverrides';
-import { diffPack, type PackDiff } from './rules/packDiff';
-import { analyzeFile } from './ui/analyzeFile';
+import { JURISDICTION_OPTIONS } from './rules/jurisdictions';
 import { JurisdictionPickerPanel } from './ui/JurisdictionPickerPanel';
 import { SeverityOverridesPanel } from './ui/SeverityOverridesPanel';
 import { PackDiffPanel } from './ui/PackDiffPanel';
 import { AuditLogPanel } from './ui/AuditLogPanel';
 import { BulkImportPanel } from './ui/BulkImportPanel';
 import {
-  overrideToSeverity,
   overridesToPanel,
   severityToOverride as severityToOverrideSeverity,
 } from './ui/severityMap';
@@ -54,55 +54,16 @@ import {
 } from './audit/auditLog';
 import { buildAuditLogJson, downloadAuditLogBlob } from './audit/auditExport';
 import { SigningKeyPanel } from './ui/SigningKeyPanel';
-import { createSigningKey, exportPublicKey } from './security/signingKeys';
-import { signExport } from './storage/exportReport';
-import { sha256Hex } from './security/inputHash';
 import { AnnotationsPanel } from './ui/AnnotationsPanel';
-import {
-  deleteAnnotation,
-  listAnnotations,
-  saveAnnotation,
-  updateAnnotation,
-  type Annotation,
-} from './annotations/annotations';
 import { CounterOfferPanel } from './ui/CounterOfferPanel';
-import {
-  deleteCounterOffer,
-  listCounterOffers,
-  saveCounterOffer,
-  type CounterOffer,
-} from './negotiation/counterOffers';
+import type { CounterOffer } from './negotiation/counterOffers';
 import { PortfolioPanel } from './ui/PortfolioPanel';
 import { CustomRuleBuilderPanel } from './ui/CustomRuleBuilderPanel';
 import { RedlinePanel } from './ui/RedlinePanel';
 import { VersionHistoryPanel } from './ui/VersionHistoryPanel';
 import { SideLetterPanel } from './ui/SideLetterPanel';
-import {
-  saveEdit,
-  listEditsForLease,
-  deleteEdit,
-} from './redline/redlineStorage';
-import type { RedlineEdit } from './redline/redline';
-import { buildRedlineHtml } from './redline/redline';
-import {
-  listVersionsForLease,
-  saveVersion,
-  getVersion,
-  deleteVersion,
-  type LeaseVersion,
-} from './negotiation/versionHistory';
-import { buildSideLetterHtml } from './negotiation/sideLetter';
-import {
-  getPackSignatureStatus,
-  saveSignedPack,
-  type PackSignatureStatus,
-} from './rules/packStorage';
-import { verifySignedPack } from './rules/packSigning';
-import type { PackSignatureBadge } from './ui/PackManagerPanel';
 import { needsOcr } from './compare/needsOcr';
-import { PasswordProtectedPdfError } from './parser/types';
-import type { Finding, Rule } from './rules/types';
-import { RULE_PACK_SCHEMA_VERSION } from './rules/packSchema';
+import type { Finding } from './rules/types';
 import type { ClauseTemplate } from './templates/types';
 import { matchTemplates } from './templates/matchTemplates';
 import {
@@ -112,7 +73,6 @@ import {
   deleteTemplate,
 } from './storage/templates';
 import {
-  clearAll,
   clearStandardId,
   deleteLease,
   getLease,
@@ -120,18 +80,9 @@ import {
   listAllLeaseRecords,
   listLeases,
   renameLease,
-  replaceAllLeases,
-  saveLease,
   setStandardId,
   type LeaseMetadata,
 } from './storage/storage';
-import {
-  exportEncryptedArchive,
-  importEncryptedArchive,
-  WrongPassphraseError,
-} from './storage/archive';
-import { exportFindingsJson } from './storage/exportReport';
-import { exportFindingsHtml } from './storage/exportHtml';
 
 export function App(): JSX.Element {
   const [selected, setSelected] = useState<Finding | null>(null);
@@ -139,200 +90,116 @@ export function App(): JSX.Element {
   const [selectedPage, setSelectedPage] = useState<number | null>(null);
   const [standardId, setStandardIdState] = useState<string | null>(null);
   const [templates, setTemplates] = useState<ClauseTemplate[]>([]);
-  const [installedPacks, setInstalledPacks] = useState<RulePackFile[]>([]);
-  const [enabledPacks, setEnabledPacks] = useState<Set<string>>(new Set());
-  const [selectedJurisdictions, setSelectedJurisdictionsState] = useState<string[]>([]);
-  const [severityOverrides, setSeverityOverridesState] = useState<
-    Record<string, import('./rules/types').Severity>
-  >({});
-  const [packDiff, setPackDiff] = useState<PackDiff | null>(null);
   const [auditEntries, setAuditEntries] = useState<AuditEntry[]>([]);
   const [auditVerification, setAuditVerification] = useState<ChainVerification | null>(null);
-  const [signingPublicKey, setSigningPublicKey] = useState<string | null>(null);
-  const [annotations, setAnnotations] = useState<Annotation[]>([]);
-  const [counterOffers, setCounterOffers] = useState<CounterOffer[]>([]);
   const [view, setView] = useState<'current' | 'portfolio' | 'redline'>('current');
   const [portfolioFindings, setPortfolioFindings] = useState<Map<string, Finding[]>>(
     new Map(),
   );
-  const [redlineEdits, setRedlineEdits] = useState<RedlineEdit[]>([]);
-  const [versions, setVersions] = useState<LeaseVersion[]>([]);
-  const [sideLetterSigner, setSideLetterSigner] = useState<{ name: string; title: string }>(
-    { name: '', title: '' },
-  );
-  const [packSignatureStatus, setPackSignatureStatus] = useState<
-    Record<string, PackSignatureBadge>
-  >({});
 
-  const refreshPortfolioFindings = useCallback(async () => {
-    const records = await listAllLeaseRecords();
-    const map = new Map<string, Finding[]>();
-    for (const r of records) map.set(r.id, r.findings);
-    setPortfolioFindings(map);
-  }, []);
-
-  const refreshAnnotations = useCallback(async (leaseId: string) => {
-    setAnnotations(await listAnnotations(leaseId));
-  }, []);
-
-  const refreshRedlineEdits = useCallback(async (leaseId: string) => {
-    setRedlineEdits(await listEditsForLease(leaseId));
-  }, []);
-
-  const refreshVersions = useCallback(async (leaseId: string) => {
-    setVersions(await listVersionsForLease(leaseId));
-  }, []);
-
-  const refreshCounterOffers = useCallback(async () => {
-    setCounterOffers(await listCounterOffers());
-  }, []);
-
-  const refreshSigningKey = useCallback(async () => {
-    setSigningPublicKey(await exportPublicKey());
-  }, []);
-
-  const refreshPacks = useCallback(async () => {
-    const packs = await listInstalledPacks();
-    const enabled = new Set<string>();
-    const sigStatus: Record<string, PackSignatureBadge> = {};
-    for (const p of packs) {
-      if (await getPackEnabled(p.id)) enabled.add(p.id);
-      const status: PackSignatureStatus = await getPackSignatureStatus(p.id);
-      // Map storage-layer "unsigned" to UI's "community" badge.
-      sigStatus[p.id] =
-        status === 'verified'
-          ? 'verified'
-          : status === 'invalid'
-            ? 'invalid'
-            : status === 'unknown'
-              ? 'unknown'
-              : 'community';
-    }
-    setInstalledPacks(packs);
-    setEnabledPacks(enabled);
-    setPackSignatureStatus(sigStatus);
-  }, []);
-
-  const refreshRulePackSettings = useCallback(async () => {
-    const [j, ov] = await Promise.all([
-      getSelectedJurisdictions(),
-      getSeverityOverrides(),
-    ]);
-    setSelectedJurisdictionsState(j);
-    setSeverityOverridesState(ov);
-  }, []);
-
-  const refreshAuditLog = useCallback(async () => {
+  const refreshAuditLog = useCallback(async (): Promise<void> => {
     setAuditEntries(await listAuditEntries());
   }, []);
 
-  const refreshLibrary = useCallback(async () => {
+  // Audit writes must never abort the primary pipeline; swallow + warn.
+  const safeAudit = useCallback(
+    async (input: { kind: string; payload: Record<string, unknown> }): Promise<void> => {
+      try {
+        await appendAuditEntry(input);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn('audit append failed', err);
+      }
+    },
+    [],
+  );
+
+  const refreshLibrary = useCallback(async (): Promise<void> => {
     const [leases, std] = await Promise.all([listLeases(), getStandardId()]);
     setLibrary(leases);
     setStandardIdState(std ?? null);
   }, []);
 
-  const refreshTemplates = useCallback(async () => {
+  const refreshTemplates = useCallback(async (): Promise<void> => {
     setTemplates(await listTemplates());
   }, []);
 
-  // Layered rule resolution:
-  //   built-in + installed packs → filter by jurisdictions → apply severity
-  //   overrides. Each step is pure; no IndexedDB inside the memo.
-  const baseResolvedRules = resolveActiveRules(
-    RULE_PACK_V1,
-    installedPacks,
-    enabledPacks,
-  ).rules;
-  const activeRules = useMemo(
-    () =>
-      applySeverityOverrides(
-        filterByJurisdiction(baseResolvedRules, selectedJurisdictions),
-        severityOverrides,
-      ),
-    [baseResolvedRules, selectedJurisdictions, severityOverrides],
-  );
-  const pipeline = usePipeline({ onLibraryChange: refreshLibrary, rules: activeRules });
+  const packs = usePackManager({
+    audit: safeAudit,
+    onAuditMutation: refreshAuditLog,
+    onError: (msg) => pipeline.setError(msg),
+    onBulkImportComplete: refreshLibrary,
+  });
+
+  const pipeline = usePipeline({
+    onLibraryChange: refreshLibrary,
+    rules: packs.activeRules,
+  });
   const { status, ocrState, comparison } = pipeline;
+  const analyzedLeaseId = status.kind === 'analyzed' ? status.leaseId : null;
+
+  const annotationsApi = useAnnotations(analyzedLeaseId);
+  const redline = useRedlineState({
+    leaseId: analyzedLeaseId,
+    audit: safeAudit,
+    onAuditMutation: refreshAuditLog,
+  });
+  const versionHistory = useVersionHistory({
+    leaseId: analyzedLeaseId,
+    audit: safeAudit,
+    onAuditMutation: refreshAuditLog,
+  });
+  const sideLetter = useSideLetter();
+  const counters = useCounterOffers();
+  const signingKey = useSigningKey();
+
+  // Keystone: replaces every manual `pipeline.reanalyze()` call. Skip-first-mount
+  // dedupes the redundant analyze right after upload already analyzed.
+  useReanalyzeOnRulesChange({
+    activeRules: packs.activeRules,
+    reanalyze: pipeline.reanalyze,
+  });
 
   const plainEnglishByRuleId = useMemo<Record<string, string>>(() => {
     const out: Record<string, string> = {};
-    for (const r of activeRules) {
-      if (r.plainEnglish) out[r.id] = r.plainEnglish;
-    }
+    for (const r of packs.activeRules) if (r.plainEnglish) out[r.id] = r.plainEnglish;
     return out;
-  }, [activeRules]);
+  }, [packs.activeRules]);
 
   const suggestedEditByRuleId = useMemo<Record<string, string>>(() => {
     const out: Record<string, string> = {};
-    for (const r of activeRules) {
-      if (r.suggestedEdit) out[r.id] = r.suggestedEdit;
-    }
+    for (const r of packs.activeRules) if (r.suggestedEdit) out[r.id] = r.suggestedEdit;
     return out;
-  }, [activeRules]);
+  }, [packs.activeRules]);
 
-  // For "Apply suggestion": prefer a user-authored counter-offer text over
-  // the rule's built-in `suggestedEdit`. Counter-offers are keyed by ruleId;
-  // if multiple exist we pick the most recently saved one.
+  // User counter-offers override the rule's `suggestedEdit`. Most recent wins per rule.
   const suggestedTextByRuleId = useMemo<Record<string, string>>(() => {
     const out: Record<string, string> = { ...suggestedEditByRuleId };
     const latestByRule = new Map<string, CounterOffer>();
-    for (const co of counterOffers) {
+    for (const co of counters.counterOffers) {
       const cur = latestByRule.get(co.ruleId);
       if (!cur || co.updatedAt > cur.updatedAt) latestByRule.set(co.ruleId, co);
     }
     for (const [ruleId, co] of latestByRule) out[ruleId] = co.text;
     return out;
-  }, [suggestedEditByRuleId, counterOffers]);
-
-  // All rule ids the custom-rule builder should treat as "taken", so the
-  // dup-id guard fires against both the built-in pack and any installed pack.
-  const existingRuleIds = useMemo<string[]>(() => {
-    const ids = new Set<string>();
-    for (const r of RULE_PACK_V1) ids.add(r.id);
-    for (const pack of installedPacks) for (const r of pack.rules) ids.add(r.id);
-    return Array.from(ids);
-  }, [installedPacks]);
+  }, [suggestedEditByRuleId, counters.counterOffers]);
 
   useEffect(() => {
     void refreshLibrary();
     void refreshTemplates();
-    void refreshPacks();
-    void refreshSigningKey();
-    void refreshCounterOffers();
-    void refreshRulePackSettings();
     void refreshAuditLog();
-  }, [
-    refreshLibrary,
-    refreshTemplates,
-    refreshPacks,
-    refreshSigningKey,
-    refreshCounterOffers,
-    refreshRulePackSettings,
-    refreshAuditLog,
-  ]);
+  }, [refreshLibrary, refreshTemplates, refreshAuditLog]);
 
-  // Re-index the portfolio whenever the library or the view changes.
   useEffect(() => {
     if (view === 'portfolio') {
-      void refreshPortfolioFindings();
+      void (async (): Promise<void> => {
+        const records = await listAllLeaseRecords();
+        const map = new Map<string, Finding[]>();
+        for (const r of records) map.set(r.id, r.findings);
+        setPortfolioFindings(map);
+      })();
     }
-  }, [view, library, refreshPortfolioFindings]);
-
-  // Load annotations whenever the currently-analyzed lease changes.
-  const analyzedLeaseId =
-    status.kind === 'analyzed' ? status.leaseId : null;
-  useEffect(() => {
-    if (analyzedLeaseId) {
-      void refreshAnnotations(analyzedLeaseId);
-      void refreshRedlineEdits(analyzedLeaseId);
-      void refreshVersions(analyzedLeaseId);
-    } else {
-      setAnnotations([]);
-      setRedlineEdits([]);
-      setVersions([]);
-    }
-  }, [analyzedLeaseId, refreshAnnotations, refreshRedlineEdits, refreshVersions]);
+  }, [view, library]);
 
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent): void {
@@ -357,32 +224,10 @@ export function App(): JSX.Element {
 
   async function handleBytes(bytes: Uint8Array, fileName: string): Promise<void> {
     setSelected(null);
-    // Audit writes must never block or abort the primary pipeline. If the
-    // audit database is momentarily unavailable the user still needs their
-    // analysis; we swallow errors here and log to console for diagnostics.
     await safeAudit({ kind: 'analyze', payload: { fileName, phase: 'start' } });
     await pipeline.upload(bytes, fileName);
     await safeAudit({ kind: 'analyze', payload: { fileName, phase: 'complete' } });
     void refreshAuditLog();
-  }
-
-  async function safeAudit(input: {
-    kind: string;
-    payload: Record<string, unknown>;
-  }): Promise<void> {
-    try {
-      await appendAuditEntry(input);
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.warn('audit append failed', err);
-    }
-  }
-
-  async function onFileChange(e: ChangeEvent<HTMLInputElement>): Promise<void> {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    const bytes = await readFileBytes(file);
-    await handleBytes(bytes, file.name);
   }
 
   async function onTrySample(): Promise<void> {
@@ -411,140 +256,24 @@ export function App(): JSX.Element {
     void refreshAuditLog();
   }
 
-  async function onSetStandard(id: string): Promise<void> {
-    await setStandardId(id);
-    await refreshLibrary();
-  }
-
-  async function onRename(id: string, name: string): Promise<void> {
-    await renameLease(id, name);
-    await refreshLibrary();
-  }
-
   async function onCompare(aId: string, bId: string): Promise<void> {
     const [a, b] = await Promise.all([getLease(aId), getLease(bId)]);
     if (!a || !b) return;
     pipeline.setComparison({ a, b });
   }
 
-  async function onExportArchive(): Promise<void> {
-    const passphrase = window.prompt('Passphrase for the encrypted archive:');
-    if (!passphrase) return;
-    const [records, std] = await Promise.all([listAllLeaseRecords(), getStandardId()]);
-    const bytes = await exportEncryptedArchive(records, std ?? null, passphrase);
-    const blob = new Blob([bytes as BlobPart], { type: 'application/octet-stream' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `leaseguard-${new Date().toISOString().slice(0, 10)}.lgarchive`;
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
-    URL.revokeObjectURL(url);
-  }
-
   async function onImportArchiveFile(e: ChangeEvent<HTMLInputElement>): Promise<void> {
     const file = e.target.files?.[0];
     if (!file) return;
     e.target.value = '';
-    const passphrase = window.prompt('Passphrase for this archive:');
-    if (!passphrase) return;
-    try {
-      const bytes = await readFileBytes(file);
-      const payload = await importEncryptedArchive(bytes, passphrase);
-      if (
-        !window.confirm(
-          `Replace current library with ${payload.leases.length} lease(s) from this archive?`,
-        )
-      ) {
-        return;
-      }
-      await replaceAllLeases(payload.leases, payload.standardId);
-      await refreshLibrary();
-      pipeline.reset();
-      setSelected(null);
-    } catch (err) {
-      const msg =
-        err instanceof WrongPassphraseError
-          ? err.message
-          : `Import failed: ${friendlyError(err)}`;
-      pipeline.setError(msg);
-    }
-  }
-
-  async function onClearAll(): Promise<void> {
-    if (!window.confirm('Delete all saved leases from this device? This cannot be undone.')) return;
-    await clearAll();
-    await refreshLibrary();
-    await refreshTemplates();
-    pipeline.reset();
-    setSelected(null);
-  }
-
-  async function onSaveTemplate(input: { name: string; text: string }): Promise<void> {
-    await saveTemplate(input);
-    await refreshTemplates();
-  }
-
-  async function onUpdateTemplate(id: string, patch: { name?: string; text?: string }): Promise<void> {
-    await updateTemplate(id, patch);
-    await refreshTemplates();
-  }
-
-  async function onDeleteTemplate(id: string): Promise<void> {
-    await deleteTemplate(id);
-    await refreshTemplates();
-  }
-
-  async function onSaveAnnotation(text: string): Promise<void> {
-    if (!analyzedLeaseId || selected === null) return;
-    await saveAnnotation({
-      leaseId: analyzedLeaseId,
-      paragraphIndex: selected.paragraphIndex,
-      text,
+    await importEncryptedArchiveFlow(file, {
+      onSuccess: async () => {
+        await refreshLibrary();
+        pipeline.reset();
+        setSelected(null);
+      },
+      onError: (msg) => pipeline.setError(msg),
     });
-    await refreshAnnotations(analyzedLeaseId);
-  }
-
-  async function onUpdateAnnotation(id: string, text: string): Promise<void> {
-    await updateAnnotation(id, text);
-    if (analyzedLeaseId) await refreshAnnotations(analyzedLeaseId);
-  }
-
-  async function onDeleteAnnotation(id: string): Promise<void> {
-    await deleteAnnotation(id);
-    if (analyzedLeaseId) await refreshAnnotations(analyzedLeaseId);
-  }
-
-  async function onSaveCounterOffer(
-    ruleId: string,
-    name: string,
-    text: string,
-  ): Promise<void> {
-    await saveCounterOffer({ ruleId, name, text });
-    await refreshCounterOffers();
-  }
-
-  async function onDeleteCounterOffer(id: string): Promise<void> {
-    await deleteCounterOffer(id);
-    await refreshCounterOffers();
-  }
-
-  async function onCreateSigningKey(passphrase: string): Promise<void> {
-    await createSigningKey(passphrase);
-    await refreshSigningKey();
-  }
-
-  async function onExportSigningPublicKey(publicKey: string): Promise<void> {
-    // Copy base64 public key to the clipboard. Fall back silently (CSP-friendly).
-    try {
-      const nav = globalThis.navigator as
-        | { clipboard?: { writeText?: (s: string) => Promise<void> } }
-        | undefined;
-      await nav?.clipboard?.writeText?.(publicKey);
-    } catch {
-      // swallow — exporting is best-effort
-    }
   }
 
   async function onExportSignedJson(): Promise<void> {
@@ -552,507 +281,57 @@ export function App(): JSX.Element {
     const passphrase = window.prompt('Passphrase to unlock the signing key:');
     if (!passphrase) return;
     try {
-      const inputHash = status.bytes ? await sha256Hex(status.bytes) : null;
-      const unsigned = exportFindingsJson({
-        name: status.fileName,
+      await signingKey.signAndDownloadFindings({
+        fileName: status.fileName,
         doc: status.result.doc,
         findings: status.result.findings,
-        inputHash,
+        bytes: status.bytes,
+        passphrase,
       });
-      const signed = await signExport(unsigned, passphrase);
-      downloadBlob(
-        signed,
-        'application/json',
-        `${status.fileName.replace(/\.pdf$/i, '')}-findings.signed.json`,
-      );
     } catch (err) {
       pipeline.setError(`Signing failed: ${friendlyError(err)}`);
     }
   }
 
-  async function onImportPack(file: File): Promise<void> {
-    const bytes = await readFileBytes(file);
-    const text = new TextDecoder().decode(bytes);
-    const parsed: unknown = JSON.parse(text);
-
-    // Detect a signed envelope by shape. A signed `.lgpack.json` is the
-    // envelope itself (algorithm + payload + signature + publicKey); the
-    // inner pack JSON lives as a string under `payload`. Route that case
-    // through `saveSignedPack` so the trust badge gets recorded.
-    if (
-      parsed !== null &&
-      typeof parsed === 'object' &&
-      'algorithm' in parsed &&
-      'payload' in parsed &&
-      'signature' in parsed
-    ) {
-      const verify = await verifySignedPack(parsed);
-      if (!verify.ok || !verify.pack) {
-        await safeAudit({
-          kind: 'pack-signature-invalid',
-          payload: { reason: verify.reason ?? 'unknown' },
-        });
-        void refreshAuditLog();
-        throw new Error(`Invalid signed pack: ${verify.reason ?? 'unknown'}`);
-      }
-      await saveSignedPack(
-        parsed as import('./rules/packSigning').SignedPackEnvelope,
-        verify.pack,
-      );
-      await setPackEnabled(verify.pack.id, true);
-      await safeAudit({
-        kind: 'pack-signature-verified',
-        payload: { packId: verify.pack.id, version: verify.pack.version },
-      });
-      await safeAudit({
-        kind: 'import-pack',
-        payload: { packId: verify.pack.id, version: verify.pack.version, signed: true },
-      });
-      await refreshPacks();
-      void refreshAuditLog();
-      return;
-    }
-
-    const result = validatePackFile(parsed);
-    if (!result.ok) {
-      throw new Error(`Invalid pack: ${result.errors.join('; ')}`);
-    }
-    await saveInstalledPack(result.pack);
-    await setPackEnabled(result.pack.id, true);
-    await safeAudit({
-      kind: 'import-pack',
-      payload: { packId: result.pack.id, version: result.pack.version },
-    });
-    await refreshPacks();
-    void refreshAuditLog();
-  }
-
-  async function onComparePackFile(file: File): Promise<void> {
-    try {
-      const bytes = await readFileBytes(file);
-      const text = new TextDecoder().decode(bytes);
-      const parsed: unknown = JSON.parse(text);
-      const result = validatePackFile(parsed);
-      if (!result.ok) {
-        pipeline.setError(`Invalid pack: ${result.errors.join('; ')}`);
-        return;
-      }
-      setPackDiff(diffPack(activeRules, result.pack));
-    } catch (err) {
-      pipeline.setError(`Could not diff pack: ${friendlyError(err)}`);
-    }
-  }
-
-  async function onSelectedJurisdictionsChange(next: string[]): Promise<void> {
-    setSelectedJurisdictionsState(next);
-    await setSelectedJurisdictions(next);
-    // Re-run analyze against the currently loaded doc with the new filter.
-    pipeline.reanalyze();
-  }
-
-  async function onSeverityOverrideChange(
-    ruleId: string,
-    panelSeverity: import('./ui/SeverityOverridesPanel').OverrideSeverity | null,
-  ): Promise<void> {
-    const next = { ...severityOverrides };
-    if (panelSeverity === null) {
-      delete next[ruleId];
-      await setSeverityOverride(ruleId, null);
-    } else {
-      const real = overrideToSeverity(panelSeverity);
-      next[ruleId] = real;
-      await setSeverityOverride(ruleId, real);
-    }
-    setSeverityOverridesState(next);
-    pipeline.reanalyze();
-  }
-
-  async function onRefreshAudit(): Promise<void> {
-    await refreshAuditLog();
-  }
-
-  async function onVerifyAudit(): Promise<void> {
-    setAuditVerification(await verifyAuditChain());
-  }
-
-  function onDownloadAudit(): void {
-    const json = buildAuditLogJson(auditEntries, auditVerification);
-    downloadAuditLogBlob(
-      json,
-      `leaseguard-audit-${new Date().toISOString().slice(0, 10)}.json`,
-    );
-  }
-
-  async function onBulkImportFiles(
-    files: File[],
-    onProgress: (r: BulkResult) => void,
-  ): Promise<BulkSummary> {
-    const summary = await bulkImport(
-      files,
-      (r) => {
-        onProgress(r);
-      },
-      {
-        analyze: async (bytes) => {
-          const result = await analyzeFile(bytes, activeRules);
-          return { doc: result.doc, findings: result.findings };
-        },
-        save: async (input) => saveLease(input),
-      },
-    );
-    await safeAudit({
-      kind: 'bulk-import',
-      payload: { ok: summary.ok, skipped: summary.skipped, errors: summary.errors },
-    });
-    await refreshLibrary();
-    void refreshAuditLog();
-    return summary;
-  }
-
-  async function onTogglePack(id: string, enabled: boolean): Promise<void> {
-    await setPackEnabled(id, enabled);
-    await refreshPacks();
-  }
-
-  async function onDeletePack(id: string): Promise<void> {
-    await deleteInstalledPack(id);
-    await refreshPacks();
-  }
-
-  async function onAttemptOcr(): Promise<void> {
-    setSelected(null);
-    await pipeline.ocr();
-  }
-
   function onExportJson(): void {
     if (status.kind !== 'analyzed') return;
-    const json = exportFindingsJson({
-      name: status.fileName,
+    exportFindingsAsJson({
+      fileName: status.fileName,
       doc: status.result.doc,
       findings: status.result.findings,
     });
-    downloadBlob(
-      json,
-      'application/json',
-      `${status.fileName.replace(/\.pdf$/i, '')}-findings.json`,
-    );
-    const fileName = status.fileName;
     void safeAudit({
       kind: 'export',
-      payload: { fileName, format: 'json' },
+      payload: { fileName: status.fileName, format: 'json' },
     }).then(() => refreshAuditLog());
-  }
-
-  function onExportHtml(): void {
-    if (status.kind !== 'analyzed') return;
-    const html = exportFindingsHtml({
-      name: status.fileName,
-      doc: status.result.doc,
-      findings: status.result.findings,
-    });
-    downloadBlob(
-      html,
-      'text/html',
-      `${status.fileName.replace(/\.pdf$/i, '')}-findings.html`,
-    );
   }
 
   function onBuildIcs(): void {
     if (status.kind !== 'analyzed') return;
-    const facts = extractLeaseFacts(status.result.doc);
-    const dates = leaseFactsToIcsDates(facts);
-    if (dates.length === 0) {
-      // Nothing date-shaped to emit — surface via status so the user sees why.
+    const ics = buildIcsBytes({ fileName: status.fileName, doc: status.result.doc });
+    if (!ics) {
       pipeline.setError('No dates found in this lease to export to .ics.');
       return;
     }
-    const ics = buildIcs({ leaseName: status.fileName, dates });
-    downloadBlobBytes(
-      new TextEncoder().encode(ics),
-      'text/calendar',
-      `${status.fileName.replace(/\.pdf$/i, '')}.ics`,
-    );
+    downloadBlobBytes(ics.bytes, 'text/calendar', ics.filename);
   }
 
-  async function onCopySummary(): Promise<void> {
-    if (status.kind !== 'analyzed') return;
-    const summary = buildSummary({
-      leaseName: status.fileName,
-      findings: status.result.findings,
-    });
-    await copyToClipboard(summary);
-  }
-
-  function onDownloadHandoff(): void {
-    if (status.kind !== 'analyzed') return;
-    const pdfBytes = status.bytes ?? new Uint8Array();
-    const findingsJson = exportFindingsJson({
-      name: status.fileName,
-      doc: status.result.doc,
-      findings: status.result.findings,
-    });
-    const findingsHtml = exportFindingsHtml({
-      name: status.fileName,
-      doc: status.result.doc,
-      findings: status.result.findings,
-    });
-    const readme =
-      `LeaseGuard handoff for ${status.fileName}\n\n` +
-      `- lease.pdf: original PDF (may be empty if opened from the library).\n` +
-      `- findings.html: printable findings report.\n` +
-      `- findings.json: machine-readable findings (schema leaseguard.findings.v1).\n`;
-    const zip = buildHandoffZip({ pdfBytes, findingsHtml, findingsJson, readme });
-    downloadBlobBytes(zip, 'application/zip', `${status.fileName.replace(/\.pdf$/i, '')}-handoff.zip`);
-  }
-
-  async function onSaveCustomRule(rule: Rule): Promise<void> {
-    // Wrap the single rule as a minimal `.lgpack.json` file so it can live
-    // alongside imported packs and flow through the existing enabled-packs
-    // resolver. The pack id is derived from the rule id so the user can
-    // recognize it in the pack manager.
-    const pack: RulePackFile = {
-      schema: RULE_PACK_SCHEMA_VERSION,
-      id: `custom-${rule.id}`,
-      name: `Custom: ${rule.title}`,
-      version: '1.0.0',
-      description: `User-authored rule "${rule.id}" from the custom rule builder.`,
-      rules: [rule],
-    };
-    await saveInstalledPack(pack);
-    await setPackEnabled(pack.id, true);
-    await safeAudit({
-      kind: 'custom-rule-save',
-      payload: { ruleId: rule.id, packId: pack.id },
-    });
-    await refreshPacks();
-    // After the new pack is in state, re-analyze the current lease so the
-    // rule fires immediately on the active document.
-    pipeline.reanalyze();
-    void refreshAuditLog();
-  }
-
-  async function onEditRedlineParagraph(
-    pIndex: number,
-    after: string,
-  ): Promise<void> {
-    if (status.kind !== 'analyzed' || !status.leaseId) return;
-    const before = status.result.doc.paragraphs[pIndex]?.text ?? '';
-    await saveEdit({
-      leaseId: status.leaseId,
-      paragraphIndex: pIndex,
-      before,
-      after,
-      updatedAt: new Date().toISOString(),
-    });
-    await safeAudit({
-      kind: 'redline-edit',
-      payload: { leaseId: status.leaseId, paragraphIndex: pIndex },
-    });
-    await refreshRedlineEdits(status.leaseId);
-    void refreshAuditLog();
-  }
-
-  async function onDeleteRedlineEdit(pIndex: number): Promise<void> {
-    if (status.kind !== 'analyzed' || !status.leaseId) return;
-    await deleteEdit(status.leaseId, pIndex);
-    await safeAudit({
-      kind: 'redline-edit',
-      payload: { leaseId: status.leaseId, paragraphIndex: pIndex, deleted: true },
-    });
-    await refreshRedlineEdits(status.leaseId);
-    void refreshAuditLog();
-  }
-
-  async function onCreateVersion(label?: string, note?: string): Promise<void> {
-    if (status.kind !== 'analyzed' || !status.leaseId) return;
-    const leaseId = status.leaseId;
-    // Snapshot edits live — re-read from storage so we capture anything
-    // currently persisted (the in-state `redlineEdits` should match but
-    // the storage read is authoritative).
-    const currentEdits = await listEditsForLease(leaseId);
-    const saved = await saveVersion({
-      leaseId,
-      edits: currentEdits,
-      ...(label !== undefined ? { label } : {}),
-      ...(note !== undefined ? { note } : {}),
-    });
-    await safeAudit({
-      kind: 'version-save',
-      payload: {
-        leaseId,
-        versionId: saved.versionId,
-        editCount: saved.edits.length,
-      },
-    });
-    await refreshVersions(leaseId);
-    void refreshAuditLog();
-  }
-
-  async function onRestoreVersion(versionId: string): Promise<void> {
-    if (status.kind !== 'analyzed' || !status.leaseId) return;
-    const leaseId = status.leaseId;
-    const version = await getVersion(versionId);
-    if (!version || version.leaseId !== leaseId) return;
-    // Replace strategy: delete every currently-stored edit, then save the
-    // version's snapshot in. This keeps the redline DB's
-    // `(leaseId, paragraphIndex)` uniqueness invariant intact without
-    // introducing a new "bulk replace" primitive.
-    const current = await listEditsForLease(leaseId);
-    for (const e of current) {
-      await deleteEdit(leaseId, e.paragraphIndex);
-    }
-    for (const e of version.edits) {
-      await saveEdit({ ...e, leaseId });
-    }
-    await safeAudit({
-      kind: 'version-restore',
-      payload: { leaseId, versionId, restoredEdits: version.edits.length },
-    });
-    await refreshRedlineEdits(leaseId);
-    void refreshAuditLog();
-  }
-
-  async function onDeleteVersion(versionId: string): Promise<void> {
-    if (status.kind !== 'analyzed' || !status.leaseId) return;
-    const leaseId = status.leaseId;
-    await deleteVersion(versionId);
-    await safeAudit({
-      kind: 'version-delete',
-      payload: { leaseId, versionId },
-    });
-    await refreshVersions(leaseId);
-    void refreshAuditLog();
-  }
-
-  async function onExportVersion(versionId: string): Promise<void> {
-    if (status.kind !== 'analyzed') return;
-    const version = await getVersion(versionId);
-    if (!version) return;
-    const html = buildRedlineHtml({
-      leaseName: status.fileName,
-      doc: status.result.doc,
-      edits: version.edits,
-    });
-    const labelPart = version.label ? `-${version.label.replace(/[^a-z0-9-]+/gi, '_')}` : '';
-    downloadBlob(
-      html,
-      'text/html',
-      `${status.fileName.replace(/\.pdf$/i, '')}-redline${labelPart}.html`,
-    );
-  }
-
-  /**
-   * Map a paragraph index to its section label, if the parser identified a
-   * section. Searches `doc.sections` for the section containing this
-   * paragraph's text — cheap enough at redline scale (sections are small).
-   * Returns `undefined` to let `buildSideLetterHtml` fall back to
-   * `Page N, \u00b6 M` labeling.
-   */
-  function sectionForParagraph(paragraphIndex: number): string | undefined {
-    if (status.kind !== 'analyzed') return undefined;
-    const paragraph = status.result.doc.paragraphs[paragraphIndex];
-    if (!paragraph) return undefined;
-    for (const section of status.result.doc.sections) {
-      if (section.paragraphs.includes(paragraph)) {
-        return section.number ?? section.heading;
+  // Map a paragraph index to a section label, for side-letter clause headings.
+  const sectionForParagraph = useCallback(
+    (paragraphIndex: number): string | undefined => {
+      if (status.kind !== 'analyzed') return undefined;
+      const paragraph = status.result.doc.paragraphs[paragraphIndex];
+      if (!paragraph) return undefined;
+      for (const section of status.result.doc.sections) {
+        if (section.paragraphs.includes(paragraph)) {
+          return section.number ?? section.heading;
+        }
       }
-    }
-    return undefined;
-  }
+      return undefined;
+    },
+    [status],
+  );
 
-  function onSideLetterPreview(): void {
-    if (status.kind !== 'analyzed') return;
-    const html = buildSideLetterHtml({
-      leaseName: status.fileName,
-      edits: redlineEdits,
-      sectionFor: sectionForParagraph,
-      signer:
-        sideLetterSigner.name.trim() !== ''
-          ? {
-              name: sideLetterSigner.name.trim(),
-              ...(sideLetterSigner.title.trim() !== ''
-                ? { title: sideLetterSigner.title.trim() }
-                : {}),
-            }
-          : undefined,
-    });
-    // Open in a popup window. Falls back gracefully when the browser blocks
-    // the popup by downloading instead — keeps the UI discoverable.
-    const win = window.open('', '_blank', 'noopener,noreferrer');
-    if (win) {
-      win.document.open();
-      win.document.write(html);
-      win.document.close();
-    } else {
-      onSideLetterDownload();
-    }
-  }
-
-  function onSideLetterDownload(): void {
-    if (status.kind !== 'analyzed') return;
-    const html = buildSideLetterHtml({
-      leaseName: status.fileName,
-      edits: redlineEdits,
-      sectionFor: sectionForParagraph,
-      signer:
-        sideLetterSigner.name.trim() !== ''
-          ? {
-              name: sideLetterSigner.name.trim(),
-              ...(sideLetterSigner.title.trim() !== ''
-                ? { title: sideLetterSigner.title.trim() }
-                : {}),
-            }
-          : undefined,
-    });
-    downloadBlob(
-      html,
-      'text/html',
-      `${status.fileName.replace(/\.pdf$/i, '')}-side-letter.html`,
-    );
-  }
-
-  function onExportRedlineHtml(): void {
-    if (status.kind !== 'analyzed') return;
-    const html = buildRedlineHtml({
-      leaseName: status.fileName,
-      doc: status.result.doc,
-      edits: redlineEdits,
-    });
-    downloadBlob(
-      html,
-      'text/html',
-      `${status.fileName.replace(/\.pdf$/i, '')}-redline.html`,
-    );
-  }
-
-  async function onApplySuggestion(
-    _finding: Finding,
-    paragraphIndex: number,
-    suggestedText: string,
-  ): Promise<void> {
-    if (status.kind !== 'analyzed' || !status.leaseId) return;
-    const before = status.result.doc.paragraphs[paragraphIndex]?.text ?? '';
-    await saveEdit({
-      leaseId: status.leaseId,
-      paragraphIndex,
-      before,
-      after: suggestedText,
-      updatedAt: new Date().toISOString(),
-      ruleId: _finding.ruleId,
-    });
-    await safeAudit({
-      kind: 'redline-edit',
-      payload: {
-        leaseId: status.leaseId,
-        paragraphIndex,
-        ruleId: _finding.ruleId,
-        applied: true,
-      },
-    });
-    await refreshRedlineEdits(status.leaseId);
-    void refreshAuditLog();
-    setView('redline');
-  }
 
   return (
     <main>
@@ -1069,9 +348,7 @@ export function App(): JSX.Element {
               blocks this page from loading scripts, fonts, or data from any other
               origin.
             </li>
-            <li>
-              LeaseGuard is not legal advice. Findings are heuristic pattern matches.
-            </li>
+            <li>LeaseGuard is not legal advice. Findings are heuristic pattern matches.</li>
           </ul>
         </details>
         <label>
@@ -1080,33 +357,23 @@ export function App(): JSX.Element {
             type="file"
             accept="application/pdf"
             aria-label="upload lease"
-            onChange={onFileChange}
+            onChange={async (e) => {
+              const file = e.target.files?.[0];
+              if (!file) return;
+              await handleBytes(await readFileBytes(file), file.name);
+            }}
           />
         </label>
-        <button type="button" onClick={() => void onTrySample()}>
-          Try a sample lease
-        </button>
+        <button type="button" onClick={() => void onTrySample()}>Try a sample lease</button>
         <div role="group" aria-label="view mode" className="view-toggle">
-          <button
-            type="button"
-            aria-pressed={view === 'current'}
-            onClick={() => setView('current')}
-          >
+          <button type="button" aria-pressed={view === 'current'} onClick={() => setView('current')}>
             Current lease
           </button>
-          <button
-            type="button"
-            aria-pressed={view === 'portfolio'}
-            onClick={() => setView('portfolio')}
-          >
+          <button type="button" aria-pressed={view === 'portfolio'} onClick={() => setView('portfolio')}>
             Portfolio
           </button>
           {status.kind === 'analyzed' && (
-            <button
-              type="button"
-              aria-pressed={view === 'redline'}
-              onClick={() => setView('redline')}
-            >
+            <button type="button" aria-pressed={view === 'redline'} onClick={() => setView('redline')}>
               Redline
             </button>
           )}
@@ -1114,11 +381,8 @@ export function App(): JSX.Element {
       </header>
 
       {view === 'current' && status.kind === 'loading' && (
-        <p role="status" aria-live="polite">
-          Analyzing {status.fileName}…
-        </p>
+        <p role="status" aria-live="polite">Analyzing {status.fileName}…</p>
       )}
-
       {view === 'current' && status.kind === 'error' && (
         <p role="alert">Could not analyze this file: {status.message}</p>
       )}
@@ -1138,41 +402,64 @@ export function App(): JSX.Element {
         <>
           <RedlinePanel
             doc={status.result.doc}
-            edits={redlineEdits}
+            edits={redline.redlineEdits}
             onEditParagraph={(pIdx, after) => {
-              void onEditRedlineParagraph(pIdx, after);
+              const before =
+                status.kind === 'analyzed'
+                  ? (status.result.doc.paragraphs[pIdx]?.text ?? '')
+                  : '';
+              void redline.editParagraph({ paragraphIndex: pIdx, before, after });
             }}
-            onDeleteEdit={(pIdx) => {
-              void onDeleteRedlineEdit(pIdx);
+            onDeleteEdit={(pIdx) => void redline.deleteParagraphEdit(pIdx)}
+            onExportHtml={() => {
+              if (status.kind !== 'analyzed') return;
+              downloadBlob(
+                redline.buildHtml({ leaseName: status.fileName, doc: status.result.doc }),
+                'text/html',
+                `${stripPdfExt(status.fileName)}-redline.html`,
+              );
             }}
-            onExportHtml={onExportRedlineHtml}
           />
           <details>
             <summary>Version history</summary>
             <VersionHistoryPanel
-              versions={versions}
-              currentEditCount={redlineEdits.length}
-              onCreateVersion={(label, note) => {
-                void onCreateVersion(label, note);
-              }}
-              onRestoreVersion={(vId) => {
-                void onRestoreVersion(vId);
-              }}
-              onDeleteVersion={(vId) => {
-                void onDeleteVersion(vId);
-              }}
+              versions={versionHistory.versions}
+              currentEditCount={redline.redlineEdits.length}
+              onCreateVersion={(label, note) => void versionHistory.createVersion(label, note)}
+              onRestoreVersion={(vId) =>
+                void versionHistory.restoreVersion(vId, redline.replaceAll)
+              }
+              onDeleteVersion={(vId) => void versionHistory.removeVersion(vId)}
               onExportVersion={(vId) => {
-                void onExportVersion(vId);
+                if (status.kind !== 'analyzed') return;
+                void versionHistory.exportVersion(vId, {
+                  leaseName: status.fileName,
+                  doc: status.result.doc,
+                });
               }}
             />
           </details>
           <SideLetterPanel
             leaseName={status.fileName}
-            edits={redlineEdits}
-            signerDraft={sideLetterSigner}
-            onSignerChange={(s) => setSideLetterSigner(s)}
-            onPreview={onSideLetterPreview}
-            onDownload={onSideLetterDownload}
+            edits={redline.redlineEdits}
+            signerDraft={sideLetter.signerDraft}
+            onSignerChange={(s) => sideLetter.setSignerDraft(s)}
+            onPreview={() => {
+              if (status.kind !== 'analyzed') return;
+              sideLetter.preview({
+                leaseName: status.fileName,
+                edits: redline.redlineEdits,
+                sectionFor: sectionForParagraph,
+              });
+            }}
+            onDownload={() => {
+              if (status.kind !== 'analyzed') return;
+              sideLetter.download({
+                leaseName: status.fileName,
+                edits: redline.redlineEdits,
+                sectionFor: sectionForParagraph,
+              });
+            }}
           />
         </>
       )}
@@ -1180,13 +467,21 @@ export function App(): JSX.Element {
       {view === 'current' && status.kind === 'analyzed' && (
         <div className="results">
           <div className="results-actions">
-            <button type="button" onClick={onExportJson}>
-              Export findings (JSON)
-            </button>
-            <button type="button" onClick={onExportHtml}>
+            <button type="button" onClick={onExportJson}>Export findings (JSON)</button>
+            <button
+              type="button"
+              onClick={() => {
+                if (status.kind !== 'analyzed') return;
+                exportFindingsAsHtml({
+                  fileName: status.fileName,
+                  doc: status.result.doc,
+                  findings: status.result.findings,
+                });
+              }}
+            >
               Export findings (printable HTML)
             </button>
-            {signingPublicKey !== null && (
+            {signingKey.publicKey !== null && (
               <button type="button" onClick={() => void onExportSignedJson()}>
                 Export findings (signed JSON)
               </button>
@@ -1202,7 +497,7 @@ export function App(): JSX.Element {
                   Text extraction may be incomplete.
                 </p>
                 {status.bytes && ocrState.kind !== 'running' && (
-                  <button type="button" onClick={() => void onAttemptOcr()}>
+                  <button type="button" onClick={() => { setSelected(null); void pipeline.ocr(); }}>
                     Attempt OCR
                   </button>
                 )}
@@ -1211,24 +506,27 @@ export function App(): JSX.Element {
                     Running OCR: {ocrState.stage} ({Math.round(ocrState.pct * 100)}%)
                   </p>
                 )}
-                {ocrState.kind === 'error' && (
-                  <p role="alert">OCR failed: {ocrState.message}</p>
-                )}
+                {ocrState.kind === 'error' && <p role="alert">OCR failed: {ocrState.message}</p>}
               </div>
             );
           })()}
           <div className="split">
             <FindingsPanel
               findings={status.result.findings}
-              onSelect={(f) => {
-                setSelected(f);
-                setSelectedPage(f.page);
-              }}
+              onSelect={(f) => { setSelected(f); setSelectedPage(f.page); }}
               definitions={extractLeaseFacts(status.result.doc).definitions}
               plainEnglishByRuleId={plainEnglishByRuleId}
               suggestedTextByRuleId={suggestedTextByRuleId}
               onApplySuggestion={(f, pIdx, text) => {
-                void onApplySuggestion(f, pIdx, text);
+                if (status.kind !== 'analyzed' || !status.leaseId) return;
+                void redline
+                  .applySuggestion({
+                    finding: f,
+                    paragraphIndex: pIdx,
+                    suggestedText: text,
+                    doc: status.result.doc,
+                  })
+                  .then(() => setView('redline'));
               }}
             />
             <PdfViewer
@@ -1252,29 +550,24 @@ export function App(): JSX.Element {
           <AnnotationsPanel
             leaseId={analyzedLeaseId ?? ''}
             paragraphIndex={selected ? selected.paragraphIndex : null}
-            annotations={annotations}
+            annotations={annotationsApi.annotations}
             onSave={(text) => {
-              void onSaveAnnotation(text);
+              if (!analyzedLeaseId || selected === null) return;
+              void annotationsApi.save({
+                leaseId: analyzedLeaseId,
+                paragraphIndex: selected.paragraphIndex,
+                text,
+              });
             }}
-            onUpdate={(id, text) => {
-              void onUpdateAnnotation(id, text);
-            }}
-            onDelete={(id) => {
-              void onDeleteAnnotation(id);
-            }}
+            onUpdate={(id, text) => void annotationsApi.update(id, text)}
+            onDelete={(id) => void annotationsApi.remove(id)}
           />
           <CounterOfferPanel
             finding={selected}
-            counters={counterOffers}
-            onSave={(ruleId, name, text) => {
-              void onSaveCounterOffer(ruleId, name, text);
-            }}
-            onDelete={(id) => {
-              void onDeleteCounterOffer(id);
-            }}
-            suggestedEdit={
-              selected ? suggestedEditByRuleId[selected.ruleId] : undefined
-            }
+            counters={counters.counterOffers}
+            onSave={(ruleId, name, text) => void counters.save(ruleId, name, text)}
+            onDelete={(id) => void counters.remove(id)}
+            suggestedEdit={selected ? suggestedEditByRuleId[selected.ruleId] : undefined}
           />
           <TemplateMatchesPanel matches={matchTemplates(templates, status.result.doc)} />
           <LeaseFactsPanel facts={extractLeaseFacts(status.result.doc)} />
@@ -1282,8 +575,21 @@ export function App(): JSX.Element {
             leaseName={status.fileName}
             findings={status.result.findings}
             onBuildIcs={onBuildIcs}
-            onCopySummary={onCopySummary}
-            onDownloadHandoff={onDownloadHandoff}
+            onCopySummary={async () => {
+              if (status.kind !== 'analyzed') return;
+              await copyToClipboard(
+                buildSummary({ leaseName: status.fileName, findings: status.result.findings }),
+              );
+            }}
+            onDownloadHandoff={() => {
+              if (status.kind !== 'analyzed') return;
+              downloadHandoffZip({
+                fileName: status.fileName,
+                doc: status.result.doc,
+                findings: status.result.findings,
+                bytes: status.bytes,
+              });
+            }}
           />
         </div>
       )}
@@ -1291,83 +597,54 @@ export function App(): JSX.Element {
       <LibraryPanel
         leases={library}
         standardId={standardId}
-        onOpen={(id) => {
-          void onOpenLibrary(id);
-        }}
-        onDelete={(id) => {
-          void onDeleteLibrary(id);
-        }}
-        onSetStandard={(id) => {
-          void onSetStandard(id);
-        }}
-        onRename={(id, name) => {
-          void onRename(id, name);
-        }}
+        onOpen={(id) => void onOpenLibrary(id)}
+        onDelete={(id) => void onDeleteLibrary(id)}
+        onSetStandard={(id) => void setStandardId(id).then(refreshLibrary)}
+        onRename={(id, name) => void renameLease(id, name).then(refreshLibrary)}
       />
 
-      <LibraryCompareForm
-        leases={library}
-        onCompare={(a, b) => {
-          void onCompare(a, b);
-        }}
-      />
+      <LibraryCompareForm leases={library} onCompare={(a, b) => void onCompare(a, b)} />
 
       <TemplatesPanel
         templates={templates}
-        onSave={(input) => {
-          void onSaveTemplate(input);
-        }}
-        onUpdate={(id, patch) => {
-          void onUpdateTemplate(id, patch);
-        }}
-        onDelete={(id) => {
-          void onDeleteTemplate(id);
-        }}
+        onSave={(input) => void saveTemplate(input).then(refreshTemplates)}
+        onUpdate={(id, patch) => void updateTemplate(id, patch).then(refreshTemplates)}
+        onDelete={(id) => void deleteTemplate(id).then(refreshTemplates)}
       />
 
       <PackManagerPanel
         builtInName="Built-in rules (v1)"
-        installed={installedPacks}
-        enabled={enabledPacks}
-        onImport={onImportPack}
-        onToggle={(id, enabled) => {
-          void onTogglePack(id, enabled);
-        }}
-        onDelete={(id) => {
-          void onDeletePack(id);
-        }}
-        signatureStatusByPackId={packSignatureStatus}
+        installed={packs.installedPacks}
+        enabled={packs.enabledPacks}
+        onImport={packs.importPackFile}
+        onToggle={(id, enabled) => void packs.togglePack(id, enabled)}
+        onDelete={(id) => void packs.deletePack(id)}
+        signatureStatusByPackId={packs.packSignatureStatus}
       />
 
       <details>
         <summary>Custom rule builder</summary>
         <CustomRuleBuilderPanel
           doc={status.kind === 'analyzed' ? status.result.doc : null}
-          existingRuleIds={existingRuleIds}
-          onSave={(rule) => {
-            void onSaveCustomRule(rule);
-          }}
+          existingRuleIds={packs.existingRuleIds}
+          onSave={(rule) => void packs.saveCustomRule(rule)}
         />
       </details>
 
       <JurisdictionPickerPanel
         available={JURISDICTION_OPTIONS.map((j) => j.code)}
-        selected={selectedJurisdictions}
-        onChange={(next) => {
-          void onSelectedJurisdictionsChange(next);
-        }}
+        selected={packs.selectedJurisdictions}
+        onChange={(next) => void packs.setSelectedJurisdictions(next)}
       />
 
       <SeverityOverridesPanel
-        rules={activeRules.map((r) => ({
+        rules={packs.activeRules.map((r) => ({
           id: r.id,
           title: r.title,
           severity: severityToOverrideSeverity(r.severity),
         }))}
-        overrides={overridesToPanel(severityOverrides)}
-        onChange={(ruleId, sev) => {
-          void onSeverityOverrideChange(ruleId, sev);
-        }}
+        overrides={overridesToPanel(packs.severityOverrides)}
+        onChange={(ruleId, sev) => void packs.setSeverityOverride(ruleId, sev)}
       />
 
       <section aria-label="diff rule pack">
@@ -1386,37 +663,37 @@ export function App(): JSX.Element {
             onChange={(e) => {
               const f = e.target.files?.[0];
               e.target.value = '';
-              if (f) void onComparePackFile(f);
+              if (f) void packs.comparePackFile(f);
             }}
           />
         </label>
-        {packDiff && <PackDiffPanel diff={packDiff} />}
+        {packs.packDiff && <PackDiffPanel diff={packs.packDiff} />}
       </section>
 
-      <BulkImportPanel
-        onImport={(files, onProgress) => onBulkImportFiles(files, onProgress)}
-      />
+      <BulkImportPanel onImport={(files, onProgress) => packs.bulkImportFiles(files, onProgress)} />
 
       <AuditLogPanel
         entries={auditEntries}
         verification={auditVerification}
-        onRefresh={() => {
-          void onRefreshAudit();
-        }}
+        onRefresh={() => void refreshAuditLog()}
         onVerify={() => {
-          void onVerifyAudit();
+          void (async (): Promise<void> => {
+            setAuditVerification(await verifyAuditChain());
+          })();
         }}
-        onDownload={onDownloadAudit}
+        onDownload={() => {
+          const json = buildAuditLogJson(auditEntries, auditVerification);
+          downloadAuditLogBlob(
+            json,
+            `leaseguard-audit-${new Date().toISOString().slice(0, 10)}.json`,
+          );
+        }}
       />
 
       <SigningKeyPanel
-        state={{ publicKey: signingPublicKey }}
-        onCreateKey={(pp) => {
-          void onCreateSigningKey(pp);
-        }}
-        onExportPublicKey={(pk) => {
-          void onExportSigningPublicKey(pk);
-        }}
+        state={{ publicKey: signingKey.publicKey }}
+        onCreateKey={(pp) => void signingKey.createKey(pp)}
+        onExportPublicKey={(pk) => void signingKey.exportKeyToClipboard(pk)}
       />
 
       {comparison && (
@@ -1437,7 +714,7 @@ export function App(): JSX.Element {
       )}
 
       <footer>
-        <button type="button" onClick={() => void onExportArchive()}>
+        <button type="button" onClick={() => void exportEncryptedArchiveFlow()}>
           Export encrypted archive
         </button>
         <label>
@@ -1450,91 +727,22 @@ export function App(): JSX.Element {
             onChange={(e) => void onImportArchiveFile(e)}
           />
         </label>
-        <button type="button" onClick={() => void onClearAll()}>
+        <button
+          type="button"
+          onClick={() => {
+            void clearAllFlow({
+              onCleared: async () => {
+                await refreshLibrary();
+                await refreshTemplates();
+                pipeline.reset();
+                setSelected(null);
+              },
+            });
+          }}
+        >
           Clear all saved data
         </button>
       </footer>
     </main>
   );
-}
-
-function friendlyError(err: unknown): string {
-  if (err instanceof PasswordProtectedPdfError) return err.message;
-  if (err instanceof Error) return err.message;
-  return String(err);
-}
-
-async function readFileBytes(file: File): Promise<Uint8Array> {
-  if (typeof file.arrayBuffer === 'function') {
-    return new Uint8Array(await file.arrayBuffer());
-  }
-  return new Promise<Uint8Array>((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = (): void => {
-      const result = reader.result;
-      if (result instanceof ArrayBuffer) resolve(new Uint8Array(result));
-      else reject(new Error('unexpected FileReader result'));
-    };
-    reader.onerror = (): void => reject(reader.error ?? new Error('file read failed'));
-    reader.readAsArrayBuffer(file);
-  });
-}
-
-function downloadBlob(content: string, mime: string, filename: string): void {
-  const blob = new Blob([content], { type: mime });
-  triggerDownload(blob, filename);
-}
-
-function downloadBlobBytes(bytes: Uint8Array, mime: string, filename: string): void {
-  const blob = new Blob([bytes as BlobPart], { type: mime });
-  triggerDownload(blob, filename);
-}
-
-function triggerDownload(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = filename;
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
-  URL.revokeObjectURL(url);
-}
-
-/**
- * Adapter from Phase 8 `LeaseFacts` to the date-shape `buildIcs` expects.
- * We surface commencement + expiration + a 30-day-out notice reminder when
- * the lease specifies a notice period. Skip anything we can't ISO-format.
- */
-function leaseFactsToIcsDates(facts: LeaseFacts): IcsDateInput[] {
-  const out: IcsDateInput[] = [];
-  if (facts.commencementDate) {
-    out.push({ summary: 'Lease commences', date: facts.commencementDate });
-  }
-  if (facts.expirationDate) {
-    out.push({ summary: 'Lease expires', date: facts.expirationDate });
-  }
-  if (facts.expirationDate && facts.noticePeriodDays) {
-    const notice = subtractDaysIso(facts.expirationDate, facts.noticePeriodDays);
-    if (notice) {
-      out.push({
-        summary: `Notice deadline (${facts.noticePeriodDays} days before expiration)`,
-        date: notice,
-      });
-    }
-  }
-  return out;
-}
-
-function subtractDaysIso(iso: string, days: number): string | null {
-  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
-  if (!m) return null;
-  const [, y, mo, d] = m;
-  const t = Date.UTC(Number(y), Number(mo) - 1, Number(d));
-  if (Number.isNaN(t)) return null;
-  const shifted = new Date(t - days * 86_400_000);
-  const yy = shifted.getUTCFullYear();
-  const mm = String(shifted.getUTCMonth() + 1).padStart(2, '0');
-  const dd = String(shifted.getUTCDate()).padStart(2, '0');
-  return `${yy}-${mm}-${dd}`;
 }

--- a/app/src/App/appHelpers.ts
+++ b/app/src/App/appHelpers.ts
@@ -1,0 +1,254 @@
+import { PasswordProtectedPdfError } from '../parser/types';
+import type { LeaseFacts } from '../facts/types';
+import type { IcsDateInput } from '../workflow/buildIcs';
+import { buildIcs } from '../workflow/buildIcs';
+import { extractLeaseFacts } from '../facts/extractFacts';
+import { buildHandoffZip } from '../workflow/buildHandoffZip';
+import { exportFindingsHtml } from '../storage/exportHtml';
+import { exportFindingsJson } from '../storage/exportReport';
+import type { LeaseDocument } from '../parser/types';
+import type { Finding } from '../rules/types';
+import {
+  clearAll,
+  getStandardId,
+  listAllLeaseRecords,
+  replaceAllLeases,
+  type LeaseRecord,
+} from '../storage/storage';
+import {
+  exportEncryptedArchive,
+  importEncryptedArchive,
+  WrongPassphraseError,
+} from '../storage/archive';
+
+export function friendlyError(err: unknown): string {
+  if (err instanceof PasswordProtectedPdfError) return err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/** jsdom doesn't implement `File.arrayBuffer`; fall back to `FileReader`. */
+export async function readFileBytes(file: File): Promise<Uint8Array> {
+  if (typeof file.arrayBuffer === 'function') {
+    return new Uint8Array(await file.arrayBuffer());
+  }
+  return new Promise<Uint8Array>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (): void => {
+      const result = reader.result;
+      if (result instanceof ArrayBuffer) resolve(new Uint8Array(result));
+      else reject(new Error('unexpected FileReader result'));
+    };
+    reader.onerror = (): void => reject(reader.error ?? new Error('file read failed'));
+    reader.readAsArrayBuffer(file);
+  });
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+export function downloadBlob(content: string, mime: string, filename: string): void {
+  triggerDownload(new Blob([content], { type: mime }), filename);
+}
+
+export function downloadBlobBytes(
+  bytes: Uint8Array,
+  mime: string,
+  filename: string,
+): void {
+  triggerDownload(new Blob([bytes as BlobPart], { type: mime }), filename);
+}
+
+export function stripPdfExt(name: string): string {
+  return name.replace(/\.pdf$/i, '');
+}
+
+/** Adapter from `LeaseFacts` to the date shape `buildIcs` expects. */
+export function leaseFactsToIcsDates(facts: LeaseFacts): IcsDateInput[] {
+  const out: IcsDateInput[] = [];
+  if (facts.commencementDate) {
+    out.push({ summary: 'Lease commences', date: facts.commencementDate });
+  }
+  if (facts.expirationDate) {
+    out.push({ summary: 'Lease expires', date: facts.expirationDate });
+  }
+  if (facts.expirationDate && facts.noticePeriodDays) {
+    const notice = subtractDaysIso(facts.expirationDate, facts.noticePeriodDays);
+    if (notice) {
+      out.push({
+        summary: `Notice deadline (${facts.noticePeriodDays} days before expiration)`,
+        date: notice,
+      });
+    }
+  }
+  return out;
+}
+
+export interface AnalyzedExportInput {
+  fileName: string;
+  doc: LeaseDocument;
+  findings: Finding[];
+  bytes?: Uint8Array | null;
+}
+
+/** Trigger a JSON export download for the current analysis. */
+export function exportFindingsAsJson(input: AnalyzedExportInput): void {
+  downloadBlob(
+    exportFindingsJson({
+      name: input.fileName,
+      doc: input.doc,
+      findings: input.findings,
+    }),
+    'application/json',
+    `${stripPdfExt(input.fileName)}-findings.json`,
+  );
+}
+
+/** Trigger a printable-HTML export download for the current analysis. */
+export function exportFindingsAsHtml(input: AnalyzedExportInput): void {
+  downloadBlob(
+    exportFindingsHtml({
+      name: input.fileName,
+      doc: input.doc,
+      findings: input.findings,
+    }),
+    'text/html',
+    `${stripPdfExt(input.fileName)}-findings.html`,
+  );
+}
+
+/**
+ * Build an .ics calendar export for the lease's commencement / expiration /
+ * notice deadline. Returns null if the lease has no extractable dates so the
+ * caller can surface a friendly message.
+ */
+export function buildIcsBytes(input: {
+  fileName: string;
+  doc: LeaseDocument;
+}): { bytes: Uint8Array; filename: string } | null {
+  const dates = leaseFactsToIcsDates(extractLeaseFacts(input.doc));
+  if (dates.length === 0) return null;
+  return {
+    bytes: new TextEncoder().encode(
+      buildIcs({ leaseName: input.fileName, dates }),
+    ),
+    filename: `${stripPdfExt(input.fileName)}.ics`,
+  };
+}
+
+/** Build the handoff zip (PDF + findings + readme) and trigger a download. */
+export function downloadHandoffZip(input: AnalyzedExportInput): void {
+  const findingsJson = exportFindingsJson({
+    name: input.fileName,
+    doc: input.doc,
+    findings: input.findings,
+  });
+  const findingsHtml = exportFindingsHtml({
+    name: input.fileName,
+    doc: input.doc,
+    findings: input.findings,
+  });
+  const readme =
+    `LeaseGuard handoff for ${input.fileName}\n\n` +
+    `- lease.pdf: original PDF (may be empty if opened from the library).\n` +
+    `- findings.html: printable findings report.\n` +
+    `- findings.json: machine-readable findings (schema leaseguard.findings.v1).\n`;
+  const zip = buildHandoffZip({
+    pdfBytes: input.bytes ?? new Uint8Array(),
+    findingsHtml,
+    findingsJson,
+    readme,
+  });
+  downloadBlobBytes(zip, 'application/zip', `${stripPdfExt(input.fileName)}-handoff.zip`);
+}
+
+/**
+ * Prompt for a passphrase, build an encrypted archive of every saved lease
+ * (plus the standard-id pointer), and trigger a download. No-op if the user
+ * cancels the prompt.
+ */
+export async function exportEncryptedArchiveFlow(): Promise<void> {
+  const passphrase = window.prompt('Passphrase for the encrypted archive:');
+  if (!passphrase) return;
+  const [records, std] = await Promise.all([listAllLeaseRecords(), getStandardId()]);
+  const bytes = await exportEncryptedArchive(records, std ?? null, passphrase);
+  downloadBlobBytes(
+    bytes,
+    'application/octet-stream',
+    `leaseguard-${new Date().toISOString().slice(0, 10)}.lgarchive`,
+  );
+}
+
+export interface ImportArchiveCallbacks {
+  onSuccess: (leases: LeaseRecord[]) => void | Promise<void>;
+  onError: (message: string) => void;
+}
+
+/**
+ * Decrypt + replace the entire library from an `.lgarchive` file. Confirms
+ * with the user before destructive replace. Errors flow through `onError`
+ * rather than being thrown, since this is a UI-driven flow.
+ */
+export async function importEncryptedArchiveFlow(
+  file: File,
+  cb: ImportArchiveCallbacks,
+): Promise<void> {
+  const passphrase = window.prompt('Passphrase for this archive:');
+  if (!passphrase) return;
+  try {
+    const bytes = await readFileBytes(file);
+    const payload = await importEncryptedArchive(bytes, passphrase);
+    if (
+      !window.confirm(
+        `Replace current library with ${payload.leases.length} lease(s) from this archive?`,
+      )
+    ) {
+      return;
+    }
+    await replaceAllLeases(payload.leases, payload.standardId);
+    await cb.onSuccess(payload.leases);
+  } catch (err) {
+    cb.onError(
+      err instanceof WrongPassphraseError
+        ? err.message
+        : `Import failed: ${friendlyError(err)}`,
+    );
+  }
+}
+
+/**
+ * Confirm + nuke every saved lease and template. The two refresh callbacks
+ * exist so the caller can collapse its in-memory mirrors without us reaching
+ * back into React state from a pure helper.
+ */
+export async function clearAllFlow(callbacks: {
+  onCleared: () => void | Promise<void>;
+}): Promise<boolean> {
+  if (!window.confirm('Delete all saved leases from this device? This cannot be undone.')) {
+    return false;
+  }
+  await clearAll();
+  await callbacks.onCleared();
+  return true;
+}
+
+function subtractDaysIso(iso: string, days: number): string | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+  if (!m) return null;
+  const [, y, mo, d] = m;
+  const t = Date.UTC(Number(y), Number(mo) - 1, Number(d));
+  if (Number.isNaN(t)) return null;
+  const shifted = new Date(t - days * 86_400_000);
+  const yy = shifted.getUTCFullYear();
+  const mm = String(shifted.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(shifted.getUTCDate()).padStart(2, '0');
+  return `${yy}-${mm}-${dd}`;
+}

--- a/app/src/App/useAnnotations.test.ts
+++ b/app/src/App/useAnnotations.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useAnnotations } from './useAnnotations';
+import { _resetAnnotationsDbForTests, openAnnotationsDb } from '../annotations/annotations';
+import { at } from '../test/assert';
+
+beforeEach(async () => {
+  try {
+    (await openAnnotationsDb()).close();
+  } catch {
+    // ignore
+  }
+  _resetAnnotationsDbForTests();
+  await new Promise<void>((r) => setTimeout(r, 0));
+  await new Promise<void>((resolve) => {
+    const req = indexedDB.deleteDatabase('leaseguard-annotations');
+    req.onsuccess = (): void => resolve();
+    req.onerror = (): void => resolve();
+    req.onblocked = (): void => resolve();
+  });
+});
+
+describe('useAnnotations', () => {
+  it('saves and lists annotations for a lease', async () => {
+    const { result } = renderHook(() => useAnnotations('lease-1'));
+    await waitFor(() => {
+      expect(result.current.annotations).toEqual([]);
+    });
+    await act(async () => {
+      await result.current.save({
+        leaseId: 'lease-1',
+        paragraphIndex: 3,
+        text: 'note one',
+      });
+    });
+    expect(result.current.annotations).toHaveLength(1);
+    expect(at(result.current.annotations, 0).text).toBe('note one');
+  });
+
+  it('clears annotations when leaseId becomes null', async () => {
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string | null }) => useAnnotations(id),
+      { initialProps: { id: 'lease-A' as string | null } },
+    );
+    await waitFor(() => {
+      expect(result.current.annotations).toEqual([]);
+    });
+    await act(async () => {
+      await result.current.save({
+        leaseId: 'lease-A',
+        paragraphIndex: 0,
+        text: 'x',
+      });
+    });
+    expect(result.current.annotations).toHaveLength(1);
+    rerender({ id: null });
+    await waitFor(() => {
+      expect(result.current.annotations).toEqual([]);
+    });
+  });
+});

--- a/app/src/App/useAnnotations.ts
+++ b/app/src/App/useAnnotations.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  deleteAnnotation,
+  listAnnotations,
+  saveAnnotation,
+  updateAnnotation,
+  type Annotation,
+} from '../annotations/annotations';
+
+export interface UseAnnotationsApi {
+  annotations: Annotation[];
+  /** Save an annotation against a paragraph and refresh the list. */
+  save: (input: {
+    leaseId: string;
+    paragraphIndex: number;
+    text: string;
+  }) => Promise<void>;
+  update: (id: string, text: string) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+}
+
+/**
+ * Owns the per-lease annotations list. Loads when `leaseId` changes; clears
+ * to `[]` when there is no analyzed lease.
+ */
+export function useAnnotations(leaseId: string | null): UseAnnotationsApi {
+  const [annotations, setAnnotations] = useState<Annotation[]>([]);
+
+  const refresh = useCallback(async (id: string): Promise<void> => {
+    setAnnotations(await listAnnotations(id));
+  }, []);
+
+  const save = useCallback<UseAnnotationsApi['save']>(
+    async (input) => {
+      await saveAnnotation(input);
+      await refresh(input.leaseId);
+    },
+    [refresh],
+  );
+
+  const update = useCallback<UseAnnotationsApi['update']>(
+    async (id, text) => {
+      await updateAnnotation(id, text);
+      if (leaseId) await refresh(leaseId);
+    },
+    [refresh, leaseId],
+  );
+
+  const remove = useCallback<UseAnnotationsApi['remove']>(
+    async (id) => {
+      await deleteAnnotation(id);
+      if (leaseId) await refresh(leaseId);
+    },
+    [refresh, leaseId],
+  );
+
+  useEffect(() => {
+    if (leaseId) void refresh(leaseId);
+    else setAnnotations([]);
+  }, [leaseId, refresh]);
+
+  return { annotations, save, update, remove };
+}

--- a/app/src/App/useCounterOffers.test.ts
+++ b/app/src/App/useCounterOffers.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useCounterOffers } from './useCounterOffers';
+import { _resetCountersDbForTests, openCountersDb } from '../negotiation/counterOffers';
+import { at } from '../test/assert';
+
+beforeEach(async () => {
+  try {
+    (await openCountersDb()).close();
+  } catch {
+    // ignore
+  }
+  _resetCountersDbForTests();
+  await new Promise<void>((r) => setTimeout(r, 0));
+  await new Promise<void>((resolve) => {
+    const req = indexedDB.deleteDatabase('leaseguard-counters');
+    req.onsuccess = (): void => resolve();
+    req.onerror = (): void => resolve();
+    req.onblocked = (): void => resolve();
+  });
+});
+
+describe('useCounterOffers', () => {
+  it('initial mount loads empty list, save adds an entry', async () => {
+    const { result } = renderHook(() => useCounterOffers());
+    await waitFor(() => {
+      expect(result.current.counterOffers).toEqual([]);
+    });
+    await act(async () => {
+      await result.current.save('rule-1', 'My counter', 'Some text');
+    });
+    expect(result.current.counterOffers).toHaveLength(1);
+    expect(at(result.current.counterOffers, 0).ruleId).toBe('rule-1');
+  });
+
+  it('remove deletes the saved counter offer', async () => {
+    const { result } = renderHook(() => useCounterOffers());
+    await waitFor(() => {
+      expect(result.current.counterOffers).toEqual([]);
+    });
+    await act(async () => {
+      await result.current.save('rule-x', 'A', 'aa');
+    });
+    await waitFor(() => {
+      expect(result.current.counterOffers).toHaveLength(1);
+    });
+    const id = at(result.current.counterOffers, 0).id;
+    await act(async () => {
+      await result.current.remove(id);
+    });
+    expect(result.current.counterOffers).toEqual([]);
+  });
+});

--- a/app/src/App/useCounterOffers.ts
+++ b/app/src/App/useCounterOffers.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  deleteCounterOffer,
+  listCounterOffers,
+  saveCounterOffer,
+  type CounterOffer,
+} from '../negotiation/counterOffers';
+
+export interface UseCounterOffersApi {
+  counterOffers: CounterOffer[];
+  refresh: () => Promise<void>;
+  save: (ruleId: string, name: string, text: string) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+}
+
+/**
+ * Owns the counter-offer list state. Counter-offers are pure persistence —
+ * no audit, no rule reanalyze, no pipeline coupling.
+ */
+export function useCounterOffers(): UseCounterOffersApi {
+  const [counterOffers, setCounterOffers] = useState<CounterOffer[]>([]);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setCounterOffers(await listCounterOffers());
+  }, []);
+
+  const save = useCallback(
+    async (ruleId: string, name: string, text: string): Promise<void> => {
+      await saveCounterOffer({ ruleId, name, text });
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const remove = useCallback(
+    async (id: string): Promise<void> => {
+      await deleteCounterOffer(id);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return { counterOffers, refresh, save, remove };
+}

--- a/app/src/App/usePackManager.test.ts
+++ b/app/src/App/usePackManager.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { usePackManager } from './usePackManager';
+import { _resetPacksDbForTests, openPacksDb } from '../rules/packStorage';
+
+beforeEach(async () => {
+  try {
+    (await openPacksDb()).close();
+  } catch {
+    // ignore
+  }
+  _resetPacksDbForTests();
+  await new Promise<void>((r) => setTimeout(r, 0));
+  await new Promise<void>((resolve) => {
+    const req = indexedDB.deleteDatabase('leaseguard-packs');
+    req.onsuccess = (): void => resolve();
+    req.onerror = (): void => resolve();
+    req.onblocked = (): void => resolve();
+  });
+});
+
+function makePackFile(text: string): File {
+  return new File([text], 'pack.lgpack.json', { type: 'application/json' });
+}
+
+describe('usePackManager', () => {
+  it('initial state has no installed packs and resolves the built-in rules', async () => {
+    const { result } = renderHook(() => usePackManager());
+    await waitFor(() => {
+      expect(result.current.installedPacks).toEqual([]);
+    });
+    expect(result.current.enabledPacks.size).toBe(0);
+    expect(result.current.activeRules.length).toBeGreaterThan(0);
+    expect(result.current.existingRuleIds.length).toBeGreaterThan(0);
+    expect(result.current.packDiff).toBeNull();
+  });
+
+  it('importPackFile rejects an invalid pack and surfaces the error', async () => {
+    const audit = vi.fn(async () => undefined);
+    const onAuditMutation = vi.fn();
+    const { result } = renderHook(() =>
+      usePackManager({ audit, onAuditMutation }),
+    );
+    await waitFor(() => {
+      expect(result.current.installedPacks).toEqual([]);
+    });
+    const bad = makePackFile(JSON.stringify({ not: 'a pack' }));
+    await expect(
+      act(async () => {
+        await result.current.importPackFile(bad);
+      }),
+    ).rejects.toThrow(/Invalid pack/);
+  });
+
+  it('saveCustomRule installs and enables a derived pack and audits', async () => {
+    const audit = vi.fn(async () => undefined);
+    const { result } = renderHook(() => usePackManager({ audit }));
+    await waitFor(() => {
+      expect(result.current.installedPacks).toEqual([]);
+    });
+    await act(async () => {
+      await result.current.saveCustomRule({
+        id: 'custom-rule-1',
+        title: 'Custom 1',
+        severity: 'medium',
+        category: 'general',
+        explanation: 'why',
+        citation: null,
+        match: { type: 'keywordProximity', keywords: ['foo'], window: 10 },
+      });
+    });
+    expect(result.current.installedPacks).toHaveLength(1);
+    expect(result.current.enabledPacks.has('custom-custom-rule-1')).toBe(true);
+    expect(audit).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'custom-rule-save' }),
+    );
+  });
+});

--- a/app/src/App/usePackManager.ts
+++ b/app/src/App/usePackManager.ts
@@ -1,0 +1,374 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  deleteInstalledPack,
+  getPackEnabled,
+  getPackSignatureStatus,
+  getSelectedJurisdictions,
+  getSeverityOverrides,
+  listInstalledPacks,
+  saveInstalledPack,
+  saveSignedPack,
+  setPackEnabled,
+  setSelectedJurisdictions,
+  setSeverityOverride,
+  type PackSignatureStatus,
+} from '../rules/packStorage';
+import { resolveActiveRules } from '../rules/activePack';
+import { RULE_PACK_V1 } from '../rules/packV1';
+import { analyzeFile } from '../ui/analyzeFile';
+import { saveLease } from '../storage/storage';
+import {
+  bulkImport,
+  type BulkResult,
+  type BulkSummary,
+} from '../workflow/bulkImport';
+import { applySeverityOverrides } from '../rules/severityOverrides';
+import { filterByJurisdiction } from '../rules/jurisdictions';
+import {
+  RULE_PACK_SCHEMA_VERSION,
+  validatePackFile,
+  type RulePackFile,
+} from '../rules/packSchema';
+import { verifySignedPack, type SignedPackEnvelope } from '../rules/packSigning';
+import { diffPack, type PackDiff } from '../rules/packDiff';
+import { overrideToSeverity } from '../ui/severityMap';
+import type { OverrideSeverity } from '../ui/SeverityOverridesPanel';
+import type { PackSignatureBadge } from '../ui/PackManagerPanel';
+import type { Rule, Severity } from '../rules/types';
+
+export interface UsePackManagerDeps {
+  audit?: (input: { kind: string; payload: Record<string, unknown> }) => Promise<void>;
+  onAuditMutation?: () => void;
+  onError?: (msg: string) => void;
+  /** Called after a bulk import so the library panel can refresh. */
+  onBulkImportComplete?: () => void | Promise<void>;
+}
+
+export interface UsePackManagerApi {
+  installedPacks: RulePackFile[];
+  enabledPacks: Set<string>;
+  selectedJurisdictions: string[];
+  severityOverrides: Record<string, Severity>;
+  packDiff: PackDiff | null;
+  packSignatureStatus: Record<string, PackSignatureBadge>;
+  /** Layered rule set: built-in + installed → jurisdictions → severity overrides. */
+  activeRules: Rule[];
+  /** All rule ids (built-in + installed) for the custom-rule dup-id guard. */
+  existingRuleIds: string[];
+  refresh: () => Promise<void>;
+  importPackFile: (file: File) => Promise<void>;
+  togglePack: (id: string, enabled: boolean) => Promise<void>;
+  deletePack: (id: string) => Promise<void>;
+  saveCustomRule: (rule: Rule) => Promise<void>;
+  setSelectedJurisdictions: (next: string[]) => Promise<void>;
+  setSeverityOverride: (
+    ruleId: string,
+    panelSeverity: OverrideSeverity | null,
+  ) => Promise<void>;
+  comparePackFile: (file: File) => Promise<void>;
+  clearPackDiff: () => void;
+  /**
+   * Analyze + save a batch of PDF files using the current `activeRules`.
+   * Surfaces a `bulk-import` audit event on completion. Returns the bulk
+   * summary so the caller can render success / skip / error counts.
+   */
+  bulkImportFiles: (
+    files: File[],
+    onProgress: (r: BulkResult) => void,
+  ) => Promise<BulkSummary>;
+}
+
+async function readFileBytes(file: File): Promise<Uint8Array> {
+  if (typeof file.arrayBuffer === 'function') {
+    return new Uint8Array(await file.arrayBuffer());
+  }
+  return new Promise<Uint8Array>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (): void => {
+      const result = reader.result;
+      if (result instanceof ArrayBuffer) resolve(new Uint8Array(result));
+      else reject(new Error('unexpected FileReader result'));
+    };
+    reader.onerror = (): void => reject(reader.error ?? new Error('file read failed'));
+    reader.readAsArrayBuffer(file);
+  });
+}
+
+function friendlyError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/**
+ * Owns rule-pack installation, jurisdictions, severity overrides, and the
+ * derived `activeRules` array. The signed-pack import flow goes through
+ * `saveSignedPack` so trust badges are recorded; unsigned packs go through
+ * `saveInstalledPack`. Audit writes are best-effort via the injected
+ * `audit` dep so failure never blocks an install.
+ */
+export function usePackManager(deps: UsePackManagerDeps = {}): UsePackManagerApi {
+  const { audit, onAuditMutation, onError, onBulkImportComplete } = deps;
+  const [installedPacks, setInstalledPacks] = useState<RulePackFile[]>([]);
+  const [enabledPacks, setEnabledPacks] = useState<Set<string>>(new Set());
+  const [selectedJurisdictions, setSelectedJurisdictionsState] = useState<string[]>(
+    [],
+  );
+  const [severityOverrides, setSeverityOverridesState] = useState<
+    Record<string, Severity>
+  >({});
+  const [packDiff, setPackDiff] = useState<PackDiff | null>(null);
+  const [packSignatureStatus, setPackSignatureStatus] = useState<
+    Record<string, PackSignatureBadge>
+  >({});
+
+  const refresh = useCallback(async (): Promise<void> => {
+    const packs = await listInstalledPacks();
+    const enabled = new Set<string>();
+    const sigStatus: Record<string, PackSignatureBadge> = {};
+    for (const p of packs) {
+      if (await getPackEnabled(p.id)) enabled.add(p.id);
+      const status: PackSignatureStatus = await getPackSignatureStatus(p.id);
+      sigStatus[p.id] =
+        status === 'verified'
+          ? 'verified'
+          : status === 'invalid'
+            ? 'invalid'
+            : status === 'unknown'
+              ? 'unknown'
+              : 'community';
+    }
+    setInstalledPacks(packs);
+    setEnabledPacks(enabled);
+    setPackSignatureStatus(sigStatus);
+    const [j, ov] = await Promise.all([
+      getSelectedJurisdictions(),
+      getSeverityOverrides(),
+    ]);
+    setSelectedJurisdictionsState(j);
+    setSeverityOverridesState(ov);
+  }, []);
+
+  const baseResolvedRules = resolveActiveRules(
+    RULE_PACK_V1,
+    installedPacks,
+    enabledPacks,
+  ).rules;
+
+  const activeRules = useMemo(
+    () =>
+      applySeverityOverrides(
+        filterByJurisdiction(baseResolvedRules, selectedJurisdictions),
+        severityOverrides,
+      ),
+    [baseResolvedRules, selectedJurisdictions, severityOverrides],
+  );
+
+  const existingRuleIds = useMemo<string[]>(() => {
+    const ids = new Set<string>();
+    for (const r of RULE_PACK_V1) ids.add(r.id);
+    for (const pack of installedPacks) for (const r of pack.rules) ids.add(r.id);
+    return Array.from(ids);
+  }, [installedPacks]);
+
+  const importPackFile = useCallback<UsePackManagerApi['importPackFile']>(
+    async (file) => {
+      const bytes = await readFileBytes(file);
+      const text = new TextDecoder().decode(bytes);
+      const parsed: unknown = JSON.parse(text);
+
+      if (
+        parsed !== null &&
+        typeof parsed === 'object' &&
+        'algorithm' in parsed &&
+        'payload' in parsed &&
+        'signature' in parsed
+      ) {
+        const verify = await verifySignedPack(parsed);
+        if (!verify.ok || !verify.pack) {
+          if (audit) {
+            await audit({
+              kind: 'pack-signature-invalid',
+              payload: { reason: verify.reason ?? 'unknown' },
+            });
+          }
+          onAuditMutation?.();
+          throw new Error(`Invalid signed pack: ${verify.reason ?? 'unknown'}`);
+        }
+        await saveSignedPack(parsed as SignedPackEnvelope, verify.pack);
+        await setPackEnabled(verify.pack.id, true);
+        if (audit) {
+          await audit({
+            kind: 'pack-signature-verified',
+            payload: { packId: verify.pack.id, version: verify.pack.version },
+          });
+          await audit({
+            kind: 'import-pack',
+            payload: {
+              packId: verify.pack.id,
+              version: verify.pack.version,
+              signed: true,
+            },
+          });
+        }
+        await refresh();
+        onAuditMutation?.();
+        return;
+      }
+
+      const result = validatePackFile(parsed);
+      if (!result.ok) {
+        throw new Error(`Invalid pack: ${result.errors.join('; ')}`);
+      }
+      await saveInstalledPack(result.pack);
+      await setPackEnabled(result.pack.id, true);
+      if (audit) {
+        await audit({
+          kind: 'import-pack',
+          payload: { packId: result.pack.id, version: result.pack.version },
+        });
+      }
+      await refresh();
+      onAuditMutation?.();
+    },
+    [audit, onAuditMutation, refresh],
+  );
+
+  const togglePack = useCallback<UsePackManagerApi['togglePack']>(
+    async (id, enabled) => {
+      await setPackEnabled(id, enabled);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const deletePack = useCallback<UsePackManagerApi['deletePack']>(
+    async (id) => {
+      await deleteInstalledPack(id);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const saveCustomRule = useCallback<UsePackManagerApi['saveCustomRule']>(
+    async (rule) => {
+      const pack: RulePackFile = {
+        schema: RULE_PACK_SCHEMA_VERSION,
+        id: `custom-${rule.id}`,
+        name: `Custom: ${rule.title}`,
+        version: '1.0.0',
+        description: `User-authored rule "${rule.id}" from the custom rule builder.`,
+        rules: [rule],
+      };
+      await saveInstalledPack(pack);
+      await setPackEnabled(pack.id, true);
+      if (audit) {
+        await audit({
+          kind: 'custom-rule-save',
+          payload: { ruleId: rule.id, packId: pack.id },
+        });
+      }
+      await refresh();
+      onAuditMutation?.();
+    },
+    [audit, onAuditMutation, refresh],
+  );
+
+  const setSelectedJurisdictionsApi = useCallback<
+    UsePackManagerApi['setSelectedJurisdictions']
+  >(async (next) => {
+    setSelectedJurisdictionsState(next);
+    await setSelectedJurisdictions(next);
+  }, []);
+
+  const setSeverityOverrideApi = useCallback<UsePackManagerApi['setSeverityOverride']>(
+    async (ruleId, panelSeverity) => {
+      setSeverityOverridesState((prev) => {
+        const next = { ...prev };
+        if (panelSeverity === null) {
+          delete next[ruleId];
+        } else {
+          next[ruleId] = overrideToSeverity(panelSeverity);
+        }
+        return next;
+      });
+      if (panelSeverity === null) {
+        await setSeverityOverride(ruleId, null);
+      } else {
+        await setSeverityOverride(ruleId, overrideToSeverity(panelSeverity));
+      }
+    },
+    [],
+  );
+
+  const comparePackFile = useCallback<UsePackManagerApi['comparePackFile']>(
+    async (file) => {
+      try {
+        const bytes = await readFileBytes(file);
+        const text = new TextDecoder().decode(bytes);
+        const parsed: unknown = JSON.parse(text);
+        const result = validatePackFile(parsed);
+        if (!result.ok) {
+          onError?.(`Invalid pack: ${result.errors.join('; ')}`);
+          return;
+        }
+        setPackDiff(diffPack(activeRules, result.pack));
+      } catch (err) {
+        onError?.(`Could not diff pack: ${friendlyError(err)}`);
+      }
+    },
+    [activeRules, onError],
+  );
+
+  const clearPackDiff = useCallback(() => setPackDiff(null), []);
+
+  const bulkImportFiles = useCallback<UsePackManagerApi['bulkImportFiles']>(
+    async (files, onProgress) => {
+      const summary = await bulkImport(files, onProgress, {
+        analyze: async (bytes) => {
+          const r = await analyzeFile(bytes, activeRules);
+          return { doc: r.doc, findings: r.findings };
+        },
+        save: async (input) => saveLease(input),
+      });
+      if (audit) {
+        await audit({
+          kind: 'bulk-import',
+          payload: {
+            ok: summary.ok,
+            skipped: summary.skipped,
+            errors: summary.errors,
+          },
+        });
+      }
+      if (onBulkImportComplete) await onBulkImportComplete();
+      onAuditMutation?.();
+      return summary;
+    },
+    [activeRules, audit, onAuditMutation, onBulkImportComplete],
+  );
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return {
+    installedPacks,
+    enabledPacks,
+    selectedJurisdictions,
+    severityOverrides,
+    packDiff,
+    packSignatureStatus,
+    activeRules,
+    existingRuleIds,
+    refresh,
+    importPackFile,
+    togglePack,
+    deletePack,
+    saveCustomRule,
+    setSelectedJurisdictions: setSelectedJurisdictionsApi,
+    setSeverityOverride: setSeverityOverrideApi,
+    comparePackFile,
+    clearPackDiff,
+    bulkImportFiles,
+  };
+}

--- a/app/src/App/useReanalyzeOnRulesChange.test.tsx
+++ b/app/src/App/useReanalyzeOnRulesChange.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useReanalyzeOnRulesChange } from './useReanalyzeOnRulesChange';
+import type { Rule } from '../rules/types';
+
+function rule(id: string): Rule {
+  return {
+    id,
+    severity: 'low',
+    category: 'general',
+    title: id,
+    explanation: '',
+    citation: null,
+    match: { type: 'keywordProximity', keywords: [id], window: 10 },
+  };
+}
+
+describe('useReanalyzeOnRulesChange', () => {
+  it('does not call reanalyze on initial mount', () => {
+    const reanalyze = vi.fn();
+    const initialRules = [rule('a'), rule('b')];
+    renderHook(
+      ({ rules }: { rules: Rule[] }) =>
+        useReanalyzeOnRulesChange({ activeRules: rules, reanalyze }),
+      { initialProps: { rules: initialRules } },
+    );
+    expect(reanalyze).not.toHaveBeenCalled();
+  });
+
+  it('fires exactly once when the rules array identity changes (jurisdiction toggle)', () => {
+    const reanalyze = vi.fn();
+    const initialRules = [rule('a')];
+    const { rerender } = renderHook(
+      ({ rules }: { rules: Rule[] }) =>
+        useReanalyzeOnRulesChange({ activeRules: rules, reanalyze }),
+      { initialProps: { rules: initialRules } },
+    );
+    expect(reanalyze).not.toHaveBeenCalled();
+    // Re-render with a fresh array (simulates jurisdictions filter producing new identity).
+    rerender({ rules: [rule('a'), rule('b')] });
+    expect(reanalyze).toHaveBeenCalledTimes(1);
+    // Re-rendering with the SAME identity must not re-fire.
+    const stable = [rule('a'), rule('b')];
+    rerender({ rules: stable });
+    rerender({ rules: stable });
+    expect(reanalyze).toHaveBeenCalledTimes(2);
+  });
+
+  it('unmounting between rule changes is safe and does not throw', () => {
+    const reanalyze = vi.fn();
+    const { rerender, unmount } = renderHook(
+      ({ rules }: { rules: Rule[] }) =>
+        useReanalyzeOnRulesChange({ activeRules: rules, reanalyze }),
+      { initialProps: { rules: [rule('a')] } },
+    );
+    rerender({ rules: [rule('a'), rule('b')] });
+    expect(reanalyze).toHaveBeenCalledTimes(1);
+    expect(() => unmount()).not.toThrow();
+    // After unmount, no further calls.
+    expect(reanalyze).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/App/useReanalyzeOnRulesChange.ts
+++ b/app/src/App/useReanalyzeOnRulesChange.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react';
+import type { Rule } from '../rules/types';
+
+export interface UseReanalyzeOnRulesChangeDeps {
+  /** Currently active rule array. Identity changes drive reanalysis. */
+  activeRules: Rule[];
+  /** Reanalyze trigger — typically `pipeline.reanalyze` from `usePipeline`. */
+  reanalyze: () => void;
+}
+
+/**
+ * Auto-trigger pipeline reanalysis when the active rule set changes.
+ *
+ * Replaces every manual `pipeline.reanalyze()` call site (jurisdiction
+ * picker, severity overrides, custom-rule save). The skip-first-mount
+ * guard avoids a redundant analyze right after `usePipeline.upload`
+ * already produced findings against the same rule set.
+ *
+ * Identity, not deep equality, is the trigger — `activeRules` should be
+ * memoized in `usePackManager` so unrelated re-renders don't churn the
+ * analysis worker.
+ */
+export function useReanalyzeOnRulesChange(
+  deps: UseReanalyzeOnRulesChangeDeps,
+): void {
+  const { activeRules, reanalyze } = deps;
+  const previousRef = useRef<Rule[] | null>(null);
+
+  useEffect(() => {
+    if (previousRef.current === null) {
+      // Initial mount: record the rules but do NOT trigger reanalyze. The
+      // pipeline already analyzed against this exact rule set on upload.
+      previousRef.current = activeRules;
+      return;
+    }
+    if (previousRef.current === activeRules) return;
+    previousRef.current = activeRules;
+    reanalyze();
+  }, [activeRules, reanalyze]);
+}

--- a/app/src/App/useRedlineState.test.ts
+++ b/app/src/App/useRedlineState.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useRedlineState } from './useRedlineState';
+import { _resetRedlineDbForTests, openRedlineDb } from '../redline/redlineStorage';
+import { at } from '../test/assert';
+
+beforeEach(async () => {
+  try {
+    (await openRedlineDb()).close();
+  } catch {
+    // ignore
+  }
+  _resetRedlineDbForTests();
+  await new Promise<void>((r) => setTimeout(r, 0));
+  await new Promise<void>((resolve) => {
+    const req = indexedDB.deleteDatabase('leaseguard-redlines');
+    req.onsuccess = (): void => resolve();
+    req.onerror = (): void => resolve();
+    req.onblocked = (): void => resolve();
+  });
+});
+
+describe('useRedlineState', () => {
+  it('editParagraph saves and audits, deleteParagraphEdit removes', async () => {
+    const audit = vi.fn(async () => undefined);
+    const onAuditMutation = vi.fn();
+    const { result } = renderHook(() =>
+      useRedlineState({ leaseId: 'lease-1', audit, onAuditMutation }),
+    );
+    await waitFor(() => {
+      expect(result.current.redlineEdits).toEqual([]);
+    });
+    await act(async () => {
+      await result.current.editParagraph({
+        paragraphIndex: 5,
+        before: 'old',
+        after: 'new',
+        ruleId: 'r',
+      });
+    });
+    expect(result.current.redlineEdits).toHaveLength(1);
+    expect(at(result.current.redlineEdits, 0).after).toBe('new');
+    expect(audit).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'redline-edit' }),
+    );
+    expect(onAuditMutation).toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.deleteParagraphEdit(5);
+    });
+    expect(result.current.redlineEdits).toEqual([]);
+  });
+
+  it('clears edits when leaseId becomes null', async () => {
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string | null }) => useRedlineState({ leaseId: id }),
+      { initialProps: { id: 'L' as string | null } },
+    );
+    await waitFor(() => {
+      expect(result.current.redlineEdits).toEqual([]);
+    });
+    await act(async () => {
+      await result.current.editParagraph({
+        paragraphIndex: 1,
+        before: 'a',
+        after: 'b',
+      });
+    });
+    expect(result.current.redlineEdits).toHaveLength(1);
+    rerender({ id: null });
+    await waitFor(() => {
+      expect(result.current.redlineEdits).toEqual([]);
+    });
+  });
+});

--- a/app/src/App/useRedlineState.ts
+++ b/app/src/App/useRedlineState.ts
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  saveEdit,
+  listEditsForLease,
+  deleteEdit,
+} from '../redline/redlineStorage';
+import { buildRedlineHtml } from '../redline/redline';
+import type { RedlineEdit } from '../redline/redline';
+import type { LeaseDocument } from '../parser/types';
+import type { Finding } from '../rules/types';
+
+export interface UseRedlineStateDeps {
+  leaseId: string | null;
+  /**
+   * Best-effort audit append. Wired to `safeAudit` from App.tsx so audit
+   * failures never block a redline edit.
+   */
+  audit?: (input: { kind: string; payload: Record<string, unknown> }) => Promise<void>;
+  /**
+   * Called after an audited mutation, so the audit log panel can refresh.
+   * Optional — pure data tests may omit it.
+   */
+  onAuditMutation?: () => void;
+}
+
+export interface UseRedlineStateApi {
+  redlineEdits: RedlineEdit[];
+  /** Save (or replace) an edit for `paragraphIndex` with `before`/`after` text. */
+  editParagraph: (input: {
+    paragraphIndex: number;
+    before: string;
+    after: string;
+    ruleId?: string;
+  }) => Promise<void>;
+  deleteParagraphEdit: (paragraphIndex: number) => Promise<void>;
+  /**
+   * Replace all stored edits for the active lease with the supplied list.
+   * Used by version-restore — keeps the (leaseId, paragraphIndex) uniqueness
+   * invariant intact without introducing a bulk-replace primitive.
+   */
+  replaceAll: (edits: RedlineEdit[]) => Promise<void>;
+  /** Manually refresh from storage (e.g. after a version-restore audit). */
+  refresh: () => Promise<void>;
+  /** Build a printable redline HTML for the supplied doc + the current edits. */
+  buildHtml: (input: { leaseName: string; doc: LeaseDocument }) => string;
+  /**
+   * Apply a rule's suggested edit (or a counter-offer) to a paragraph. Resolves
+   * `before` from `doc` and audits the change as `applied: true`.
+   */
+  applySuggestion: (input: {
+    finding: Finding;
+    paragraphIndex: number;
+    suggestedText: string;
+    doc: LeaseDocument;
+  }) => Promise<void>;
+}
+
+/**
+ * Owns the per-lease redline edit list. When `leaseId` flips to null (no
+ * analyzed lease) the list clears.
+ */
+export function useRedlineState(deps: UseRedlineStateDeps): UseRedlineStateApi {
+  const { leaseId, audit, onAuditMutation } = deps;
+  const [redlineEdits, setRedlineEdits] = useState<RedlineEdit[]>([]);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (!leaseId) return;
+    setRedlineEdits(await listEditsForLease(leaseId));
+  }, [leaseId]);
+
+  const editParagraph = useCallback<UseRedlineStateApi['editParagraph']>(
+    async (input) => {
+      if (!leaseId) return;
+      await saveEdit({
+        leaseId,
+        paragraphIndex: input.paragraphIndex,
+        before: input.before,
+        after: input.after,
+        updatedAt: new Date().toISOString(),
+        ...(input.ruleId !== undefined ? { ruleId: input.ruleId } : {}),
+      });
+      if (audit) {
+        await audit({
+          kind: 'redline-edit',
+          payload: {
+            leaseId,
+            paragraphIndex: input.paragraphIndex,
+            ...(input.ruleId !== undefined
+              ? { ruleId: input.ruleId, applied: true }
+              : {}),
+          },
+        });
+      }
+      setRedlineEdits(await listEditsForLease(leaseId));
+      onAuditMutation?.();
+    },
+    [leaseId, audit, onAuditMutation],
+  );
+
+  const deleteParagraphEdit = useCallback<UseRedlineStateApi['deleteParagraphEdit']>(
+    async (paragraphIndex) => {
+      if (!leaseId) return;
+      await deleteEdit(leaseId, paragraphIndex);
+      if (audit) {
+        await audit({
+          kind: 'redline-edit',
+          payload: { leaseId, paragraphIndex, deleted: true },
+        });
+      }
+      setRedlineEdits(await listEditsForLease(leaseId));
+      onAuditMutation?.();
+    },
+    [leaseId, audit, onAuditMutation],
+  );
+
+  const replaceAll = useCallback<UseRedlineStateApi['replaceAll']>(
+    async (edits) => {
+      if (!leaseId) return;
+      const current = await listEditsForLease(leaseId);
+      for (const e of current) {
+        await deleteEdit(leaseId, e.paragraphIndex);
+      }
+      for (const e of edits) {
+        await saveEdit({ ...e, leaseId });
+      }
+      setRedlineEdits(await listEditsForLease(leaseId));
+    },
+    [leaseId],
+  );
+
+  const buildHtml = useCallback<UseRedlineStateApi['buildHtml']>(
+    ({ leaseName, doc }) =>
+      buildRedlineHtml({ leaseName, doc, edits: redlineEdits }),
+    [redlineEdits],
+  );
+
+  useEffect(() => {
+    if (leaseId) void refresh();
+    else setRedlineEdits([]);
+  }, [leaseId, refresh]);
+
+  const applySuggestion = useCallback<UseRedlineStateApi['applySuggestion']>(
+    async ({ finding, paragraphIndex, suggestedText, doc }) => {
+      const before = doc.paragraphs[paragraphIndex]?.text ?? '';
+      await editParagraph({
+        paragraphIndex,
+        before,
+        after: suggestedText,
+        ruleId: finding.ruleId,
+      });
+    },
+    [editParagraph],
+  );
+
+  return {
+    redlineEdits,
+    editParagraph,
+    deleteParagraphEdit,
+    replaceAll,
+    refresh,
+    buildHtml,
+    applySuggestion,
+  };
+}

--- a/app/src/App/useSideLetter.test.ts
+++ b/app/src/App/useSideLetter.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useSideLetter } from './useSideLetter';
+import type { RedlineEdit } from '../redline/redline';
+
+const sampleEdits: RedlineEdit[] = [
+  {
+    leaseId: 'L',
+    paragraphIndex: 0,
+    before: 'old text',
+    after: 'new text',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+  },
+];
+
+describe('useSideLetter', () => {
+  it('omits the signer block when name is blank', () => {
+    const { result } = renderHook(() => useSideLetter());
+    const html = result.current.buildHtml({
+      leaseName: 'Lease.pdf',
+      edits: sampleEdits,
+    });
+    expect(html).not.toMatch(/Signed[, ]/i);
+    expect(html.toLowerCase()).toContain('lease.pdf');
+  });
+
+  it('includes the signer block when the name is set', () => {
+    const { result } = renderHook(() => useSideLetter());
+    act(() => {
+      result.current.setSignerDraft({ name: '  Jane Doe ', title: ' Counsel ' });
+    });
+    const html = result.current.buildHtml({
+      leaseName: 'Lease.pdf',
+      edits: sampleEdits,
+    });
+    expect(html).toContain('Jane Doe');
+    expect(html).toContain('Counsel');
+  });
+});

--- a/app/src/App/useSideLetter.ts
+++ b/app/src/App/useSideLetter.ts
@@ -1,0 +1,105 @@
+import { useCallback, useState } from 'react';
+import {
+  buildSideLetterHtml,
+  type SideLetterSigner,
+} from '../negotiation/sideLetter';
+import type { RedlineEdit } from '../redline/redline';
+import { downloadBlob, stripPdfExt } from './appHelpers';
+
+export interface SideLetterSignerDraft {
+  name: string;
+  title: string;
+}
+
+export interface UseSideLetterApi {
+  signerDraft: SideLetterSignerDraft;
+  setSignerDraft: (draft: SideLetterSignerDraft) => void;
+  /**
+   * Render the side-letter HTML using the current signer draft. `sectionFor`
+   * lets callers map paragraph indices to section labels — falls back to
+   * `Page N, ¶ M` inside `buildSideLetterHtml`.
+   */
+  buildHtml: (input: {
+    leaseName: string;
+    edits: RedlineEdit[];
+    sectionFor?: (paragraphIndex: number) => string | undefined;
+  }) => string;
+  /**
+   * Open the rendered side-letter in a popup window. If the browser blocks
+   * the popup we fall back to triggering a file download instead — keeps
+   * the UI affordance discoverable.
+   */
+  preview: (input: {
+    leaseName: string;
+    edits: RedlineEdit[];
+    sectionFor?: (paragraphIndex: number) => string | undefined;
+  }) => void;
+  /** Download the rendered side-letter HTML as a file. */
+  download: (input: {
+    leaseName: string;
+    edits: RedlineEdit[];
+    sectionFor?: (paragraphIndex: number) => string | undefined;
+  }) => void;
+}
+
+function trimmedSigner(draft: SideLetterSignerDraft): SideLetterSigner | undefined {
+  if (draft.name.trim() === '') return undefined;
+  const out: SideLetterSigner = { name: draft.name.trim() };
+  const title = draft.title.trim();
+  if (title !== '') out.title = title;
+  return out;
+}
+
+/**
+ * Owns the side-letter signer draft and exposes a single render helper. The
+ * preview / download decision lives in App.tsx (popup vs file download is a
+ * UI concern, not a hook concern).
+ */
+export function useSideLetter(): UseSideLetterApi {
+  const [signerDraft, setSignerDraft] = useState<SideLetterSignerDraft>({
+    name: '',
+    title: '',
+  });
+
+  const buildHtml = useCallback<UseSideLetterApi['buildHtml']>(
+    (input) => {
+      const signer = trimmedSigner(signerDraft);
+      return buildSideLetterHtml({
+        leaseName: input.leaseName,
+        edits: input.edits,
+        sectionFor: input.sectionFor ?? ((): string | undefined => undefined),
+        ...(signer !== undefined ? { signer } : {}),
+      });
+    },
+    [signerDraft],
+  );
+
+  const download = useCallback<UseSideLetterApi['download']>(
+    (input) => {
+      const html = buildHtml(input);
+      downloadBlob(
+        html,
+        'text/html',
+        `${stripPdfExt(input.leaseName)}-side-letter.html`,
+      );
+    },
+    [buildHtml],
+  );
+
+  const preview = useCallback<UseSideLetterApi['preview']>(
+    (input) => {
+      const html = buildHtml(input);
+      const win = window.open('', '_blank', 'noopener,noreferrer');
+      if (win) {
+        win.document.open();
+        win.document.write(html);
+        win.document.close();
+      } else {
+        download(input);
+      }
+    },
+    [buildHtml, download],
+  );
+
+  return { signerDraft, setSignerDraft, buildHtml, preview, download };
+}

--- a/app/src/App/useSigningKey.test.ts
+++ b/app/src/App/useSigningKey.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useSigningKey } from './useSigningKey';
+import { _resetSigningDbForTests } from '../security/signingKeys';
+
+beforeEach(async () => {
+  _resetSigningDbForTests();
+  await new Promise<void>((r) => setTimeout(r, 0));
+  await new Promise<void>((resolve) => {
+    const req = indexedDB.deleteDatabase('leaseguard-signing');
+    req.onsuccess = (): void => resolve();
+    req.onerror = (): void => resolve();
+    req.onblocked = (): void => resolve();
+  });
+});
+
+describe('useSigningKey', () => {
+  it('initial mount reports no key, createKey populates publicKey', async () => {
+    const { result } = renderHook(() => useSigningKey());
+    await waitFor(() => {
+      expect(result.current.publicKey).toBeNull();
+    });
+    await act(async () => {
+      await result.current.createKey('correct horse battery staple');
+    });
+    expect(typeof result.current.publicKey).toBe('string');
+    expect(result.current.publicKey).not.toBe('');
+  });
+
+  it('exportKeyToClipboard swallows clipboard failures', async () => {
+    const { result } = renderHook(() => useSigningKey());
+    const writeText = vi.fn().mockRejectedValue(new Error('blocked'));
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    await expect(result.current.exportKeyToClipboard('pkbase64')).resolves.toBeUndefined();
+    expect(writeText).toHaveBeenCalledWith('pkbase64');
+  });
+});

--- a/app/src/App/useSigningKey.ts
+++ b/app/src/App/useSigningKey.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useState } from 'react';
+import { createSigningKey, exportPublicKey } from '../security/signingKeys';
+import { signExport, exportFindingsJson } from '../storage/exportReport';
+import { sha256Hex } from '../security/inputHash';
+import type { LeaseDocument } from '../parser/types';
+import type { Finding } from '../rules/types';
+import { downloadBlob, stripPdfExt } from './appHelpers';
+
+export interface UseSigningKeyApi {
+  /** Base64 public key, or null if no key has been generated yet. */
+  publicKey: string | null;
+  /** Generate a new signing key, encrypted with `passphrase`. */
+  createKey: (passphrase: string) => Promise<void>;
+  /**
+   * Best-effort copy of the base64 public key to the clipboard. CSP / focus
+   * policies may block; failure is intentionally silent (UI fallback shows
+   * the key inline anyway).
+   */
+  exportKeyToClipboard: (publicKey: string) => Promise<void>;
+  /**
+   * Sign + download a findings JSON. Throws on bad passphrase or signing
+   * failure so callers can surface the message via their error channel.
+   */
+  signAndDownloadFindings: (input: {
+    fileName: string;
+    doc: LeaseDocument;
+    findings: Finding[];
+    bytes: Uint8Array | null;
+    passphrase: string;
+  }) => Promise<void>;
+  /** Re-read the public key from storage (used after rotation). */
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Owns the user's Ed25519 signing key state. Storage is the leaseguard-signing
+ * IDB database; the public-key cache is purely a UI mirror.
+ */
+export function useSigningKey(): UseSigningKeyApi {
+  const [publicKey, setPublicKey] = useState<string | null>(null);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setPublicKey(await exportPublicKey());
+  }, []);
+
+  const createKey = useCallback(
+    async (passphrase: string): Promise<void> => {
+      await createSigningKey(passphrase);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const exportKeyToClipboard = useCallback(async (pk: string): Promise<void> => {
+    try {
+      const nav = globalThis.navigator as
+        | { clipboard?: { writeText?: (s: string) => Promise<void> } }
+        | undefined;
+      await nav?.clipboard?.writeText?.(pk);
+    } catch {
+      // swallow — exporting is best-effort
+    }
+  }, []);
+
+  const signAndDownloadFindings = useCallback<
+    UseSigningKeyApi['signAndDownloadFindings']
+  >(async ({ fileName, doc, findings, bytes, passphrase }) => {
+    const inputHash = bytes ? await sha256Hex(bytes) : null;
+    const unsigned = exportFindingsJson({ name: fileName, doc, findings, inputHash });
+    const signed = await signExport(unsigned, passphrase);
+    downloadBlob(
+      signed,
+      'application/json',
+      `${stripPdfExt(fileName)}-findings.signed.json`,
+    );
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return {
+    publicKey,
+    createKey,
+    exportKeyToClipboard,
+    signAndDownloadFindings,
+    refresh,
+  };
+}

--- a/app/src/App/useVersionHistory.test.ts
+++ b/app/src/App/useVersionHistory.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useVersionHistory } from './useVersionHistory';
+import {
+  _resetVersionsDbForTests,
+  openVersionsDb,
+} from '../negotiation/versionHistory';
+import {
+  _resetRedlineDbForTests,
+  openRedlineDb,
+  saveEdit,
+} from '../redline/redlineStorage';
+import { at } from '../test/assert';
+
+beforeEach(async () => {
+  try {
+    (await openVersionsDb()).close();
+  } catch {
+    // ignore
+  }
+  try {
+    (await openRedlineDb()).close();
+  } catch {
+    // ignore
+  }
+  _resetVersionsDbForTests();
+  _resetRedlineDbForTests();
+  await new Promise<void>((r) => setTimeout(r, 0));
+  for (const name of ['leaseguard-versions', 'leaseguard-redlines']) {
+    await new Promise<void>((resolve) => {
+      const req = indexedDB.deleteDatabase(name);
+      req.onsuccess = (): void => resolve();
+      req.onerror = (): void => resolve();
+      req.onblocked = (): void => resolve();
+    });
+  }
+});
+
+describe('useVersionHistory', () => {
+  it('createVersion snapshots current edits and audits', async () => {
+    await saveEdit({
+      leaseId: 'lease-1',
+      paragraphIndex: 1,
+      before: 'a',
+      after: 'b',
+      updatedAt: new Date().toISOString(),
+    });
+    const audit = vi.fn(async () => undefined);
+    const { result } = renderHook(() =>
+      useVersionHistory({ leaseId: 'lease-1', audit }),
+    );
+    await waitFor(() => {
+      expect(result.current.versions).toEqual([]);
+    });
+    let saved;
+    await act(async () => {
+      saved = await result.current.createVersion('label-A', 'note-A');
+    });
+    expect(saved).not.toBeNull();
+    expect(result.current.versions).toHaveLength(1);
+    expect(at(result.current.versions, 0).label).toBe('label-A');
+    expect(audit).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'version-save' }),
+    );
+  });
+
+  it('getVersionById returns null when versionId belongs to another lease', async () => {
+    const { result } = renderHook(() =>
+      useVersionHistory({ leaseId: 'lease-other' }),
+    );
+    await waitFor(() => {
+      expect(result.current.versions).toEqual([]);
+    });
+    const got = await result.current.getVersionById('does-not-exist');
+    expect(got).toBeNull();
+  });
+});

--- a/app/src/App/useVersionHistory.ts
+++ b/app/src/App/useVersionHistory.ts
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  deleteVersion,
+  getVersion,
+  listVersionsForLease,
+  saveVersion,
+  type LeaseVersion,
+} from '../negotiation/versionHistory';
+import { listEditsForLease } from '../redline/redlineStorage';
+import { buildRedlineHtml } from '../redline/redline';
+import type { LeaseDocument } from '../parser/types';
+import type { RedlineEdit } from '../redline/redline';
+import { downloadBlob, stripPdfExt } from './appHelpers';
+
+export interface UseVersionHistoryDeps {
+  leaseId: string | null;
+  audit?: (input: { kind: string; payload: Record<string, unknown> }) => Promise<void>;
+  onAuditMutation?: () => void;
+}
+
+export interface UseVersionHistoryApi {
+  versions: LeaseVersion[];
+  /** Snapshot the lease's currently-stored edits as a new version. */
+  createVersion: (label?: string, note?: string) => Promise<LeaseVersion | null>;
+  /** Delete a specific version by id. */
+  removeVersion: (versionId: string) => Promise<void>;
+  /** Look up a version by id (null if missing or wrong lease). */
+  getVersionById: (versionId: string) => Promise<LeaseVersion | null>;
+  refresh: () => Promise<void>;
+  /**
+   * Restore a version by replacing the lease's current edits with the
+   * version's snapshot. The replace is delegated through `applyRestore` so
+   * the redline DB stays the single source of truth — we only audit here.
+   */
+  restoreVersion: (
+    versionId: string,
+    applyRestore: (edits: RedlineEdit[]) => Promise<void>,
+  ) => Promise<void>;
+  /** Build + download a redline HTML snapshot for a saved version. */
+  exportVersion: (
+    versionId: string,
+    input: { leaseName: string; doc: LeaseDocument },
+  ) => Promise<void>;
+}
+
+/**
+ * Owns the per-lease version history list. Restoring a version mutates the
+ * redline DB; we leave that mutation to `useRedlineState.replaceAll` and
+ * only audit the restore here, to keep the responsibilities separable.
+ */
+export function useVersionHistory(deps: UseVersionHistoryDeps): UseVersionHistoryApi {
+  const { leaseId, audit, onAuditMutation } = deps;
+  const [versions, setVersions] = useState<LeaseVersion[]>([]);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (!leaseId) return;
+    setVersions(await listVersionsForLease(leaseId));
+  }, [leaseId]);
+
+  const createVersion = useCallback<UseVersionHistoryApi['createVersion']>(
+    async (label, note) => {
+      if (!leaseId) return null;
+      const currentEdits = await listEditsForLease(leaseId);
+      const saved = await saveVersion({
+        leaseId,
+        edits: currentEdits,
+        ...(label !== undefined ? { label } : {}),
+        ...(note !== undefined ? { note } : {}),
+      });
+      if (audit) {
+        await audit({
+          kind: 'version-save',
+          payload: {
+            leaseId,
+            versionId: saved.versionId,
+            editCount: saved.edits.length,
+          },
+        });
+      }
+      setVersions(await listVersionsForLease(leaseId));
+      onAuditMutation?.();
+      return saved;
+    },
+    [leaseId, audit, onAuditMutation],
+  );
+
+  const removeVersion = useCallback<UseVersionHistoryApi['removeVersion']>(
+    async (versionId) => {
+      if (!leaseId) return;
+      await deleteVersion(versionId);
+      if (audit) {
+        await audit({
+          kind: 'version-delete',
+          payload: { leaseId, versionId },
+        });
+      }
+      setVersions(await listVersionsForLease(leaseId));
+      onAuditMutation?.();
+    },
+    [leaseId, audit, onAuditMutation],
+  );
+
+  const getVersionById = useCallback<UseVersionHistoryApi['getVersionById']>(
+    async (versionId) => {
+      const v = await getVersion(versionId);
+      if (!v || (leaseId && v.leaseId !== leaseId)) return null;
+      return v;
+    },
+    [leaseId],
+  );
+
+  const restoreVersion = useCallback<UseVersionHistoryApi['restoreVersion']>(
+    async (versionId, applyRestore) => {
+      if (!leaseId) return;
+      const v = await getVersion(versionId);
+      if (!v || v.leaseId !== leaseId) return;
+      await applyRestore(v.edits);
+      if (audit) {
+        await audit({
+          kind: 'version-restore',
+          payload: { leaseId, versionId, restoredEdits: v.edits.length },
+        });
+      }
+      onAuditMutation?.();
+    },
+    [leaseId, audit, onAuditMutation],
+  );
+
+  const exportVersion = useCallback<UseVersionHistoryApi['exportVersion']>(
+    async (versionId, { leaseName, doc }) => {
+      const v = await getVersion(versionId);
+      if (!v) return;
+      const labelPart = v.label
+        ? `-${v.label.replace(/[^a-z0-9-]+/gi, '_')}`
+        : '';
+      downloadBlob(
+        buildRedlineHtml({ leaseName, doc, edits: v.edits }),
+        'text/html',
+        `${stripPdfExt(leaseName)}-redline${labelPart}.html`,
+      );
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (leaseId) void refresh();
+    else setVersions([]);
+  }, [leaseId, refresh]);
+
+  return {
+    versions,
+    createVersion,
+    removeVersion,
+    getVersionById,
+    refresh,
+    restoreVersion,
+    exportVersion,
+  };
+}


### PR DESCRIPTION
## Summary

Wave 7 Part D, **full subagent attempt** for the head-to-head comparison against the direct-Claude scoped attempt on PR #4.

## What's in

8 hooks + a helpers module:
- `useAnnotations`, `useCounterOffers`, `usePackManager`, `useReanalyzeOnRulesChange`, `useRedlineState`, `useSideLetter`, `useSigningKey`, `useVersionHistory`
- `appHelpers.ts`

## Metrics

| Axis | Subagent | Direct (PR #4) |
|---|---|---|
| Hooks extracted | 8 + helpers | 3 |
| App.tsx LOC | 1540 → 748 | 1540 → ~1490 |
| Plan target (≤ 600) | over by ~150 | not attempted |
| `src/App/` hook tests | 30/30 pass | 19/19 pass |
| typecheck / lint | clean / unverified | clean / clean |
| `App.panels.test.tsx` | hangs >120s (unverified) | 26/26 in isolation |

## Caveats

The agent was **stopped manually** after spending ~5+ hours stuck in a verify loop trying to read background-test output. Implementation is complete; final verification was not. App.panels.test.tsx hangs in this branch — needs follow-up debugging before this can be considered ship-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)