### PR TITLE
docs(wave8): mark Phase 17 done + add REPRODUCIBILITY.md

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -17,11 +17,12 @@ enough to land in one PR.
 | Axis | Value | Gate |
 |------|-------|------|
 | Source | 117 non-test files (~13.0k LOC) + 91 test files (~12.5k LOC) | `find app/src -name '*.ts' -o -name '*.tsx'` |
-| Tests | ~803 passing across 91 files | `npm test` |
+| Tests | ~856 passing across 110 files (app) + 3 in `cli/` | `npm test` |
 | Coverage | 97.02% stmt · 88.06% branch · 93.21% func · 97.02% line | `npm run test:coverage` (thresholds 90/85/90/90) |
 | Bundles | app shell ~290 KiB (`index-*.js` + split) · pdf.js api 400 KiB · pdf.worker 1.3 MiB · leaseWorker ~8 KiB · tesseract runtime 8 MiB (opt-in) | `npm run check:budget` |
-| IndexedDB | main `leaseguard` v3 (`leases` + `settings` + `clauseTemplates`); 8 side dbs: `leaseguard-packs` v3 (adds `signatures` store), `leaseguard-annotations` v1, `leaseguard-counters` v1, `leaseguard-signing` v1, `leaseguard-audit` v1, `leaseguard-redlines` v1, `leaseguard-versions` v1, `leaseguard-bulk-dedup` v1 | migrations tested |
-| App.tsx | ~1540 lines (panels + handlers inline); see "Cross-cutting tech debt" for the decomposition ticket | — |
+| IndexedDB | main `leaseguard` v3 (`leases` + `settings` + `clauseTemplates`); 8 side dbs: `leaseguard-packs` v3 (adds `signatures` store), `leaseguard-annotations` v1, `leaseguard-counters` v1, `leaseguard-signing` **v2** (multi-key store, post Wave 8-D), `leaseguard-audit` v1 (entries gain optional `signedByKeyId`), `leaseguard-redlines` v1, `leaseguard-versions` v1, `leaseguard-bulk-dedup` v1 | migrations tested |
+| App.tsx | decomposed into per-panel containers around `usePipeline` (Wave 7-D) | — |
+| CLI | `leaseguard-verify` (Node, no browser, no network) — `cli/` workspace, 3 tests | `cd cli && npm test` |
 | Build | Vite 5 + vite-plugin-pwa → `dist/` with `sw.js`; Web Worker chunk for parse+analyze | `npm run build` |
 | Lint / types | `tsc -b --noEmit` + ESLint clean (0 warnings) | `npm run typecheck && npm run lint` |
 
@@ -388,23 +389,23 @@ onboarding tour, commercial golden) and clear the two largest cross-cutting
 tech-debt rocks (App.tsx decomposition + reanalyze-staleness guard, secondary
 IDB index). After Wave 7 lands, no ticket older than Phase 13 should be open.
 
-- [ ] Wave 7 Part A — Lighthouse + Tauri CI gates (`wave7-ci-gates`)
-- [ ] Wave 7 Part B — First-run onboarding tour (`wave7-onboarding`)
-- [ ] Wave 7 Part C — Commercial golden fixture (`wave7-golden-commercial`)
-- [ ] Wave 7 Part D — App.tsx decomposition + reanalyze-staleness guard (`wave7-appHooks`)
-- [ ] Wave 7 Part E — Secondary IndexedDB index (`wave7-idb-index`)
+- [x] Wave 7 Part A — Lighthouse + Tauri CI gates (`wave7-ci-gates`, PR #7)
+- [x] Wave 7 Part B — First-run onboarding tour (`wave7-onboarding`, PR #8)
+- [x] Wave 7 Part C — Commercial golden fixture (`wave7-golden-commercial`, PR #10)
+- [x] Wave 7 Part D — App.tsx decomposition + reanalyze-staleness guard (`wave7-appHooks`, PR #6)
+- [x] Wave 7 Part E — Secondary IndexedDB index (`wave7-idb-index`, PR #9)
 
 ## Wave 8 — Trust infrastructure (Phase 17)
 
 Plan: [`plans/wave8-trust-infra.md`](./plans/wave8-trust-infra.md). Four
 parallel-safe parts that turn the existing trust primitives (signed packs,
 signed reports, hash-chained audit log, replay bundles) into an
-externally-auditable ecosystem. Pre-flight requires Wave 7 to be fully merged.
+externally-auditable ecosystem.
 
-- [ ] Wave 8 Part A — Offline pack marketplace (`wave8-marketplace`)
-- [ ] Wave 8 Part B — Diff-vs-verified warnings (`wave8-deviation-warnings`)
-- [ ] Wave 8 Part C — Reproducibility CLI (`wave8-cli`)
-- [ ] Wave 8 Part D — Key-rotation workflow (`wave8-key-rotation`)
+- [x] Wave 8 Part A — Offline pack marketplace (`wave8-marketplace`, PR #11)
+- [x] Wave 8 Part B — Diff-vs-verified warnings (`wave8-deviation-warnings`, PR #12)
+- [x] Wave 8 Part C — Reproducibility CLI (`wave8-cli`, PR #12)
+- [x] Wave 8 Part D — Key-rotation workflow (`wave8-key-rotation`, PR #12)
 
 ## Cross-cutting tech debt
 

--- a/docs/REPRODUCIBILITY.md
+++ b/docs/REPRODUCIBILITY.md
@@ -1,0 +1,83 @@
+# Reproducibility — verifying a LeaseGuard report end-to-end
+
+LeaseGuard's analysis is deterministic. Given the same lease bytes and the
+same rule pack, the same set of findings comes out — and a third party can
+verify that without running the browser app. This document is the
+auditor's checklist.
+
+## What you need
+
+- `report.signed.json` — the exported, Ed25519-signed analysis envelope
+  (Phase 12, "Export signed JSON report").
+- `bundle.replay.zip` — the replay bundle the user exported alongside the
+  report. Contains `lease.pdf`, the rule pack at the time of analysis,
+  and the expected findings JSON (Phase 12, "Replay bundle export").
+- The signer's public key — the user can paste it from
+  `SigningKeyPanel`'s "Export public key" button. Wave 8-D added a key
+  history; pre-rotation reports verify against the matching retired key,
+  not the current active one (`signedByKeyId` on each audit entry tells
+  you which).
+- Node ≥ 20 and the `cli/` workspace from this repo.
+
+## The verification
+
+```sh
+cd cli
+npm install
+npx tsx src/index.ts /path/to/bundle.replay.zip
+```
+
+Exit code semantics:
+
+| Exit | Meaning |
+| ---- | ------- |
+| 0    | Replay reproduced byte-identical findings. The report is faithful. |
+| 1    | Mismatch. CLI prints the diff between expected and actual JSON. |
+
+The CLI does the same work the in-app `reproducibility.test.ts` does, but
+out of the browser:
+
+1. Extract the bundle (pure node `storeZipReader`, CRC-checked).
+2. Re-parse `lease.pdf` via `pdfjs-dist/legacy/build/pdf.mjs` — node
+   build, no worker, no network.
+3. Re-run `analyze(LeaseDocument, RulePack)` from `app/src/rules/`.
+4. Canonicalize both findings sets and compare.
+
+## Verifying the signed report itself
+
+The CLI verifies *reproduction*. To verify the *signature* on
+`report.signed.json`, use any Ed25519-aware tool — the JSON envelope's
+`signature` field is base64; the canonical payload is everything except
+that field, serialized via the same canonical-JSON helper used in
+`app/src/storage/exportReport.ts`. A 30-line node script using
+`crypto.verify('ed25519', ...)` is sufficient.
+
+For audit-log chains, `app/src/audit/auditLog.ts` exports
+`verifyAuditChain` which is pure and reusable from node. Each entry's
+`signedByKeyId` (defaulting to `'k0'`) tells you which historical key
+should verify it; the chain itself only covers `{seq, timestamp, kind,
+payload, prevHash}`, so adding the key-id field is back-compat with
+pre–Wave 8 entries.
+
+## The privacy contract this preserves
+
+- The CLI is filesystem-only. No network egress at any step.
+- The replay bundle contains exactly what the user chose to share — no
+  telemetry, no IDB dump, no key material.
+- Rotated signing keys never leave the user's device; only public keys
+  are exported. Verification of historical reports works against the
+  retired public key.
+
+## What the marketplace adds
+
+Wave 8-A ships build-time-curated `.lgpack.json` packs under
+`app/public/packs/curated/`, each Ed25519-signed by a
+`build-curated-packs.mjs`-managed author key. The marketplace UI shows
+the verified-author badge that Phase 10 built. Curated-pack signatures
+are reproducible: `npm run build:curated-packs` regenerates them with
+byte-identical output.
+
+If a user edits a curated rule, Wave 8-B's `packBaseline` resolver
+flags the deviation in `FindingsPanel` and on the signed export
+(`deviations[]` field). Auditors get a machine-readable signal that the
+rule body diverges from the verified baseline.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -67,15 +67,16 @@ Each phase links to its backlog section.
 | 3 | UI | Done |
 | 4 | Local Storage | Done |
 | 5 | Compare & OCR | Done |
-| 6 | Polish & Distribution | Partial — Lighthouse a11y/PWA CI, Tauri CI, onboarding tour open |
+| 6 | Polish & Distribution | Done |
 | 7 | Observability & hygiene | Done |
-| 8 | Structured lease understanding | Substantially done — commercial golden fixture open |
+| 8 | Structured lease understanding | Done |
 | 9 | Negotiation support | Done |
 | 10 | Rule ecosystem | Done |
 | 11 | Workflow & integrations | Done |
 | 12 | Trust & verification | Done |
-| 13 | Performance & scale | Substantially done — secondary IDB index open |
+| 13 | Performance & scale | Done |
 | 14 | Content depth | Substantially done — static glossary JSON, i18n scaffold, OCR language picker open |
+| 17 | Trust infrastructure | Done — Wave 8 shipped marketplace, deviation warnings, repro CLI, key rotation |
 
 "Substantially done" means the phase's primary surface is built and wired;
 the open items are scoped follow-ups rather than net-new work.
@@ -87,21 +88,6 @@ the open items are scoped follow-ups rather than net-new work.
 The roadmap below is organized by where the product is heading, not by
 phase number. Each bullet points to the backlog section that tracks the
 tickets.
-
-### Ship-readiness — getting 1.0 out the door
-
-- Lighthouse CI gates: a11y ≥95 and PWA ≥95 on every PR. (Phase 6)
-- Tauri desktop build + CI artifact. (Phase 6)
-- First-run onboarding tour that explains the local-first contract and
-  the OCR opt-in. (Phase 6)
-- Commercial-lease golden fixture that exercises tables + definitions +
-  cross-refs simultaneously. (Phase 8)
-
-### Perceived performance — stay snappy as leases grow
-
-- Secondary IndexedDB index on `findingCount` + `rulePackVersion` so
-  `listLeases` filters cheaply without hydrating every `LeaseRecord`.
-  (Phase 13)
 
 ### Content depth — more useful without phoning home
 
@@ -177,28 +163,30 @@ Phase 16 makes it analytical.
   override model so a tenant can say "treat this rule as High across
   my whole portfolio" without re-declaring it per lease.
 
-### Phase 17 — Trust infrastructure
+### Phase 17 — Trust infrastructure (shipped, Wave 8)
 
-Phase 10 shipped signed packs. Phase 12 shipped signed reports. Phase
-17 turns those primitives into an ecosystem a third party can audit.
+Phase 10 shipped signed packs. Phase 12 shipped signed reports. Wave 8
+turned those primitives into an ecosystem a third party can audit. See
+[`REPRODUCIBILITY.md`](./REPRODUCIBILITY.md) for the auditor walk-through.
 
-- **Offline pack marketplace** — a curated, build-time-bundled static
-  directory of packs with publisher keys, install-with-one-click,
-  verified-author badges from Phase 10, and a visible pack-diff view
-  before adoption.
-- **Diff-vs-verified warnings** — if a user edits a signed pack (or
-  imports an unsigned one derived from a signed one), show an explicit
-  "this deviates from the verified baseline" warning in the
-  findings and report views.
-- **Reproducibility CLI** — package the deterministic `analyze` +
-  replay-bundle format as a Node CLI (no browser, no network) so
-  auditors can verify `{inputHash, rulePackVersion, findings}` from
-  the command line. Shares its test fixtures with the in-app
-  `reproducibility.test.ts`.
-- **Key-rotation workflow** — UX for rotating a user's signing key
-  without invalidating historical audit-log entries (hash chain
-  stays intact; new entries signed with the new key; old entries
-  remain independently verifiable).
+- **Offline pack marketplace** — curated `.lgpack.json` files under
+  `app/public/packs/curated/`, each Ed25519-signed at build time;
+  in-app `MarketplacePanel` lists them with verified badge + diff
+  preview + one-click install.
+- **Diff-vs-verified warnings** — `packBaseline.ts` resolves each
+  active rule against its signed baseline; deviations carry through
+  `Finding.deviation` to the badge in `FindingsPanel` and the
+  `deviations[]` field in the signed export envelope.
+- **Reproducibility CLI** — `cli/` workspace ships `leaseguard-verify`,
+  a node-only command that extracts a replay bundle, re-runs
+  `parseLease` + `analyze`, and exits 0 on byte-identical match (1 on
+  mismatch with a diff). Shares fixtures with the in-app reproducibility
+  test.
+- **Key-rotation workflow** — `signingKeys.ts` v1→v2 migration
+  introduces a multi-key store with `rotateKey` / `listKeys` /
+  `getActiveKey`; audit entries record `signedByKeyId` and the hash
+  chain stays intact across rotations (retired keys remain
+  verification-only).
 
 ---
 


### PR DESCRIPTION
## Summary
- Wave 8 done-definition follow-ups: ROADMAP table now lists Phase 17 as Done (and ticks Phase 6/8/13 which Wave 7 closed); BACKLOG reflects Wave 7 + Wave 8 PR landings with refreshed footprint.
- New `docs/REPRODUCIBILITY.md` — one-page auditor walk-through for the `leaseguard-verify` CLI, signed-report verification, and audit-chain semantics across key rotation.

## Test plan
- [x] No code changes — docs only
- [ ] CI green