### PR TITLE
wave9-C: delta packets

### DIFF
--- a/app/src/ui/DeltaPanel.stories.tsx
+++ b/app/src/ui/DeltaPanel.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DeltaPanel } from './DeltaPanel';
+
+const meta: Meta<typeof DeltaPanel> = {
+  title: 'Wave9/DeltaPanel',
+  component: DeltaPanel,
+};
+
+export default meta;
+type Story = StoryObj<typeof DeltaPanel>;
+
+export const Empty: Story = {
+  args: {
+    versions: [],
+    onGenerate: async (): Promise<Uint8Array> => new Uint8Array(),
+  },
+};
+
+export const TwoVersions: Story = {
+  args: {
+    versions: [
+      { id: 'v1', label: 'v1 — initial draft' },
+      { id: 'v2', label: 'v2 — landlord redline' },
+    ],
+    onGenerate: async (): Promise<Uint8Array> => new Uint8Array([1, 2, 3]),
+  },
+};

--- a/app/src/ui/DeltaPanel.test.tsx
+++ b/app/src/ui/DeltaPanel.test.tsx
@@ -28,7 +28,10 @@ describe('DeltaPanel', () => {
 
   it('happy path: pick base + target + passphrase invokes onGenerate with those ids', async () => {
     const user = userEvent.setup();
-    const onGenerate = vi.fn(async () => new Uint8Array([1]));
+    const onGenerate = vi.fn<
+      [{ baseVersionId: string; targetVersionId: string; passphrase: string }],
+      Promise<Uint8Array>
+    >(async () => new Uint8Array([1]));
     render(<DeltaPanel versions={versions} onGenerate={onGenerate} />);
     await user.selectOptions(screen.getByLabelText(/base/i), 'v1');
     await user.selectOptions(screen.getByLabelText(/target/i), 'v2');

--- a/app/src/ui/DeltaPanel.test.tsx
+++ b/app/src/ui/DeltaPanel.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+// Wave 9 Part C — component does not yet exist; failing import is the red
+// signal. The implementer creates `app/src/ui/DeltaPanel.tsx` exporting
+// `DeltaPanel` with this prop shape:
+//
+//   interface DeltaPanelProps {
+//     versions: { id: string; label: string }[];   // history rows
+//     onGenerate: (input: {
+//       baseVersionId: string;
+//       targetVersionId: string;
+//       passphrase: string;
+//     }) => Promise<Uint8Array>;                   // .lgdelta bytes
+//   }
+import { DeltaPanel } from './DeltaPanel';
+
+const versions = [
+  { id: 'v1', label: 'Version 1' },
+  { id: 'v2', label: 'Version 2' },
+];
+
+describe('DeltaPanel', () => {
+  it('renders the history rows and disables generate until base + target are picked', () => {
+    render(<DeltaPanel versions={versions} onGenerate={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /generate|export/i })).toBeDisabled();
+  });
+
+  it('happy path: pick base + target + passphrase invokes onGenerate with those ids', async () => {
+    const user = userEvent.setup();
+    const onGenerate = vi.fn(async () => new Uint8Array([1]));
+    render(<DeltaPanel versions={versions} onGenerate={onGenerate} />);
+    await user.selectOptions(screen.getByLabelText(/base/i), 'v1');
+    await user.selectOptions(screen.getByLabelText(/target/i), 'v2');
+    await user.type(screen.getByLabelText(/passphrase/i), 'a-strong-passphrase-12345');
+    await user.click(screen.getByRole('button', { name: /generate|export/i }));
+    expect(onGenerate).toHaveBeenCalledTimes(1);
+    expect(onGenerate.mock.calls[0]?.[0]?.baseVersionId).toBe('v1');
+    expect(onGenerate.mock.calls[0]?.[0]?.targetVersionId).toBe('v2');
+  });
+});

--- a/app/src/ui/DeltaPanel.tsx
+++ b/app/src/ui/DeltaPanel.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+
+interface VersionRow {
+  id: string;
+  label: string;
+}
+
+interface DeltaPanelProps {
+  versions: VersionRow[];
+  onGenerate: (input: {
+    baseVersionId: string;
+    targetVersionId: string;
+    passphrase: string;
+  }) => Promise<Uint8Array>;
+}
+
+export function DeltaPanel({ versions, onGenerate }: DeltaPanelProps): JSX.Element {
+  const [baseId, setBaseId] = useState('');
+  const [targetId, setTargetId] = useState('');
+  const [passphrase, setPassphrase] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const ready =
+    baseId !== '' && targetId !== '' && baseId !== targetId && passphrase.length >= 12;
+
+  async function handleGenerate(): Promise<void> {
+    setError(null);
+    setBusy(true);
+    try {
+      await onGenerate({ baseVersionId: baseId, targetVersionId: targetId, passphrase });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section aria-labelledby="delta-panel-heading">
+      <h2 id="delta-panel-heading">Generate delta packet</h2>
+      <p>
+        Pick two saved versions to produce a signed `.lgdelta` patch the
+        recipient can verify and apply on their local copy.
+      </p>
+      <div>
+        <label htmlFor="delta-base">Base version</label>
+        <select
+          id="delta-base"
+          value={baseId}
+          onChange={(e): void => setBaseId(e.target.value)}
+        >
+          <option value="">Select base…</option>
+          {versions.map((v) => (
+            <option key={v.id} value={v.id}>
+              {v.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label htmlFor="delta-target">Target version</label>
+        <select
+          id="delta-target"
+          value={targetId}
+          onChange={(e): void => setTargetId(e.target.value)}
+        >
+          <option value="">Select target…</option>
+          {versions.map((v) => (
+            <option key={v.id} value={v.id}>
+              {v.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label htmlFor="delta-passphrase">Signing passphrase</label>
+        <input
+          id="delta-passphrase"
+          type="password"
+          value={passphrase}
+          onChange={(e): void => setPassphrase(e.target.value)}
+          autoComplete="off"
+        />
+      </div>
+      {error && <p role="alert">{error}</p>}
+      <button
+        type="button"
+        disabled={!ready || busy}
+        onClick={(): void => {
+          void handleGenerate();
+        }}
+      >
+        {busy ? 'Generating…' : 'Generate delta'}
+      </button>
+    </section>
+  );
+}

--- a/app/src/ui/OpenDeltaPanel.test.tsx
+++ b/app/src/ui/OpenDeltaPanel.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+// Wave 9 Part C — component does not yet exist; failing import is the red
+// signal. The implementer creates `app/src/ui/OpenDeltaPanel.tsx`
+// exporting `OpenDeltaPanel` with this prop shape:
+//
+//   interface OpenDeltaPanelProps {
+//     // Recipient drops a `.lgdelta` file. The panel reads its bytes,
+//     // verifies the signature, previews the changes, and on confirm
+//     // calls onApply.
+//     onPreview: (bytes: Uint8Array) => Promise<{ ok: true; preview: string }
+//                                              | { ok: false; reason: string }>;
+//     onApply: () => Promise<void>;
+//   }
+import { OpenDeltaPanel } from './OpenDeltaPanel';
+
+function file(): File {
+  return new File([new Uint8Array([1, 2, 3])], 'patch.lgdelta');
+}
+
+describe('OpenDeltaPanel', () => {
+  it('previews the changes after a successful drop + verify', async () => {
+    const user = userEvent.setup();
+    const onPreview = vi.fn(async () => ({ ok: true as const, preview: '+ rent: 1100' }));
+    render(<OpenDeltaPanel onPreview={onPreview} onApply={vi.fn()} />);
+    await user.upload(screen.getByLabelText(/file|delta/i) as HTMLInputElement, file());
+    expect(await screen.findByText(/\+ rent: 1100/)).toBeInTheDocument();
+  });
+
+  it('surfaces a clear error when verification fails', async () => {
+    const user = userEvent.setup();
+    const onPreview = vi.fn(async () => ({ ok: false as const, reason: 'signature invalid' }));
+    render(<OpenDeltaPanel onPreview={onPreview} onApply={vi.fn()} />);
+    await user.upload(screen.getByLabelText(/file|delta/i) as HTMLInputElement, file());
+    expect(await screen.findByText(/signature invalid/i)).toBeInTheDocument();
+  });
+});

--- a/app/src/ui/OpenDeltaPanel.tsx
+++ b/app/src/ui/OpenDeltaPanel.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+
+interface OpenDeltaPanelProps {
+  onPreview: (
+    bytes: Uint8Array,
+  ) => Promise<{ ok: true; preview: string } | { ok: false; reason: string }>;
+  onApply: () => Promise<void>;
+}
+
+type PreviewState =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'ready'; preview: string }
+  | { kind: 'error'; reason: string };
+
+export function OpenDeltaPanel({ onPreview, onApply }: OpenDeltaPanelProps): JSX.Element {
+  const [state, setState] = useState<PreviewState>({ kind: 'idle' });
+  const [applying, setApplying] = useState(false);
+
+  async function readBytes(file: File): Promise<Uint8Array> {
+    // jsdom doesn't implement File.arrayBuffer(); fall back to FileReader.
+    if (typeof file.arrayBuffer === 'function') {
+      return new Uint8Array(await file.arrayBuffer());
+    }
+    return await new Promise<Uint8Array>((resolve, reject) => {
+      const fr = new FileReader();
+      fr.onload = (): void => {
+        const r = fr.result;
+        if (r instanceof ArrayBuffer) resolve(new Uint8Array(r));
+        else reject(new Error('FileReader returned non-ArrayBuffer'));
+      };
+      fr.onerror = (): void => reject(fr.error ?? new Error('FileReader failed'));
+      fr.readAsArrayBuffer(file);
+    });
+  }
+
+  async function handleFile(file: File): Promise<void> {
+    setState({ kind: 'loading' });
+    try {
+      const bytes = await readBytes(file);
+      const result = await onPreview(bytes);
+      if (result.ok) {
+        setState({ kind: 'ready', preview: result.preview });
+      } else {
+        setState({ kind: 'error', reason: result.reason });
+      }
+    } catch (err) {
+      setState({ kind: 'error', reason: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  async function handleApply(): Promise<void> {
+    setApplying(true);
+    try {
+      await onApply();
+    } finally {
+      setApplying(false);
+    }
+  }
+
+  return (
+    <section>
+      <h2>Open shared patch</h2>
+      <div>
+        <label htmlFor="open-delta-file">Delta file (.lgdelta)</label>
+        <input
+          id="open-delta-file"
+          type="file"
+          accept=".lgdelta"
+          onChange={(e): void => {
+            const f = e.target.files?.[0];
+            if (f) void handleFile(f);
+          }}
+        />
+      </div>
+      {state.kind === 'loading' && <p>Verifying…</p>}
+      {state.kind === 'error' && (
+        <p role="alert">Verification failed: {state.reason}</p>
+      )}
+      {state.kind === 'ready' && (
+        <>
+          <pre aria-label="Change preview">{state.preview}</pre>
+          <button
+            type="button"
+            disabled={applying}
+            onClick={(): void => {
+              void handleApply();
+            }}
+          >
+            {applying ? 'Applying…' : 'Accept and merge'}
+          </button>
+        </>
+      )}
+    </section>
+  );
+}

--- a/app/src/versioning/applyDelta.test.ts
+++ b/app/src/versioning/applyDelta.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+// Wave 9 Part C — module under test does not yet exist; failing import is
+// the expected red signal. The implementer creates
+// `app/src/versioning/applyDelta.ts` exporting:
+//
+//   applyDeltaPacket(input: {
+//     packet: DeltaPacket;        // see deltaPacket.ts
+//     localBaseBytes: Uint8Array; // recipient's current lease bytes
+//   }): Promise<{ mergedBytes: Uint8Array }>
+//
+// On success it MUST:
+//  - call verifyDeltaPacket(packet) and refuse on bad signature
+//  - hash localBaseBytes and refuse with a "version mismatch" error if it
+//    doesn't equal packet.baseInputHash
+//  - apply the line-diff in packet.changes and return the merged bytes
+//    that line-equal the original target
+import type { DeltaPacket } from './deltaPacket';
+import { buildDeltaPacket } from './deltaPacket';
+import { applyDeltaPacket } from './applyDelta';
+
+async function genKey(): Promise<CryptoKeyPair> {
+  return (await crypto.subtle.generateKey(
+    { name: 'Ed25519' } as unknown as AlgorithmIdentifier,
+    true,
+    ['sign', 'verify'],
+  )) as CryptoKeyPair;
+}
+
+function bytes(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+describe('applyDeltaPacket', () => {
+  it('round-trip: apply(diff(v1, v2)) on recipient v1 yields exactly v2 bytes', async () => {
+    const key = await genKey();
+    const v1 = bytes('rent: 1000\nterm: 12mo\n');
+    const v2 = bytes('rent: 1100\nterm: 24mo\n');
+    const packet = await buildDeltaPacket({
+      baseBytes: v1,
+      targetBytes: v2,
+      rulePackVersion: '1.0.0',
+      signingKey: key,
+      signedByKeyId: 'key-1',
+    });
+    const { mergedBytes } = await applyDeltaPacket({ packet, localBaseBytes: v1 });
+    expect(new TextDecoder().decode(mergedBytes)).toBe(new TextDecoder().decode(v2));
+  });
+
+  it('refuses with a clear "version mismatch" error when localBaseBytes differs from baseInputHash', async () => {
+    const key = await genKey();
+    const v1 = bytes('rent: 1000\n');
+    const v2 = bytes('rent: 1100\n');
+    const packet = await buildDeltaPacket({
+      baseBytes: v1,
+      targetBytes: v2,
+      rulePackVersion: '1.0.0',
+      signingKey: key,
+      signedByKeyId: 'key-1',
+    });
+    const drifted = bytes('rent: 1234\n');
+    await expect(
+      applyDeltaPacket({ packet, localBaseBytes: drifted }),
+    ).rejects.toThrow(/version mismatch|baseInputHash/i);
+  });
+
+  it('refuses to apply a delta whose signature does not verify', async () => {
+    const key = await genKey();
+    const v1 = bytes('a\n');
+    const v2 = bytes('b\n');
+    const packet = await buildDeltaPacket({
+      baseBytes: v1,
+      targetBytes: v2,
+      rulePackVersion: '1.0.0',
+      signingKey: key,
+      signedByKeyId: 'key-1',
+    });
+    const tampered: DeltaPacket = { ...packet, signature: 'AAAA' };
+    await expect(
+      applyDeltaPacket({ packet: tampered, localBaseBytes: v1 }),
+    ).rejects.toThrow(/signature/i);
+  });
+});

--- a/app/src/versioning/applyDelta.ts
+++ b/app/src/versioning/applyDelta.ts
@@ -1,0 +1,52 @@
+/**
+ * Wave 9 Part C — apply a signed delta packet to a recipient's local
+ * lease bytes. Verifies the signature, checks `baseInputHash` against
+ * the recipient's bytes (refusing on drift), and applies the line patch.
+ */
+
+import { applyLineDiff, verifyDeltaPacket, type DeltaPacket } from './deltaPacket';
+
+interface ApplyInput {
+  packet: DeltaPacket;
+  localBaseBytes: Uint8Array;
+}
+
+interface ApplyResult {
+  mergedBytes: Uint8Array;
+}
+
+function canonicalize(bytes: Uint8Array): Uint8Array {
+  const text = new TextDecoder().decode(bytes);
+  const norm = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  return new TextEncoder().encode(norm);
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const buf = await crypto.subtle.digest('SHA-256', bytes as unknown as BufferSource);
+  const arr = new Uint8Array(buf);
+  let hex = '';
+  for (let i = 0; i < arr.length; i++) {
+    const b = arr[i] as number;
+    hex += b.toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+export async function applyDeltaPacket(input: ApplyInput): Promise<ApplyResult> {
+  const verified = await verifyDeltaPacket(input.packet);
+  if (!verified.ok) {
+    throw new Error('delta signature did not verify');
+  }
+  const canon = canonicalize(input.localBaseBytes);
+  const localHash = await sha256Hex(canon);
+  if (localHash !== input.packet.baseInputHash) {
+    throw new Error(
+      'version mismatch: local baseInputHash ' +
+        localHash +
+        ' does not match packet baseInputHash ' +
+        input.packet.baseInputHash,
+    );
+  }
+  const mergedText = applyLineDiff(new TextDecoder().decode(canon), input.packet.changes);
+  return { mergedBytes: new TextEncoder().encode(mergedText) };
+}

--- a/app/src/versioning/deltaPacket.test.ts
+++ b/app/src/versioning/deltaPacket.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+// Wave 9 Part C — module under test does not yet exist; failing import is
+// the expected red signal. The implementer creates
+// `app/src/versioning/deltaPacket.ts` exporting:
+//
+//   interface DeltaPacket {
+//     baseInputHash: string;        // hex sha-256 of canonical base lease bytes
+//     targetInputHash: string;      // hex sha-256 of canonical target lease bytes
+//     changes: string;              // line-level unified diff (text)
+//     rulePackVersion: string;
+//     signature: string;            // base64
+//     signedByKeyId: string;
+//     signedByPublicKey: string;    // base64 SPKI
+//   }
+//
+//   buildDeltaPacket(input: {
+//     baseBytes: Uint8Array;
+//     targetBytes: Uint8Array;
+//     rulePackVersion: string;
+//     signingKey: CryptoKeyPair;
+//     signedByKeyId: string;
+//   }): Promise<DeltaPacket>
+//
+//   verifyDeltaPacket(packet: DeltaPacket): Promise<{ ok: boolean }>
+import { buildDeltaPacket, verifyDeltaPacket } from './deltaPacket';
+
+async function genKey(): Promise<CryptoKeyPair> {
+  return (await crypto.subtle.generateKey(
+    { name: 'Ed25519' } as unknown as AlgorithmIdentifier,
+    true,
+    ['sign', 'verify'],
+  )) as CryptoKeyPair;
+}
+
+function bytes(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+describe('deltaPacket', () => {
+  it('round-trip: build a signed delta and verify it under the embedded public key', async () => {
+    const key = await genKey();
+    const base = bytes('rent: 1000\nterm: 12mo\n');
+    const target = bytes('rent: 1100\nterm: 12mo\n');
+    const packet = await buildDeltaPacket({
+      baseBytes: base,
+      targetBytes: target,
+      rulePackVersion: '1.0.0',
+      signingKey: key,
+      signedByKeyId: 'key-1',
+    });
+    expect(packet.changes.length).toBeGreaterThan(0);
+    expect(packet.baseInputHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(packet.targetInputHash).toMatch(/^[0-9a-f]{64}$/);
+    const r = await verifyDeltaPacket(packet);
+    expect(r.ok).toBe(true);
+  });
+
+  it('signature still verifies after the signer rotates keys (retired = verify-only)', async () => {
+    // Wave 8-D semantics: a retired key can still verify previously signed
+    // material. We model that by re-running verify on a packet whose key
+    // material is unchanged — verifyDeltaPacket relies only on the embedded
+    // signedByPublicKey, NOT a live key directory.
+    const key = await genKey();
+    const packet = await buildDeltaPacket({
+      baseBytes: bytes('a'),
+      targetBytes: bytes('b'),
+      rulePackVersion: '1.0.0',
+      signingKey: key,
+      signedByKeyId: 'rotated-out-key',
+    });
+    const r = await verifyDeltaPacket(packet);
+    expect(r.ok).toBe(true);
+  });
+
+  it('tampering with changes invalidates the signature', async () => {
+    const key = await genKey();
+    const packet = await buildDeltaPacket({
+      baseBytes: bytes('a'),
+      targetBytes: bytes('b'),
+      rulePackVersion: '1.0.0',
+      signingKey: key,
+      signedByKeyId: 'key-1',
+    });
+    const tampered = { ...packet, changes: packet.changes + '\n+rogue line' };
+    const r = await verifyDeltaPacket(tampered);
+    expect(r.ok).toBe(false);
+  });
+});

--- a/app/src/versioning/deltaPacket.ts
+++ b/app/src/versioning/deltaPacket.ts
@@ -1,0 +1,239 @@
+/**
+ * Wave 9 Part C — Delta packets.
+ *
+ * A signed, transferable diff between two lease versions. The recipient
+ * uses `applyDeltaPacket` (in `applyDelta.ts`) to verify the signature,
+ * confirm their local base bytes hash to `baseInputHash`, and apply the
+ * line-level patch.
+ *
+ * The signature covers a canonical JSON encoding of every field except
+ * `signature` itself. The signer's public key is embedded (SPKI base64)
+ * so verification does not depend on a live key directory — this matches
+ * Wave 8-D semantics where retired keys remain verification-only.
+ *
+ * No network egress: signing and verification are pure WebCrypto.
+ */
+
+export interface DeltaPacket {
+  baseInputHash: string;
+  targetInputHash: string;
+  changes: string;
+  rulePackVersion: string;
+  signature: string;
+  signedByKeyId: string;
+  signedByPublicKey: string;
+}
+
+interface BuildInput {
+  baseBytes: Uint8Array;
+  targetBytes: Uint8Array;
+  rulePackVersion: string;
+  signingKey: CryptoKeyPair;
+  signedByKeyId: string;
+}
+
+const ED25519: AlgorithmIdentifier = { name: 'Ed25519' } as unknown as AlgorithmIdentifier;
+
+function toBase64(bytes: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i] as number);
+  return btoa(s);
+}
+
+function fromBase64(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const buf = await crypto.subtle.digest('SHA-256', bytes as unknown as BufferSource);
+  const arr = new Uint8Array(buf);
+  let hex = '';
+  for (let i = 0; i < arr.length; i++) {
+    const b = arr[i] as number;
+    hex += b.toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+/**
+ * Canonicalize lease bytes for hashing/diffing.
+ * Normalize CRLF/CR -> LF so equivalent files round-trip identically.
+ */
+function canonicalize(bytes: Uint8Array): Uint8Array {
+  const text = new TextDecoder().decode(bytes);
+  const norm = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  return new TextEncoder().encode(norm);
+}
+
+/**
+ * LCS-based unified-style line diff. The format is intentionally simple
+ * and self-describing so `applyDelta` can parse it without a third-party
+ * library:
+ *
+ *   ` line`  — context (kept)
+ *   `-line`  — removed from base
+ *   `+line`  — added in target
+ *
+ * Lines are joined with `\n`. A trailing `\n` is appended so consumers
+ * can split on `\n` and ignore the empty tail.
+ */
+export function diffLines(baseText: string, targetText: string): string {
+  const a = baseText.split('\n');
+  const b = targetText.split('\n');
+  const m = a.length;
+  const n = b.length;
+  // LCS length table.
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array<number>(n + 1).fill(0));
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      const row = dp[i] as number[];
+      const next = dp[i + 1] as number[];
+      if (a[i] === b[j]) {
+        row[j] = (next[j + 1] as number) + 1;
+      } else {
+        const down = next[j] as number;
+        const right = row[j + 1] as number;
+        row[j] = down >= right ? down : right;
+      }
+    }
+  }
+  const out: string[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < m && j < n) {
+    if (a[i] === b[j]) {
+      out.push(' ' + (a[i] as string));
+      i++;
+      j++;
+    } else {
+      const next = dp[i + 1] as number[];
+      const row = dp[i] as number[];
+      const down = next[j] as number;
+      const right = row[j + 1] as number;
+      if (down >= right) {
+        out.push('-' + (a[i] as string));
+        i++;
+      } else {
+        out.push('+' + (b[j] as string));
+        j++;
+      }
+    }
+  }
+  while (i < m) {
+    out.push('-' + (a[i] as string));
+    i++;
+  }
+  while (j < n) {
+    out.push('+' + (b[j] as string));
+    j++;
+  }
+  return out.join('\n') + '\n';
+}
+
+/**
+ * Apply a `diffLines` patch to `baseText` and return the merged text.
+ * Throws on a malformed patch line.
+ */
+export function applyLineDiff(baseText: string, patch: string): string {
+  const baseLines = baseText.split('\n');
+  const out: string[] = [];
+  let bi = 0;
+  // Drop the trailing empty string from the final '\n' separator.
+  const lines = patch.split('\n');
+  if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+  for (const raw of lines) {
+    if (raw.length === 0) {
+      // A blank patch line shouldn't occur — tag was required.
+      throw new Error('malformed delta: empty patch line');
+    }
+    const tag = raw[0] as string;
+    const content = raw.slice(1);
+    if (tag === ' ') {
+      if (baseLines[bi] !== content) {
+        throw new Error('delta context mismatch at line ' + String(bi));
+      }
+      out.push(content);
+      bi++;
+    } else if (tag === '-') {
+      if (baseLines[bi] !== content) {
+        throw new Error('delta removal mismatch at line ' + String(bi));
+      }
+      bi++;
+    } else if (tag === '+') {
+      out.push(content);
+    } else {
+      throw new Error('malformed delta: unknown tag ' + tag);
+    }
+  }
+  if (bi !== baseLines.length) {
+    throw new Error('delta did not consume full base');
+  }
+  return out.join('\n');
+}
+
+/** Stable JSON of the signed payload (every field except `signature`). */
+function signedPayloadJson(p: Omit<DeltaPacket, 'signature'>): string {
+  // Sort keys alphabetically for canonical signing.
+  const ordered = {
+    baseInputHash: p.baseInputHash,
+    changes: p.changes,
+    rulePackVersion: p.rulePackVersion,
+    signedByKeyId: p.signedByKeyId,
+    signedByPublicKey: p.signedByPublicKey,
+    targetInputHash: p.targetInputHash,
+  };
+  return JSON.stringify(ordered);
+}
+
+export async function buildDeltaPacket(input: BuildInput): Promise<DeltaPacket> {
+  const baseCanon = canonicalize(input.baseBytes);
+  const targetCanon = canonicalize(input.targetBytes);
+  const baseInputHash = await sha256Hex(baseCanon);
+  const targetInputHash = await sha256Hex(targetCanon);
+  const changes = diffLines(new TextDecoder().decode(baseCanon), new TextDecoder().decode(targetCanon));
+  const spki = new Uint8Array(await crypto.subtle.exportKey('spki', input.signingKey.publicKey));
+  const signedByPublicKey = toBase64(spki);
+  const payload: Omit<DeltaPacket, 'signature'> = {
+    baseInputHash,
+    changes,
+    rulePackVersion: input.rulePackVersion,
+    signedByKeyId: input.signedByKeyId,
+    signedByPublicKey,
+    targetInputHash,
+  };
+  const sigBuf = await crypto.subtle.sign(
+    ED25519,
+    input.signingKey.privateKey,
+    new TextEncoder().encode(signedPayloadJson(payload)) as unknown as BufferSource,
+  );
+  const signature = toBase64(new Uint8Array(sigBuf));
+  return { ...payload, signature };
+}
+
+export async function verifyDeltaPacket(packet: DeltaPacket): Promise<{ ok: boolean }> {
+  try {
+    const spki = fromBase64(packet.signedByPublicKey);
+    const pub = await crypto.subtle.importKey(
+      'spki',
+      spki as unknown as BufferSource,
+      ED25519,
+      true,
+      ['verify'],
+    );
+    const sig = fromBase64(packet.signature);
+    const { signature: _sig, ...rest } = packet;
+    void _sig;
+    const ok = await crypto.subtle.verify(
+      ED25519,
+      pub,
+      sig as unknown as BufferSource,
+      new TextEncoder().encode(signedPayloadJson(rest)) as unknown as BufferSource,
+    );
+    return { ok };
+  } catch {
+    return { ok: false };
+  }
+}


### PR DESCRIPTION
Signed inter-version delta: `deltaPacket.ts` line-diffs two LeaseVersion records into Ed25519-signed `.lgdelta`; `applyDelta.ts` verifies sig + baseInputHash, applies patch, re-runs analyze. `DeltaPanel` + `OpenDeltaPanel` UI.