### PR TITLE
wave7-B: First-run onboarding tour

### DIFF
--- a/app/src/App.panels.test.tsx
+++ b/app/src/App.panels.test.tsx
@@ -32,7 +32,12 @@ vi.mock('./ui/renderPdfPages', () => ({
 
 import { App } from './App';
 import { makePdf } from './parser/testFixtures';
-import { _resetDbForTests, openLeaseDb, listLeases } from './storage/storage';
+import {
+  _resetDbForTests,
+  openLeaseDb,
+  listLeases,
+  setOnboardingDismissedAt,
+} from './storage/storage';
 import {
   _resetPacksDbForTests,
   listInstalledPacks,
@@ -161,6 +166,8 @@ beforeEach(async () => {
   await wipeDb(BULK_DEDUP_DB_NAME);
   await wipeDb('leaseguard-redlines');
   await wipeDb('leaseguard-versions');
+  // Mark the onboarding tour dismissed so it never intercepts these tests.
+  await setOnboardingDismissedAt(Date.now());
 });
 
 async function makeLeaseFile(name = 'lease.pdf'): Promise<File> {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -76,13 +76,16 @@ import {
   clearStandardId,
   deleteLease,
   getLease,
+  getOnboardingDismissedAt,
   getStandardId,
   listAllLeaseRecords,
   listLeases,
   renameLease,
+  setOnboardingDismissedAt,
   setStandardId,
   type LeaseMetadata,
 } from './storage/storage';
+import { OnboardingTour } from './ui/OnboardingTour';
 
 export function App(): JSX.Element {
   const [selected, setSelected] = useState<Finding | null>(null);
@@ -96,6 +99,22 @@ export function App(): JSX.Element {
   const [portfolioFindings, setPortfolioFindings] = useState<Map<string, Finding[]>>(
     new Map(),
   );
+  // `undefined` = "not yet loaded from IDB" — we render nothing for the tour
+  // until we know, so first-run users don't see a flash-of-modal followed by
+  // dismissal. `null` = first run, show the tour. number = already dismissed.
+  const [onboardingDismissedAt, setOnboardingDismissedAtState] = useState<
+    number | null | undefined
+  >(undefined);
+
+  useEffect(() => {
+    void getOnboardingDismissedAt().then((ts) => setOnboardingDismissedAtState(ts));
+  }, []);
+
+  const dismissOnboarding = useCallback(async (): Promise<void> => {
+    const ts = Date.now();
+    setOnboardingDismissedAtState(ts);
+    await setOnboardingDismissedAt(ts);
+  }, []);
 
   const refreshAuditLog = useCallback(async (): Promise<void> => {
     setAuditEntries(await listAuditEntries());
@@ -342,6 +361,14 @@ export function App(): JSX.Element {
 
   return (
     <main>
+      {onboardingDismissedAt !== undefined && (
+        <OnboardingTour
+          dismissedAt={onboardingDismissedAt}
+          onDismiss={() => {
+            void dismissOnboarding();
+          }}
+        />
+      )}
       <header>
         <h1>LeaseGuard</h1>
         <p>Private, local-first lease analyzer. Nothing leaves your device.</p>

--- a/app/src/storage/storage.test.ts
+++ b/app/src/storage/storage.test.ts
@@ -3,13 +3,16 @@ import { beforeEach, describe, it, expect } from 'vitest';
 import {
   _resetDbForTests,
   clearAll,
+  clearOnboardingDismissedAt,
   deleteLease,
   getLease,
+  getOnboardingDismissedAt,
   listLeases,
   openLeaseDb,
   renameLease,
   replaceAllLeases,
   saveLease,
+  setOnboardingDismissedAt,
 } from './storage';
 import type { LeaseDocument } from '../parser/types';
 import type { Finding } from '../rules/types';
@@ -132,6 +135,32 @@ describe('storage', () => {
     await clearAll();
     expect(await listLeases()).toEqual([]);
     expect(id).toBeTruthy();
+  });
+
+  it('onboardingDismissedAt is null on a fresh DB', async () => {
+    expect(await getOnboardingDismissedAt()).toBeNull();
+  });
+
+  it('round-trips a numeric onboardingDismissedAt timestamp', async () => {
+    const ts = 1_700_000_000_000;
+    await setOnboardingDismissedAt(ts);
+    expect(await getOnboardingDismissedAt()).toBe(ts);
+  });
+
+  it('clearOnboardingDismissedAt resets to null', async () => {
+    await setOnboardingDismissedAt(Date.now());
+    await clearOnboardingDismissedAt();
+    expect(await getOnboardingDismissedAt()).toBeNull();
+  });
+
+  it('migration preserves leases when onboarding key is added later', async () => {
+    // Seed a lease, then simulate "later" by setting + reading the new key.
+    // This guards against a future v-bump dropping rows when adding the key.
+    const id = await saveLease({ name: 'Mig.pdf', doc: makeDoc(), findings: [] });
+    await setOnboardingDismissedAt(42);
+    const list = await listLeases();
+    expect(list.find((l) => l.id === id)).toBeDefined();
+    expect(await getOnboardingDismissedAt()).toBe(42);
   });
 
   it('stamps createdAt', async () => {

--- a/app/src/storage/storage.ts
+++ b/app/src/storage/storage.ts
@@ -8,6 +8,7 @@ const DB_VERSION = 3;
 const STORE = 'leases';
 const SETTINGS = 'settings';
 const STANDARD_KEY = 'standardLeaseId';
+const ONBOARDING_DISMISSED_KEY = 'onboardingDismissedAt';
 export const CLAUSE_TEMPLATES_STORE = 'clauseTemplates';
 
 export interface LeaseRecord {
@@ -178,6 +179,27 @@ export async function getStandardId(): Promise<string | undefined> {
 export async function clearStandardId(): Promise<void> {
   const db = await openLeaseDb();
   await db.delete(SETTINGS, STANDARD_KEY);
+}
+
+// Onboarding tour dismissal timestamp. Stored as a JSON-encoded number in
+// the existing SETTINGS store (value type: string), so no schema bump is
+// required. `null` (or unset) means "first run, show the tour".
+export async function getOnboardingDismissedAt(): Promise<number | null> {
+  const db = await openLeaseDb();
+  const raw = await db.get(SETTINGS, ONBOARDING_DISMISSED_KEY);
+  if (raw === undefined) return null;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export async function setOnboardingDismissedAt(ts: number): Promise<void> {
+  const db = await openLeaseDb();
+  await db.put(SETTINGS, String(ts), ONBOARDING_DISMISSED_KEY);
+}
+
+export async function clearOnboardingDismissedAt(): Promise<void> {
+  const db = await openLeaseDb();
+  await db.delete(SETTINGS, ONBOARDING_DISMISSED_KEY);
 }
 
 export function randomId(): string {

--- a/app/src/ui/OnboardingTour.stories.tsx
+++ b/app/src/ui/OnboardingTour.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { OnboardingTour } from './OnboardingTour';
+
+const meta = {
+  title: 'UI/OnboardingTour',
+  component: OnboardingTour,
+  args: {
+    onDismiss: () => {
+      // eslint-disable-next-line no-console
+      console.log('[stories] onboarding dismissed');
+    },
+  },
+} satisfies Meta<typeof OnboardingTour>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const FirstRun: Story = {
+  args: {
+    dismissedAt: null,
+  },
+};
+
+export const AlreadyDismissed: Story = {
+  args: {
+    dismissedAt: 1_700_000_000_000,
+  },
+};

--- a/app/src/ui/OnboardingTour.test.tsx
+++ b/app/src/ui/OnboardingTour.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { OnboardingTour } from './OnboardingTour';
+
+describe('OnboardingTour', () => {
+  it('renders the first step on initial mount when dismissedAt is null', () => {
+    render(<OnboardingTour dismissedAt={null} onDismiss={() => {}} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(/step 1 of 4/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /local-first by design/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('walks through all 4 steps via Next and back via Back', async () => {
+    const user = userEvent.setup();
+    render(<OnboardingTour dismissedAt={null} onDismiss={() => {}} />);
+    expect(screen.getByText(/step 1 of 4/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    expect(screen.getByText(/step 2 of 4/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    expect(screen.getByText(/step 3 of 4/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    expect(screen.getByText(/step 4 of 4/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /ocr is opt-in/i }),
+    ).toBeInTheDocument();
+    // Back returns to step 3.
+    await user.click(screen.getByRole('button', { name: /^back$/i }));
+    expect(screen.getByText(/step 3 of 4/i)).toBeInTheDocument();
+  });
+
+  it('clicking Got it on the last step calls onDismiss', async () => {
+    const user = userEvent.setup();
+    const onDismiss = vi.fn();
+    render(<OnboardingTour dismissedAt={null} onDismiss={onDismiss} />);
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    await user.click(screen.getByRole('button', { name: /finish onboarding tour/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when dismissedAt is already set (second mount)', () => {
+    const { container } = render(
+      <OnboardingTour dismissedAt={1_700_000_000_000} onDismiss={() => {}} />,
+    );
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('Escape key dismisses the tour', async () => {
+    const user = userEvent.setup();
+    const onDismiss = vi.fn();
+    render(<OnboardingTour dismissedAt={null} onDismiss={onDismiss} />);
+    await user.keyboard('{Escape}');
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('Skip button dismisses immediately from any step', async () => {
+    const user = userEvent.setup();
+    const onDismiss = vi.fn();
+    render(<OnboardingTour dismissedAt={null} onDismiss={onDismiss} />);
+    await user.click(screen.getByRole('button', { name: /skip onboarding tour/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('action buttons are focusable (tabIndex=0)', () => {
+    render(<OnboardingTour dismissedAt={null} onDismiss={() => {}} />);
+    for (const btn of screen.getAllByRole('button')) {
+      expect(btn.getAttribute('tabindex')).not.toBe('-1');
+    }
+    cleanup();
+  });
+});

--- a/app/src/ui/OnboardingTour.tsx
+++ b/app/src/ui/OnboardingTour.tsx
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useState } from 'react';
+
+interface OnboardingTourProps {
+  /** Existing dismissal timestamp; if non-null, the tour renders nothing. */
+  dismissedAt: number | null;
+  /** Called when the user dismisses the tour (Got it / Skip / Esc). */
+  onDismiss: () => void;
+}
+
+interface Step {
+  title: string;
+  body: string;
+}
+
+const STEPS: readonly Step[] = [
+  {
+    title: 'Local-first by design',
+    body:
+      'LeaseGuard runs entirely in your browser. PDFs are parsed on your device, ' +
+      'findings live in IndexedDB, and nothing leaves your machine.',
+  },
+  {
+    title: 'Upload a lease — or try a sample',
+    body:
+      'Drop a PDF onto the upload control to get started. No PDF handy? Click ' +
+      '"Try a sample lease" to walk through a fully synthetic example.',
+  },
+  {
+    title: 'Click through findings',
+    body:
+      'Each finding links back to the page and clause that triggered it. ' +
+      'Use the sidebar to filter by category or severity.',
+  },
+  {
+    title: 'OCR is opt-in',
+    body:
+      'If a lease is a scanned image, LeaseGuard can run OCR locally — but ' +
+      'only after you opt in. The OCR engine ships with the app; no upload happens.',
+  },
+];
+
+export function OnboardingTour({ dismissedAt, onDismiss }: OnboardingTourProps): JSX.Element | null {
+  const [stepIndex, setStepIndex] = useState(0);
+  const total = STEPS.length;
+  const isLast = stepIndex === total - 1;
+  const isFirst = stepIndex === 0;
+
+  const handleDismiss = useCallback((): void => {
+    onDismiss();
+  }, [onDismiss]);
+
+  useEffect(() => {
+    if (dismissedAt !== null) return;
+    function onKeyDown(e: KeyboardEvent): void {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleDismiss();
+      }
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [dismissedAt, handleDismiss]);
+
+  if (dismissedAt !== null) return null;
+
+  const step = STEPS[stepIndex];
+  if (!step) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="onboarding-tour-title"
+      className="onboarding-tour"
+      tabIndex={-1}
+    >
+      <div className="onboarding-tour__panel">
+        <h2 id="onboarding-tour-title">{step.title}</h2>
+        <p>{step.body}</p>
+        <p
+          className="onboarding-tour__progress"
+          aria-label={`step ${stepIndex + 1} of ${total}`}
+        >
+          Step {stepIndex + 1} of {total}
+        </p>
+        <div className="onboarding-tour__actions">
+          <button
+            type="button"
+            tabIndex={0}
+            onClick={handleDismiss}
+            aria-label="skip onboarding tour"
+          >
+            Skip
+          </button>
+          <button
+            type="button"
+            tabIndex={0}
+            onClick={() => setStepIndex((i) => Math.max(0, i - 1))}
+            disabled={isFirst}
+          >
+            Back
+          </button>
+          {isLast ? (
+            <button
+              type="button"
+              tabIndex={0}
+              onClick={handleDismiss}
+              aria-label="finish onboarding tour"
+            >
+              Got it
+            </button>
+          ) : (
+            <button
+              type="button"
+              tabIndex={0}
+              onClick={() => setStepIndex((i) => Math.min(total - 1, i + 1))}
+            >
+              Next
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 4-step onboarding modal in `src/ui/OnboardingTour.tsx`: (1) local-first contract, (2) upload or sample lease, (3) findings interaction, (4) OCR opt-in disclosure. Plain TSX, no animations. Dismiss via Got it / Skip / Esc.
- Persistence via the existing leaseguard SETTINGS store (`getOnboardingDismissedAt` / `setOnboardingDismissedAt`). No DB version bump — value is JSON-encoded into the existing string-keyed store. Part E owns the v4 bump.
- App.tsx mounts the tour behind a three-state guard (`undefined` = loading from IDB, `null` = first run, `number` = dismissed) so first-run users don't see a flash of the modal followed by dismissal.
- App.panels.test.tsx wipe seeds `onboardingDismissedAt = Date.now()` so existing panel tests don't interact with the tour.

## Test plan
- [x] `OnboardingTour.test.tsx` covers 7 cases: initial render, all 4 steps reachable via Next/Back, dismiss writes via callback, second mount with `dismissedAt` set returns null, Esc dismisses, Skip dismisses, action buttons are focusable (`tabindex` not `-1`).
- [x] `storage.test.ts` adds 4 cases: null on fresh DB, round-trip set+get, clear resets to null, lease rows preserved when the new key is written.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean (0 warnings).
- [x] `npm test -- --run` — 813 tests pass (was 802 + 11 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)