### PR TITLE
wave9-B: counter-sign-and-return

### DIFF
--- a/app/src/redline/applyPatch.test.ts
+++ b/app/src/redline/applyPatch.test.ts
@@ -16,7 +16,26 @@ import { describe, it, expect, beforeEach } from 'vitest';
 //  - append exactly one audit entry of kind 'patch-applied' with
 //    payload { archiveFingerprint, acceptedEditIds }
 import type { RedlinePatch } from './redlinePatch';
+import { buildRedlinePatch } from './redlinePatch';
 import { applyRedlinePatch } from './applyPatch';
+
+async function realPatch(over: Partial<RedlinePatch> = {}): Promise<RedlinePatch> {
+  const keyPair = (await crypto.subtle.generateKey('Ed25519', true, [
+    'sign',
+    'verify',
+  ])) as CryptoKeyPair;
+  const built = await buildRedlinePatch({
+    archiveFingerprint: FINGERPRINT,
+    knownEditIds: ['e1', 'e2'],
+    decisions: [
+      { editId: 'e1', accepted: true },
+      { editId: 'e2', accepted: false },
+    ],
+    signingKey: keyPair,
+    signedByKeyId: 'key-1',
+  });
+  return { ...built, ...over };
+}
 import {
   _resetRedlineDbForTests,
   listEditsForLease,
@@ -24,20 +43,6 @@ import {
 import { _resetAuditDbForTests, listAuditEntries } from '../audit/auditLog';
 
 const FINGERPRINT = 'c'.repeat(64);
-
-function fakePatch(over: Partial<RedlinePatch> = {}): RedlinePatch {
-  return {
-    archiveFingerprint: FINGERPRINT,
-    decisions: [
-      { editId: 'e1', accepted: true },
-      { editId: 'e2', accepted: false },
-    ],
-    signature: 'AAAA',
-    signedByKeyId: 'key-1',
-    signedByPublicKey: 'BBBB',
-    ...over,
-  };
-}
 
 beforeEach(async () => {
   _resetRedlineDbForTests();
@@ -48,9 +53,10 @@ beforeEach(async () => {
 
 describe('applyRedlinePatch', () => {
   it('refuses to apply a patch with an invalid signature', async () => {
+    const patch = await realPatch({ signature: 'tampered' });
     await expect(
       applyRedlinePatch({
-        patch: fakePatch({ signature: 'tampered' }),
+        patch,
         archiveFingerprint: FINGERPRINT,
         editsByPatchId: {
           e1: { leaseId: 'L', paragraphIndex: 0, before: 'a', after: 'b', updatedAt: 'now' },
@@ -61,9 +67,10 @@ describe('applyRedlinePatch', () => {
   });
 
   it('refuses to apply when the local archive fingerprint does not match the patch', async () => {
+    const patch = await realPatch();
     await expect(
       applyRedlinePatch({
-        patch: fakePatch(),
+        patch,
         archiveFingerprint: 'd'.repeat(64),
         editsByPatchId: {
           e1: { leaseId: 'L', paragraphIndex: 0, before: 'a', after: 'b', updatedAt: 'now' },
@@ -73,13 +80,9 @@ describe('applyRedlinePatch', () => {
   });
 
   it('on success, persists exactly the accepted edits and writes one patch-applied audit entry', async () => {
-    // The signature path will fail with the placeholder fakePatch above, so
-    // this test pins the contract: after success we expect exactly one
-    // accepted edit in the redline store and exactly one new audit entry of
-    // kind 'patch-applied'. Until applyRedlinePatch is implemented this
-    // test fails at the await call (module missing).
+    const patch = await realPatch();
     const result = await applyRedlinePatch({
-      patch: fakePatch(),
+      patch,
       archiveFingerprint: FINGERPRINT,
       editsByPatchId: {
         e1: { leaseId: 'L', paragraphIndex: 0, before: 'a', after: 'b', updatedAt: 'now' },

--- a/app/src/redline/applyPatch.test.ts
+++ b/app/src/redline/applyPatch.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+// Wave 9 Part B — module under test does not yet exist; failing import is
+// the expected red signal. The implementer creates
+// `app/src/redline/applyPatch.ts` exporting:
+//
+//   applyRedlinePatch(input: {
+//     patch: RedlinePatch;            // see redlinePatch.ts
+//     archiveFingerprint: string;     // recipient's local fingerprint to match
+//     editsByPatchId: Record<string, RedlineEdit>;
+//   }): Promise<{ acceptedEditIds: string[] }>
+//
+// On success it MUST:
+//  - verify the patch signature against patch.signedByPublicKey
+//  - check archiveFingerprint matches patch.archiveFingerprint
+//  - persist accepted edits to the RedlineEdit store via saveEdit()
+//  - append exactly one audit entry of kind 'patch-applied' with
+//    payload { archiveFingerprint, acceptedEditIds }
+import type { RedlinePatch } from './redlinePatch';
+import { applyRedlinePatch } from './applyPatch';
+import {
+  _resetRedlineDbForTests,
+  listEditsForLease,
+} from './redlineStorage';
+import { _resetAuditDbForTests, listAuditEntries } from '../audit/auditLog';
+
+const FINGERPRINT = 'c'.repeat(64);
+
+function fakePatch(over: Partial<RedlinePatch> = {}): RedlinePatch {
+  return {
+    archiveFingerprint: FINGERPRINT,
+    decisions: [
+      { editId: 'e1', accepted: true },
+      { editId: 'e2', accepted: false },
+    ],
+    signature: 'AAAA',
+    signedByKeyId: 'key-1',
+    signedByPublicKey: 'BBBB',
+    ...over,
+  };
+}
+
+beforeEach(async () => {
+  _resetRedlineDbForTests();
+  _resetAuditDbForTests();
+  indexedDB.deleteDatabase('leaseguard-redlines');
+  indexedDB.deleteDatabase('leaseguard-audit');
+});
+
+describe('applyRedlinePatch', () => {
+  it('refuses to apply a patch with an invalid signature', async () => {
+    await expect(
+      applyRedlinePatch({
+        patch: fakePatch({ signature: 'tampered' }),
+        archiveFingerprint: FINGERPRINT,
+        editsByPatchId: {
+          e1: { leaseId: 'L', paragraphIndex: 0, before: 'a', after: 'b', updatedAt: 'now' },
+          e2: { leaseId: 'L', paragraphIndex: 1, before: 'a', after: 'b', updatedAt: 'now' },
+        },
+      }),
+    ).rejects.toThrow(/signature/i);
+  });
+
+  it('refuses to apply when the local archive fingerprint does not match the patch', async () => {
+    await expect(
+      applyRedlinePatch({
+        patch: fakePatch(),
+        archiveFingerprint: 'd'.repeat(64),
+        editsByPatchId: {
+          e1: { leaseId: 'L', paragraphIndex: 0, before: 'a', after: 'b', updatedAt: 'now' },
+        },
+      }),
+    ).rejects.toThrow(/fingerprint|mismatch/i);
+  });
+
+  it('on success, persists exactly the accepted edits and writes one patch-applied audit entry', async () => {
+    // The signature path will fail with the placeholder fakePatch above, so
+    // this test pins the contract: after success we expect exactly one
+    // accepted edit in the redline store and exactly one new audit entry of
+    // kind 'patch-applied'. Until applyRedlinePatch is implemented this
+    // test fails at the await call (module missing).
+    const result = await applyRedlinePatch({
+      patch: fakePatch(),
+      archiveFingerprint: FINGERPRINT,
+      editsByPatchId: {
+        e1: { leaseId: 'L', paragraphIndex: 0, before: 'a', after: 'b', updatedAt: 'now' },
+        e2: { leaseId: 'L', paragraphIndex: 1, before: 'a', after: 'b', updatedAt: 'now' },
+      },
+    });
+    expect(result.acceptedEditIds).toEqual(['e1']);
+    const persisted = await listEditsForLease('L');
+    expect(persisted).toHaveLength(1);
+    const audits = await listAuditEntries();
+    const patchApplied = audits.filter((e) => e.kind === 'patch-applied');
+    expect(patchApplied).toHaveLength(1);
+  });
+});

--- a/app/src/redline/applyPatch.ts
+++ b/app/src/redline/applyPatch.ts
@@ -1,0 +1,63 @@
+/**
+ * Wave 9 Part B — Apply a `RedlinePatch` returned by a reviewer.
+ *
+ * Verifies the embedded signature against the embedded public key,
+ * cross-checks the local archive fingerprint, persists the accepted
+ * edits to the redline IDB store, and writes exactly one
+ * `kind: 'patch-applied'` audit entry summarising the apply.
+ *
+ * Rejects (throws) on:
+ *  - signature failing Ed25519 verification under `signedByPublicKey`
+ *  - `patch.archiveFingerprint` not matching the recipient's local
+ *    `archiveFingerprint` (i.e. the patch was authored for a different
+ *    archive than the one the recipient is holding)
+ */
+
+import type { RedlinePatch } from './redlinePatch';
+import { verifyRedlinePatch } from './redlinePatch';
+import type { RedlineEdit } from './redline';
+import { saveEdit } from './redlineStorage';
+import { appendAuditEntry } from '../audit/auditLog';
+
+export interface ApplyRedlinePatchInput {
+  patch: RedlinePatch;
+  archiveFingerprint: string;
+  editsByPatchId: Record<string, RedlineEdit>;
+}
+
+export interface ApplyRedlinePatchResult {
+  acceptedEditIds: string[];
+}
+
+export async function applyRedlinePatch(
+  input: ApplyRedlinePatchInput,
+): Promise<ApplyRedlinePatchResult> {
+  const { patch, archiveFingerprint, editsByPatchId } = input;
+
+  if (patch.archiveFingerprint !== archiveFingerprint) {
+    throw new Error(
+      'redline patch: archive fingerprint mismatch (patch was authored for a different archive)',
+    );
+  }
+
+  const { ok } = await verifyRedlinePatch(patch);
+  if (!ok) {
+    throw new Error('redline patch: signature verification failed');
+  }
+
+  const acceptedEditIds: string[] = [];
+  for (const decision of patch.decisions) {
+    if (!decision.accepted) continue;
+    const edit = editsByPatchId[decision.editId];
+    if (!edit) continue;
+    await saveEdit(edit);
+    acceptedEditIds.push(decision.editId);
+  }
+
+  await appendAuditEntry({
+    kind: 'patch-applied',
+    payload: { archiveFingerprint, acceptedEditIds },
+  });
+
+  return { acceptedEditIds };
+}

--- a/app/src/redline/redlinePatch.test.ts
+++ b/app/src/redline/redlinePatch.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+// Wave 9 Part B — module under test does not yet exist; failing import is
+// the expected red signal. The implementer creates
+// `app/src/redline/redlinePatch.ts` exporting:
+//
+//   interface PatchDecision {
+//     editId: string;            // stable id for an edit known to the archive
+//     accepted: boolean;
+//   }
+//
+//   interface RedlinePatch {
+//     archiveFingerprint: string;
+//     decisions: PatchDecision[];
+//     signature: string;         // base64
+//     signedByKeyId: string;
+//     signedByPublicKey: string; // base64 SPKI
+//   }
+//
+//   buildRedlinePatch(input: {
+//     archiveFingerprint: string;
+//     knownEditIds: readonly string[];
+//     decisions: PatchDecision[];
+//     signingKey: CryptoKeyPair;        // Ed25519
+//     signedByKeyId: string;
+//   }): Promise<RedlinePatch>
+//
+//   verifyRedlinePatch(patch: RedlinePatch): Promise<{ ok: boolean }>
+import { buildRedlinePatch, verifyRedlinePatch } from './redlinePatch';
+
+async function genKey(): Promise<CryptoKeyPair> {
+  return (await crypto.subtle.generateKey(
+    { name: 'Ed25519' } as unknown as AlgorithmIdentifier,
+    true,
+    ['sign', 'verify'],
+  )) as CryptoKeyPair;
+}
+
+const FINGERPRINT = 'b'.repeat(64);
+const KNOWN_EDITS = ['e1', 'e2', 'e3'] as const;
+
+describe('redlinePatch', () => {
+  it('emit + verify: a fresh patch verifies under its embedded public key', async () => {
+    const key = await genKey();
+    const patch = await buildRedlinePatch({
+      archiveFingerprint: FINGERPRINT,
+      knownEditIds: KNOWN_EDITS,
+      decisions: [
+        { editId: 'e1', accepted: true },
+        { editId: 'e2', accepted: false },
+      ],
+      signingKey: key,
+      signedByKeyId: 'key-1',
+    });
+    const r = await verifyRedlinePatch(patch);
+    expect(r.ok).toBe(true);
+    expect(patch.archiveFingerprint).toBe(FINGERPRINT);
+    expect(patch.signedByKeyId).toBe('key-1');
+  });
+
+  it('rejects decisions referencing edits the archive does not know about', async () => {
+    const key = await genKey();
+    await expect(
+      buildRedlinePatch({
+        archiveFingerprint: FINGERPRINT,
+        knownEditIds: KNOWN_EDITS,
+        decisions: [{ editId: 'does-not-exist', accepted: true }],
+        signingKey: key,
+        signedByKeyId: 'key-1',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('signature covers the canonical decisions list (tampering invalidates)', async () => {
+    const key = await genKey();
+    const patch = await buildRedlinePatch({
+      archiveFingerprint: FINGERPRINT,
+      knownEditIds: KNOWN_EDITS,
+      decisions: [{ editId: 'e1', accepted: true }],
+      signingKey: key,
+      signedByKeyId: 'key-1',
+    });
+    const tampered = {
+      ...patch,
+      decisions: [{ editId: 'e1', accepted: false }], // flip the decision
+    };
+    const r = await verifyRedlinePatch(tampered);
+    expect(r.ok).toBe(false);
+  });
+});

--- a/app/src/redline/redlinePatch.ts
+++ b/app/src/redline/redlinePatch.ts
@@ -1,0 +1,155 @@
+/**
+ * Wave 9 Part B — Counter-sign-and-return patch format.
+ *
+ * A `RedlinePatch` is what a reviewer (e.g. a co-tenant or lawyer) emits
+ * after triaging another party's redline edits. It carries per-edit
+ * accept/reject decisions plus an Ed25519 signature over the canonical
+ * representation so the original author can verify the patch hasn't been
+ * tampered with in transit.
+ *
+ * The signature covers a canonical-JSON view of {archiveFingerprint,
+ * decisions[], signedByKeyId, signedByPublicKey} — i.e. everything *but*
+ * the signature itself. Public key is embedded so verification is
+ * self-contained; the recipient still cross-checks `archiveFingerprint`
+ * against their local archive before applying.
+ */
+
+export interface PatchDecision {
+  editId: string;
+  accepted: boolean;
+}
+
+export interface RedlinePatch {
+  archiveFingerprint: string;
+  decisions: PatchDecision[];
+  /** base64 Ed25519 signature over the signing payload. */
+  signature: string;
+  signedByKeyId: string;
+  /** base64 SPKI Ed25519 public key. */
+  signedByPublicKey: string;
+}
+
+export interface BuildRedlinePatchInput {
+  archiveFingerprint: string;
+  knownEditIds: readonly string[];
+  decisions: PatchDecision[];
+  signingKey: CryptoKeyPair;
+  signedByKeyId: string;
+}
+
+/**
+ * JSON.stringify with object keys sorted lexicographically at every depth.
+ * Matches the audit-log canonicalisation so signatures are reproducible.
+ */
+function canonicalJsonStringify(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(canonicalize);
+  const obj = value as Record<string, unknown>;
+  const sorted: Record<string, unknown> = {};
+  for (const k of Object.keys(obj).sort()) {
+    sorted[k] = canonicalize(obj[k]);
+  }
+  return sorted;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i] ?? 0);
+  return btoa(bin);
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+interface SigningPayload {
+  archiveFingerprint: string;
+  decisions: PatchDecision[];
+  signedByKeyId: string;
+  signedByPublicKey: string;
+}
+
+function encodeSigningPayload(p: SigningPayload): Uint8Array {
+  return new TextEncoder().encode(canonicalJsonStringify(p));
+}
+
+export async function buildRedlinePatch(
+  input: BuildRedlinePatchInput,
+): Promise<RedlinePatch> {
+  const { archiveFingerprint, knownEditIds, decisions, signingKey, signedByKeyId } =
+    input;
+
+  const known = new Set(knownEditIds);
+  for (const d of decisions) {
+    if (!known.has(d.editId)) {
+      throw new Error(
+        `redlinePatch: decision references unknown editId "${d.editId}"`,
+      );
+    }
+  }
+
+  const pubRaw = new Uint8Array(
+    await crypto.subtle.exportKey('spki', signingKey.publicKey),
+  );
+  const signedByPublicKey = bytesToBase64(pubRaw);
+
+  const payload = encodeSigningPayload({
+    archiveFingerprint,
+    decisions,
+    signedByKeyId,
+    signedByPublicKey,
+  });
+  const sig = new Uint8Array(
+    await crypto.subtle.sign(
+      { name: 'Ed25519' } as unknown as AlgorithmIdentifier,
+      signingKey.privateKey,
+      payload as BufferSource,
+    ),
+  );
+
+  return {
+    archiveFingerprint,
+    decisions: [...decisions],
+    signature: bytesToBase64(sig),
+    signedByKeyId,
+    signedByPublicKey,
+  };
+}
+
+export async function verifyRedlinePatch(
+  patch: RedlinePatch,
+): Promise<{ ok: boolean }> {
+  try {
+    const pubRaw = base64ToBytes(patch.signedByPublicKey);
+    const pubKey = await crypto.subtle.importKey(
+      'spki',
+      pubRaw as BufferSource,
+      { name: 'Ed25519' } as unknown as AlgorithmIdentifier,
+      true,
+      ['verify'],
+    );
+    const payload = encodeSigningPayload({
+      archiveFingerprint: patch.archiveFingerprint,
+      decisions: patch.decisions,
+      signedByKeyId: patch.signedByKeyId,
+      signedByPublicKey: patch.signedByPublicKey,
+    });
+    const sig = base64ToBytes(patch.signature);
+    const ok = await crypto.subtle.verify(
+      { name: 'Ed25519' } as unknown as AlgorithmIdentifier,
+      pubKey,
+      sig as BufferSource,
+      payload as BufferSource,
+    );
+    return { ok };
+  } catch {
+    return { ok: false };
+  }
+}

--- a/app/src/ui/CounterSignPanel.test.tsx
+++ b/app/src/ui/CounterSignPanel.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+// Wave 9 Part B — component does not yet exist; failing import is the red
+// signal. The implementer creates `app/src/ui/CounterSignPanel.tsx`
+// exporting `CounterSignPanel` with this prop shape:
+//
+//   interface CounterSignPanelProps {
+//     decisions: { editId: string; accepted: boolean }[];
+//     archiveFingerprint: string;
+//     // Called when the user enters a passphrase to unlock their signing
+//     // key and presses "Sign & export". Returns the .lgpatch bytes.
+//     onSign: (input: {
+//       passphrase: string;
+//       decisions: { editId: string; accepted: boolean }[];
+//     }) => Promise<Uint8Array>;
+//   }
+import { CounterSignPanel } from './CounterSignPanel';
+
+describe('CounterSignPanel', () => {
+  it('renders a signing button that is disabled until a passphrase is entered', () => {
+    render(
+      <CounterSignPanel
+        decisions={[{ editId: 'e1', accepted: true }]}
+        archiveFingerprint={'a'.repeat(64)}
+        onSign={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /sign/i })).toBeDisabled();
+  });
+
+  it('happy path: passphrase + click invokes onSign with the decisions list', async () => {
+    const user = userEvent.setup();
+    const onSign = vi.fn(async () => new Uint8Array([9, 9, 9]));
+    render(
+      <CounterSignPanel
+        decisions={[
+          { editId: 'e1', accepted: true },
+          { editId: 'e2', accepted: false },
+        ]}
+        archiveFingerprint={'a'.repeat(64)}
+        onSign={onSign}
+      />,
+    );
+    await user.type(screen.getByLabelText(/passphrase/i), 'a-strong-passphrase-12345');
+    await user.click(screen.getByRole('button', { name: /sign/i }));
+    expect(onSign).toHaveBeenCalledTimes(1);
+    expect(onSign.mock.calls[0]?.[0]?.decisions).toHaveLength(2);
+  });
+
+  it('surfaces an error when onSign rejects (e.g. wrong passphrase)', async () => {
+    const user = userEvent.setup();
+    const onSign = vi.fn(async () => {
+      throw new Error('bad passphrase');
+    });
+    render(
+      <CounterSignPanel
+        decisions={[{ editId: 'e1', accepted: true }]}
+        archiveFingerprint={'a'.repeat(64)}
+        onSign={onSign}
+      />,
+    );
+    await user.type(screen.getByLabelText(/passphrase/i), 'a-strong-passphrase-12345');
+    await user.click(screen.getByRole('button', { name: /sign/i }));
+    expect(await screen.findByText(/bad passphrase|error|failed/i)).toBeInTheDocument();
+  });
+});

--- a/app/src/ui/CounterSignPanel.test.tsx
+++ b/app/src/ui/CounterSignPanel.test.tsx
@@ -15,7 +15,7 @@ import userEvent from '@testing-library/user-event';
 //       decisions: { editId: string; accepted: boolean }[];
 //     }) => Promise<Uint8Array>;
 //   }
-import { CounterSignPanel } from './CounterSignPanel';
+import { CounterSignPanel, type CounterSignDecision } from './CounterSignPanel';
 
 describe('CounterSignPanel', () => {
   it('renders a signing button that is disabled until a passphrase is entered', () => {
@@ -31,7 +31,10 @@ describe('CounterSignPanel', () => {
 
   it('happy path: passphrase + click invokes onSign with the decisions list', async () => {
     const user = userEvent.setup();
-    const onSign = vi.fn(async () => new Uint8Array([9, 9, 9]));
+    const onSign = vi.fn<
+      [{ passphrase: string; decisions: CounterSignDecision[] }],
+      Promise<Uint8Array>
+    >(async () => new Uint8Array([9, 9, 9]));
     render(
       <CounterSignPanel
         decisions={[

--- a/app/src/ui/CounterSignPanel.tsx
+++ b/app/src/ui/CounterSignPanel.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+
+/**
+ * Wave 9 Part B — passphrase prompt + sign-and-export trigger for a
+ * counter-signed redline patch. Pure presentational: the parent owns the
+ * actual `.lgpatch` byte production via the `onSign` callback so this
+ * component never touches IDB or `crypto.subtle` directly.
+ */
+
+export interface CounterSignDecision {
+  editId: string;
+  accepted: boolean;
+}
+
+export interface CounterSignPanelProps {
+  decisions: CounterSignDecision[];
+  archiveFingerprint: string;
+  onSign: (input: {
+    passphrase: string;
+    decisions: CounterSignDecision[];
+  }) => Promise<Uint8Array>;
+}
+
+export function CounterSignPanel({
+  decisions,
+  archiveFingerprint,
+  onSign,
+}: CounterSignPanelProps): JSX.Element {
+  const [passphrase, setPassphrase] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const canSign = passphrase.trim().length > 0 && !busy;
+
+  async function handleSign(): Promise<void> {
+    setError(null);
+    setBusy(true);
+    try {
+      await onSign({ passphrase, decisions });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Sign failed';
+      setError(message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section aria-label="counter-sign">
+      <h3>Sign &amp; export patch</h3>
+      <p>
+        <span aria-label="archive fingerprint">{archiveFingerprint.slice(0, 12)}…</span>
+        {' · '}
+        {decisions.length} decision{decisions.length === 1 ? '' : 's'}
+      </p>
+      <label>
+        Passphrase
+        <input
+          type="password"
+          value={passphrase}
+          onChange={(e) => setPassphrase(e.target.value)}
+          autoComplete="off"
+        />
+      </label>
+      <button
+        type="button"
+        onClick={() => {
+          void handleSign();
+        }}
+        disabled={!canSign}
+      >
+        Sign &amp; export
+      </button>
+      {error ? <p role="alert">{error}</p> : null}
+    </section>
+  );
+}

--- a/app/src/ui/RedlinePanel.tsx
+++ b/app/src/ui/RedlinePanel.tsx
@@ -1,6 +1,25 @@
 import { useEffect, useRef, useState } from 'react';
 import type { LeaseDocument } from '../parser/types';
 import type { RedlineEdit } from '../redline/redline';
+import { CounterSignPanel } from './CounterSignPanel';
+
+/**
+ * Wave 9 Part B — when the lease is being viewed inside a review-mode
+ * session (a `.lgreview` archive opened by a reviewer), the panel grows
+ * an Accept/Reject toggle next to each existing edit and a "Sign &
+ * export patch" pane at the bottom. The hook surface lives in Part A
+ * (`useReviewMode`); the panel just consumes a plain `reviewMode` prop
+ * so it stays decoupled from that hook's evolving shape.
+ */
+export interface RedlinePanelReviewMode {
+  archiveFingerprint: string;
+  /** Stable id per edit, agreed between author and reviewer. */
+  editIdByParagraphIndex: Record<number, string>;
+  onSignAndExport: (input: {
+    passphrase: string;
+    decisions: { editId: string; accepted: boolean }[];
+  }) => Promise<Uint8Array>;
+}
 
 interface RedlinePanelProps {
   doc: LeaseDocument | null;
@@ -12,6 +31,12 @@ interface RedlinePanelProps {
    * and triggering a file download. Panel just exposes the trigger.
    */
   onExportHtml: () => void;
+  /**
+   * When set, the panel renders Accept/Reject toggles on each existing
+   * edit and a counter-sign pane at the bottom. Omitted in normal
+   * (author) mode.
+   */
+  reviewMode?: RedlinePanelReviewMode;
 }
 
 /**
@@ -26,9 +51,11 @@ export function RedlinePanel({
   onEditParagraph,
   onDeleteEdit,
   onExportHtml,
+  reviewMode,
 }: RedlinePanelProps): JSX.Element {
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [draft, setDraft] = useState('');
+  const [decisions, setDecisions] = useState<Record<string, boolean>>({});
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   useEffect(() => {
@@ -135,12 +162,45 @@ export function RedlinePanel({
                       Revert
                     </button>
                   ) : null}
+                  {reviewMode && edit ? (() => {
+                    const editId = reviewMode.editIdByParagraphIndex[i];
+                    if (!editId) return null;
+                    const accepted = decisions[editId] ?? false;
+                    return (
+                      <label aria-label={`accept paragraph ${i + 1}`}>
+                        <input
+                          type="checkbox"
+                          checked={accepted}
+                          onChange={(e) =>
+                            setDecisions((prev) => ({
+                              ...prev,
+                              [editId]: e.target.checked,
+                            }))
+                          }
+                        />
+                        Accept
+                      </label>
+                    );
+                  })() : null}
                 </>
               )}
             </li>
           );
         })}
       </ol>
+
+      {reviewMode ? (
+        <CounterSignPanel
+          decisions={Object.entries(reviewMode.editIdByParagraphIndex).map(
+            ([, editId]) => ({
+              editId,
+              accepted: decisions[editId] ?? false,
+            }),
+          )}
+          archiveFingerprint={reviewMode.archiveFingerprint}
+          onSign={reviewMode.onSignAndExport}
+        />
+      ) : null}
     </section>
   );
 }


### PR DESCRIPTION
Ed25519-signed redline patches: `buildRedlinePatch` + `applyRedlinePatch` (verifies sig, checks archiveFingerprint, writes one `patch-applied` audit entry). `RedlinePanel` Accept/Reject UI + `CounterSignPanel` for `.lgpatch` export. Verifies under Wave 8-D rotated keys.