### PR TITLE
fix(lhci): drop maskable-icon + themed-omnibox audits (LH v12)

### DIFF
--- a/app/lighthouserc.json
+++ b/app/lighthouserc.json
@@ -13,9 +13,7 @@
         "categories:accessibility": ["error", { "minScore": 0.95 }],
         "categories:best-practices": ["error", { "minScore": 0.9 }],
         "installable-manifest": ["error", { "minScore": 1 }],
-        "apple-touch-icon": ["error", { "minScore": 1 }],
-        "maskable-icon": ["error", { "minScore": 1 }],
-        "themed-omnibox": ["error", { "minScore": 1 }]
+        "apple-touch-icon": ["error", { "minScore": 1 }]
       }
     },
     "upload": {


### PR DESCRIPTION
## Summary
- Lighthouse v12 removed the `maskable-icon` and `themed-omnibox` audits; the rc was asserting them and CI failed with "is not a known audit".
- These were re-introduced when PR #14 merged main into wave8-key-rotation with stale conflict resolution that picked the older config.
- Keeps `installable-manifest` and `apple-touch-icon` (still present in v12).

## Test plan
- [ ] Lighthouse CI green