### PR TITLE
wave7-E: Secondary IDB index on (findingCount, rulePackVersion)

### DIFF
--- a/app/src/storage/listLeasesFiltered.test.ts
+++ b/app/src/storage/listLeasesFiltered.test.ts
@@ -1,0 +1,121 @@
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { _resetDbForTests, openLeaseDb, saveLease } from './storage';
+import { listLeasesFiltered } from './listLeasesFiltered';
+import type { LeaseDocument } from '../parser/types';
+import type { Finding } from '../rules/types';
+
+function makeDoc(): LeaseDocument {
+  return {
+    pages: [{ pageNumber: 1, width: 612, height: 792, items: [] }],
+    paragraphs: [{ text: 'Hello', page: 1 }],
+    sections: [],
+    raw: 'Hello',
+  };
+}
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    ruleId: 'auto-renewal',
+    severity: 'medium',
+    category: 'termination',
+    title: 'Auto-renewal',
+    explanation: 'Test',
+    citation: null,
+    page: 1,
+    paragraphIndex: 0,
+    snippet: 'snippet',
+    span: { start: 0, end: 7 },
+    confidence: 0.9,
+    negated: false,
+    rulePackVersion: '1.0.0',
+    ...overrides,
+  };
+}
+
+async function wipe(): Promise<void> {
+  const db = await openLeaseDb();
+  db.close();
+  _resetDbForTests();
+  await new Promise<void>((resolve, reject) => {
+    const req = indexedDB.deleteDatabase('leaseguard');
+    req.onsuccess = (): void => resolve();
+    req.onerror = (): void => reject(req.error);
+    req.onblocked = (): void => resolve();
+  });
+}
+
+describe('listLeasesFiltered', () => {
+  beforeEach(async () => {
+    await wipe();
+  });
+
+  // saveLease derives rulePackVersion from findings[0]; a zero-finding
+  // record falls back to 'unknown'. So to pin pack version on a clean
+  // record we still pass a finding (and assert finding-count separately).
+  async function seed(): Promise<void> {
+    // Clean v1: one finding, but findingCount stamped via input.findings.length.
+    // To get a TRUE 0-finding-on-1.0.0 record we write directly to the store.
+    await saveLease({
+      name: 'Risky-1.0.0.pdf',
+      doc: makeDoc(),
+      findings: [makeFinding(), makeFinding({ ruleId: 'late-fee' })],
+    });
+    await saveLease({
+      name: 'Other-2.0.0.pdf',
+      doc: makeDoc(),
+      findings: [makeFinding({ rulePackVersion: '2.0.0' })],
+    });
+    // Direct put for a (findingCount: 0, rulePackVersion: '1.0.0') row.
+    const db = await openLeaseDb();
+    await db.put('leases', {
+      id: 'clean-v1',
+      name: 'Clean-1.0.0.pdf',
+      createdAt: 5000,
+      updatedAt: 5000,
+      rulePackVersion: '1.0.0',
+      pageCount: 1,
+      findingCount: 0,
+      doc: makeDoc(),
+      findings: [],
+    });
+  }
+
+  it('returns the full set when no filter is provided', async () => {
+    await seed();
+    const all = await listLeasesFiltered({});
+    expect(all.length).toBe(3);
+  });
+
+  it('filters by both findingCount and rulePackVersion via the compound index', async () => {
+    await seed();
+    const cleanV1 = await listLeasesFiltered({ findingCount: 0, rulePackVersion: '1.0.0' });
+    expect(cleanV1.map((m) => m.name)).toEqual(['Clean-1.0.0.pdf']);
+    const first = cleanV1[0];
+    expect(first).toBeDefined();
+    expect(first as object).not.toHaveProperty('doc');
+    expect(first as object).not.toHaveProperty('findings');
+  });
+
+  it('filters by findingCount alone', async () => {
+    await seed();
+    const zero = await listLeasesFiltered({ findingCount: 0 });
+    expect(zero.map((m) => m.name)).toEqual(['Clean-1.0.0.pdf']);
+  });
+
+  it('filters by rulePackVersion alone', async () => {
+    await seed();
+    const v1 = await listLeasesFiltered({ rulePackVersion: '1.0.0' });
+    expect(v1.length).toBe(2);
+    expect(v1.every((l) => l.rulePackVersion === '1.0.0')).toBe(true);
+  });
+
+  it('returns metadata only (no doc/findings payload)', async () => {
+    await seed();
+    const list = await listLeasesFiltered({ findingCount: 0, rulePackVersion: '1.0.0' });
+    for (const meta of list) {
+      expect(meta as object).not.toHaveProperty('doc');
+      expect(meta as object).not.toHaveProperty('findings');
+    }
+  });
+});

--- a/app/src/storage/listLeasesFiltered.ts
+++ b/app/src/storage/listLeasesFiltered.ts
@@ -1,0 +1,52 @@
+import {
+  BY_FINDING_AND_PACK_INDEX,
+  openLeaseDb,
+  type LeaseMetadata,
+  type LeaseRecord,
+} from './storage';
+
+export interface ListLeasesFilter {
+  /** Match an exact findingCount (e.g. 0 = "clean leases only"). */
+  findingCount?: number;
+  /** Match an exact rule-pack version string. */
+  rulePackVersion?: string;
+}
+
+/**
+ * Typed query helper backed by the v4 compound index `[findingCount,
+ * rulePackVersion]`. Returns metadata only — `doc` and `findings`
+ * are stripped so callers (e.g. the portfolio panel) don't pay the
+ * cost of pulling lease bodies into memory just to render a row.
+ *
+ * - Both keys provided → IDBKeyRange.only on the compound key.
+ * - Only `findingCount` → bounded range over [n, *].
+ * - Only `rulePackVersion` → falls back to a getAll + filter, since
+ *   compound indexes can't seek by the second key without the first.
+ * - Neither → full getAll (matches `listLeases` semantics).
+ */
+export async function listLeasesFiltered(
+  filter: ListLeasesFilter,
+): Promise<LeaseMetadata[]> {
+  const db = await openLeaseDb();
+  const { findingCount, rulePackVersion } = filter;
+
+  let records: LeaseRecord[];
+  if (findingCount !== undefined && rulePackVersion !== undefined) {
+    const idx = db.transaction('leases').store.index(BY_FINDING_AND_PACK_INDEX);
+    records = await idx.getAll(IDBKeyRange.only([findingCount, rulePackVersion]));
+  } else if (findingCount !== undefined) {
+    const idx = db.transaction('leases').store.index(BY_FINDING_AND_PACK_INDEX);
+    records = await idx.getAll(
+      IDBKeyRange.bound([findingCount, ''], [findingCount, '￿']),
+    );
+  } else if (rulePackVersion !== undefined) {
+    const all = await db.getAll('leases');
+    records = all.filter((r) => r.rulePackVersion === rulePackVersion);
+  } else {
+    records = await db.getAll('leases');
+  }
+
+  return records
+    .map(({ doc: _doc, findings: _findings, ...meta }) => meta)
+    .sort((a, b) => b.createdAt - a.createdAt);
+}

--- a/app/src/storage/storage.test.ts
+++ b/app/src/storage/storage.test.ts
@@ -142,4 +142,77 @@ describe('storage', () => {
     expect(loaded?.createdAt).toBeGreaterThanOrEqual(before);
     expect(loaded?.createdAt).toBeLessThanOrEqual(after);
   });
+
+  it('migrates a v3 database to v4 without dropping rows and adds the by-finding-and-pack index', async () => {
+    // Seed a v3 database directly via raw indexedDB.open so we can prove
+    // the v4 upgrade path runs against a populated v3 schema.
+    await new Promise<void>((resolve, reject) => {
+      const req = indexedDB.open('leaseguard', 3);
+      req.onupgradeneeded = (): void => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains('leases')) {
+          const store = db.createObjectStore('leases', { keyPath: 'id' });
+          store.createIndex('by-createdAt', 'createdAt');
+        }
+        if (!db.objectStoreNames.contains('settings')) {
+          db.createObjectStore('settings');
+        }
+        if (!db.objectStoreNames.contains('clauseTemplates')) {
+          db.createObjectStore('clauseTemplates', { keyPath: 'id' });
+        }
+      };
+      req.onsuccess = (): void => {
+        const db = req.result;
+        const tx = db.transaction('leases', 'readwrite');
+        tx.objectStore('leases').put({
+          id: 'lease-1',
+          name: 'Clean.pdf',
+          createdAt: 1000,
+          updatedAt: 1000,
+          rulePackVersion: '1.0.0',
+          pageCount: 1,
+          findingCount: 0,
+          doc: makeDoc(),
+          findings: [],
+        });
+        tx.objectStore('leases').put({
+          id: 'lease-2',
+          name: 'Risky.pdf',
+          createdAt: 2000,
+          updatedAt: 2000,
+          rulePackVersion: '1.0.0',
+          pageCount: 2,
+          findingCount: 3,
+          doc: makeDoc(),
+          findings: [makeFinding()],
+        });
+        tx.oncomplete = (): void => {
+          db.close();
+          resolve();
+        };
+        tx.onerror = (): void => reject(tx.error);
+      };
+      req.onerror = (): void => reject(req.error);
+    });
+
+    // Open via the v4 path. _resetDbForTests ensures we re-open through the
+    // module's upgrade ladder rather than reusing a cached v3 handle.
+    _resetDbForTests();
+    const db = await openLeaseDb();
+
+    expect(db.version).toBe(4);
+    // Existing rows preserved.
+    const survivors = await db.getAll('leases');
+    expect(survivors).toHaveLength(2);
+    expect(survivors.map((r) => r.id).sort()).toEqual(['lease-1', 'lease-2']);
+
+    // New compound index is queryable.
+    const tx = db.transaction('leases', 'readonly');
+    const idx = tx.objectStore('leases').index('by-finding-and-pack');
+    const cleanMatches = await idx.getAll(IDBKeyRange.only([0, '1.0.0']));
+    expect(cleanMatches.map((r) => r.id)).toEqual(['lease-1']);
+    const riskyMatches = await idx.getAll(IDBKeyRange.only([3, '1.0.0']));
+    expect(riskyMatches.map((r) => r.id)).toEqual(['lease-2']);
+    await tx.done;
+  });
 });

--- a/app/src/storage/storage.ts
+++ b/app/src/storage/storage.ts
@@ -4,11 +4,12 @@ import type { Finding } from '../rules/types';
 import type { ClauseTemplate } from '../templates/types';
 
 const DB_NAME = 'leaseguard';
-const DB_VERSION = 3;
+const DB_VERSION = 4;
 const STORE = 'leases';
 const SETTINGS = 'settings';
 const STANDARD_KEY = 'standardLeaseId';
 export const CLAUSE_TEMPLATES_STORE = 'clauseTemplates';
+export const BY_FINDING_AND_PACK_INDEX = 'by-finding-and-pack';
 
 export interface LeaseRecord {
   id: string;
@@ -36,7 +37,10 @@ interface LeaseGuardSchema extends DBSchema {
   [STORE]: {
     key: string;
     value: LeaseRecord;
-    indexes: { 'by-createdAt': number };
+    indexes: {
+      'by-createdAt': number;
+      'by-finding-and-pack': [number, string];
+    };
   };
   [SETTINGS]: {
     key: string;
@@ -57,7 +61,7 @@ export function _resetDbForTests(): void {
 export async function openLeaseDb(): Promise<IDBPDatabase<LeaseGuardSchema>> {
   if (!dbPromise) {
     dbPromise = openDB<LeaseGuardSchema>(DB_NAME, DB_VERSION, {
-      upgrade(db, oldVersion, _newVersion, _tx) {
+      upgrade(db, oldVersion, _newVersion, tx) {
         // v0 → v1: leases store (keyPath: id, by-createdAt index).
         if (oldVersion < 1) {
           if (!db.objectStoreNames.contains(STORE)) {
@@ -75,6 +79,19 @@ export async function openLeaseDb(): Promise<IDBPDatabase<LeaseGuardSchema>> {
         if (oldVersion < 3) {
           if (!db.objectStoreNames.contains(CLAUSE_TEMPLATES_STORE)) {
             db.createObjectStore(CLAUSE_TEMPLATES_STORE, { keyPath: 'id' });
+          }
+        }
+        // v3 → v4: compound index over [findingCount, rulePackVersion] so
+        // the portfolio panel can scan the "clean leases on the latest pack"
+        // partition without a full-store getAll. Uses fields already on
+        // every LeaseRecord; existing rows are re-indexed automatically.
+        if (oldVersion < 4) {
+          const store = tx.objectStore(STORE);
+          if (!store.indexNames.contains(BY_FINDING_AND_PACK_INDEX)) {
+            store.createIndex(BY_FINDING_AND_PACK_INDEX, [
+              'findingCount',
+              'rulePackVersion',
+            ]);
           }
         }
       },

--- a/app/src/ui/PortfolioPanel.tsx
+++ b/app/src/ui/PortfolioPanel.tsx
@@ -1,10 +1,22 @@
+import { useEffect, useState } from 'react';
 import type { LeaseMetadata } from '../storage/storage';
+import {
+  listLeasesFiltered,
+  type ListLeasesFilter,
+} from '../storage/listLeasesFiltered';
 import type { Finding, Severity } from '../rules/types';
 
 export interface PortfolioPanelProps {
   leases: LeaseMetadata[];
   findingsByLease: Map<string, Finding[]>;
   onOpenLease: (id: string) => void;
+  /**
+   * Optional server-side filter. When set, the panel queries the
+   * `by-finding-and-pack` IDB index via `listLeasesFiltered` and
+   * renders the resulting subset instead of `leases`. Unset → uses
+   * `leases` as-is (caller-supplied).
+   */
+  filter?: ListLeasesFilter;
 }
 
 interface RuleColumn {
@@ -26,8 +38,26 @@ export function PortfolioPanel({
   leases,
   findingsByLease,
   onOpenLease,
+  filter,
 }: PortfolioPanelProps): JSX.Element {
-  if (leases.length === 0) {
+  const [filtered, setFiltered] = useState<LeaseMetadata[] | null>(null);
+
+  useEffect(() => {
+    if (!filter) {
+      setFiltered(null);
+      return;
+    }
+    let cancelled = false;
+    void listLeasesFiltered(filter).then((rows) => {
+      if (!cancelled) setFiltered(rows);
+    });
+    return (): void => {
+      cancelled = true;
+    };
+  }, [filter]);
+
+  const visible = filter && filtered ? filtered : leases;
+  if (visible.length === 0) {
     return (
       <section aria-label="portfolio">
         <h2>Portfolio</h2>
@@ -36,7 +66,7 @@ export function PortfolioPanel({
     );
   }
 
-  const columns = rankRuleColumns(leases, findingsByLease);
+  const columns = rankRuleColumns(visible, findingsByLease);
 
   return (
     <section aria-label="portfolio">
@@ -56,7 +86,7 @@ export function PortfolioPanel({
             </tr>
           </thead>
           <tbody>
-            {leases.map((lease) => {
+            {visible.map((lease) => {
               const findings = findingsByLease.get(lease.id) ?? [];
               const bestBySeverity = bestSeverityByRule(findings);
               return (


### PR DESCRIPTION
## Summary

- Bumps the `leaseguard` IndexedDB to v4, adding a compound index `by-finding-and-pack` on `[findingCount, rulePackVersion]`. Index is a pure add — existing rows are preserved and re-indexed automatically by IDB.
- New `listLeasesFiltered({ findingCount?, rulePackVersion? })` helper backed by the new index. Returns metadata only (strips `doc`/`findings`) so callers don't pay the cost of pulling lease bodies into memory.
- `PortfolioPanel` gains an optional `filter` prop. When set, the panel queries the index directly via the helper; when unset, behaviour is identical to today (existing App.tsx wire-up preserved → no UX change).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (0 warnings)
- [x] `npm test` — 99 files / 808 tests green
- [x] New migration test seeds a v3 DB, opens via the v4 path, asserts (a) row preservation and (b) the new index returns the expected partition
- [x] `listLeasesFiltered` covers: no filter, both keys, findingCount-only, rulePackVersion-only, metadata-only return shape
- [x] `App.panels.test.tsx` (which exercises the IDB wipe-and-reset sequence across all nine DBs) passes unchanged — the v4 schema does not affect `_resetDbForTests` semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)