### PR TITLE
wave9-A: signed review links

### DIFF
--- a/app/src/App/useReviewMode.test.ts
+++ b/app/src/App/useReviewMode.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+// Wave 9 Part A — module does not exist yet; failing import is the red
+// signal. The implementer creates `app/src/App/useReviewMode.ts`
+// exporting a hook + provider with this shape:
+//
+//   type ReviewMode =
+//     | { active: true; archiveId: string; expiresAt: string }
+//     | { active: false };
+//
+//   export function useReviewMode(): {
+//     mode: ReviewMode;
+//     enter(args: { archiveId: string; expiresAt: string }): void;
+//     exit(): void;
+//   };
+//
+//   export function ReviewModeProvider(props: { children: React.ReactNode }):
+//     JSX.Element;
+import { useReviewMode, ReviewModeProvider } from './useReviewMode';
+
+describe('useReviewMode', () => {
+  it('defaults to inactive when no provider state has been set', () => {
+    const { result } = renderHook(() => useReviewMode(), { wrapper: ReviewModeProvider });
+    expect(result.current.mode.active).toBe(false);
+  });
+
+  it('enter() sets active=true with archiveId + expiresAt; exit() returns to inactive', () => {
+    const { result } = renderHook(() => useReviewMode(), { wrapper: ReviewModeProvider });
+    act(() => {
+      result.current.enter({ archiveId: 'arch-1', expiresAt: '2099-01-01T00:00:00Z' });
+    });
+    expect(result.current.mode).toEqual({
+      active: true,
+      archiveId: 'arch-1',
+      expiresAt: '2099-01-01T00:00:00Z',
+    });
+    act(() => {
+      result.current.exit();
+    });
+    expect(result.current.mode.active).toBe(false);
+  });
+});

--- a/app/src/App/useReviewMode.ts
+++ b/app/src/App/useReviewMode.ts
@@ -1,0 +1,47 @@
+import {
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+export type ReviewMode =
+  | { active: true; archiveId: string; expiresAt: string }
+  | { active: false };
+
+interface ReviewModeApi {
+  mode: ReviewMode;
+  enter: (args: { archiveId: string; expiresAt: string }) => void;
+  exit: () => void;
+}
+
+const INACTIVE: ReviewMode = { active: false };
+
+const ReviewModeContext = createContext<ReviewModeApi | null>(null);
+
+export function ReviewModeProvider({ children }: { children: ReactNode }): JSX.Element {
+  const [mode, setMode] = useState<ReviewMode>(INACTIVE);
+
+  const enter = useCallback((args: { archiveId: string; expiresAt: string }) => {
+    setMode({ active: true, archiveId: args.archiveId, expiresAt: args.expiresAt });
+  }, []);
+
+  const exit = useCallback(() => {
+    setMode(INACTIVE);
+  }, []);
+
+  const value = useMemo<ReviewModeApi>(() => ({ mode, enter, exit }), [mode, enter, exit]);
+
+  return createElement(ReviewModeContext.Provider, { value }, children);
+}
+
+export function useReviewMode(): ReviewModeApi {
+  const ctx = useContext(ReviewModeContext);
+  if (ctx) return ctx;
+  // Tolerate use outside the provider so downstream panels can defensively
+  // read `mode.active === false` without forcing every host to wrap them.
+  return { mode: INACTIVE, enter: () => {}, exit: () => {} };
+}

--- a/app/src/storage/reviewArchive.test.ts
+++ b/app/src/storage/reviewArchive.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+// Wave 9 Part A — module under test does not yet exist. The failing import
+// is the expected red signal until the implementer creates
+// `app/src/storage/reviewArchive.ts` exporting:
+//
+//   exportReviewArchive(input: {
+//     bundle: Uint8Array;          // a Wave 8 replay bundle
+//     packFingerprint: string;     // hex sha-256 of the signed pack
+//     expiresAt: string;           // ISO-8601
+//     passphrase: string;
+//   }): Promise<Uint8Array>        // an AES-GCM envelope (PBKDF2-derived key)
+//
+//   importReviewArchive(bytes: Uint8Array, passphrase: string, opts?: {
+//     now?: Date;
+//   }): Promise<{ bundle: Uint8Array; packFingerprint: string; expiresAt: string }>
+//
+//   The envelope must carry { packFingerprint, expiresAt, ciphertext, iv,
+//   salt, version } and be tamper-evident via AES-GCM auth tag.
+import {
+  exportReviewArchive,
+  importReviewArchive,
+} from './reviewArchive';
+
+const PASSPHRASE = 'correct horse battery staple';
+const FUTURE_EXPIRY = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+const PAST_EXPIRY = new Date(Date.now() - 60_000).toISOString();
+const FAKE_FINGERPRINT = 'a'.repeat(64);
+
+function bundle(): Uint8Array {
+  return new TextEncoder().encode('PKfake-replay-bundle-bytes');
+}
+
+describe('reviewArchive', () => {
+  it('round-trips: encrypt → decrypt yields a byte-identical inner bundle', async () => {
+    const inner = bundle();
+    const envelope = await exportReviewArchive({
+      bundle: inner,
+      packFingerprint: FAKE_FINGERPRINT,
+      expiresAt: FUTURE_EXPIRY,
+      passphrase: PASSPHRASE,
+    });
+    expect(envelope).toBeInstanceOf(Uint8Array);
+    const opened = await importReviewArchive(envelope, PASSPHRASE);
+    expect(opened.bundle).toEqual(inner);
+    expect(opened.packFingerprint).toBe(FAKE_FINGERPRINT);
+    expect(opened.expiresAt).toBe(FUTURE_EXPIRY);
+  });
+
+  it('rejects an expired archive with a clear error', async () => {
+    const envelope = await exportReviewArchive({
+      bundle: bundle(),
+      packFingerprint: FAKE_FINGERPRINT,
+      expiresAt: PAST_EXPIRY,
+      passphrase: PASSPHRASE,
+    });
+    await expect(importReviewArchive(envelope, PASSPHRASE)).rejects.toThrow(/expired/i);
+  });
+
+  it('rejects a wrong passphrase (AES-GCM auth failure)', async () => {
+    const envelope = await exportReviewArchive({
+      bundle: bundle(),
+      packFingerprint: FAKE_FINGERPRINT,
+      expiresAt: FUTURE_EXPIRY,
+      passphrase: PASSPHRASE,
+    });
+    await expect(importReviewArchive(envelope, 'wrong passphrase')).rejects.toThrow();
+  });
+
+  it('rejects a malformed envelope (bytes do not begin with the magic / shape)', async () => {
+    const garbage = new Uint8Array(64).fill(0x42);
+    await expect(importReviewArchive(garbage, PASSPHRASE)).rejects.toThrow();
+  });
+
+  it('rejects a tampered envelope (single bit flip in the ciphertext)', async () => {
+    const envelope = await exportReviewArchive({
+      bundle: bundle(),
+      packFingerprint: FAKE_FINGERPRINT,
+      expiresAt: FUTURE_EXPIRY,
+      passphrase: PASSPHRASE,
+    });
+    const tampered = new Uint8Array(envelope);
+    const idx = tampered.length - 8;
+    tampered[idx] = ((tampered[idx] ?? 0) ^ 0x01) & 0xff;
+    await expect(importReviewArchive(tampered, PASSPHRASE)).rejects.toThrow();
+  });
+});

--- a/app/src/storage/reviewArchive.ts
+++ b/app/src/storage/reviewArchive.ts
@@ -1,0 +1,228 @@
+// Wave 9 Part A — encrypted "review archive" envelope.
+//
+// Wraps a Wave 8 replay bundle (Uint8Array) inside an AES-GCM envelope keyed
+// by a PBKDF2(SHA-256)-derived key. The envelope is a UTF-8 JSON document
+// (magic-prefixed) so that the CLI verifier (Part D) can parse the metadata
+// without re-implementing a binary layout. Tamper-evidence comes from the
+// AES-GCM auth tag — we deliberately do NOT add a separate HMAC.
+//
+// Crypto parameters (documented in SYSTEM_DESIGN "Collaboration escape
+// hatches"):
+//   - AES-GCM, 256-bit key, fresh 12-byte random IV per encrypt.
+//   - PBKDF2-SHA256, 250_000 iterations, fresh 16-byte random salt per
+//     archive.
+//   - Auth tag is the AES-GCM 128-bit tag baked into the ciphertext output
+//     by WebCrypto.
+
+const MAGIC = 'LGREVIEW';
+const VERSION = 1;
+const SALT_LEN = 16;
+const IV_LEN = 12;
+const PBKDF2_ITERATIONS = 250_000;
+
+interface ReviewEnvelope {
+  magic: typeof MAGIC;
+  version: number;
+  packFingerprint: string;
+  expiresAt: string;
+  salt: string;       // base64
+  iv: string;         // base64
+  ciphertext: string; // base64
+}
+
+export interface ExportReviewArchiveInput {
+  bundle: Uint8Array;
+  packFingerprint: string;
+  expiresAt: string;
+  passphrase: string;
+}
+
+export interface OpenedReviewArchive {
+  bundle: Uint8Array;
+  packFingerprint: string;
+  expiresAt: string;
+}
+
+export class ReviewArchiveExpiredError extends Error {
+  constructor(public readonly expiresAt: string) {
+    super(`Review archive expired at ${expiresAt}.`);
+    this.name = 'ReviewArchiveExpiredError';
+  }
+}
+
+export class ReviewArchiveAuthError extends Error {
+  constructor() {
+    super('Wrong passphrase or corrupted review archive.');
+    this.name = 'ReviewArchiveAuthError';
+  }
+}
+
+export class ReviewArchiveMalformedError extends Error {
+  constructor(message = 'Not a LeaseGuard review archive.') {
+    super(message);
+    this.name = 'ReviewArchiveMalformedError';
+  }
+}
+
+export async function exportReviewArchive(
+  input: ExportReviewArchiveInput,
+): Promise<Uint8Array> {
+  const salt = randomBytes(SALT_LEN);
+  const iv = randomBytes(IV_LEN);
+  const key = await deriveKey(input.passphrase, salt);
+  const ciphertext = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv: iv as BufferSource },
+      key,
+      input.bundle as BufferSource,
+    ),
+  );
+  const envelope: ReviewEnvelope = {
+    magic: MAGIC,
+    version: VERSION,
+    packFingerprint: input.packFingerprint,
+    expiresAt: input.expiresAt,
+    salt: toBase64(salt),
+    iv: toBase64(iv),
+    ciphertext: toBase64(ciphertext),
+  };
+  // Copy through `new Uint8Array(...)` so the result is a Uint8Array of the
+  // ambient realm (TextEncoder in some test envs returns a Node-realm
+  // instance that fails `instanceof Uint8Array` against the jsdom global).
+  return new Uint8Array(new TextEncoder().encode(JSON.stringify(envelope)));
+}
+
+export async function importReviewArchive(
+  bytes: Uint8Array,
+  passphrase: string,
+  opts: { now?: Date } = {},
+): Promise<OpenedReviewArchive> {
+  const envelope = parseEnvelope(bytes);
+  const now = opts.now ?? new Date();
+  const expiresAtMs = Date.parse(envelope.expiresAt);
+  if (Number.isFinite(expiresAtMs) && expiresAtMs <= now.getTime()) {
+    throw new ReviewArchiveExpiredError(envelope.expiresAt);
+  }
+  const salt = fromBase64(envelope.salt);
+  const iv = fromBase64(envelope.iv);
+  const ciphertext = fromBase64(envelope.ciphertext);
+  const key = await deriveKey(passphrase, salt);
+  let plaintext: ArrayBuffer;
+  try {
+    plaintext = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: iv as BufferSource },
+      key,
+      ciphertext as BufferSource,
+    );
+  } catch {
+    throw new ReviewArchiveAuthError();
+  }
+  // Copy bytes into a fresh Uint8Array (ambient realm) — see the export
+  // path for the realm-mismatch rationale.
+  // Match the realm of `TextEncoder().encode()` so deep-equality against
+  // bytes produced that way (e.g. in tests) succeeds. Some test
+  // environments expose a TextEncoder whose Uint8Array subclass differs
+  // from `globalThis.Uint8Array`.
+  const TENC_CTOR = (new TextEncoder().encode('') as Uint8Array).constructor as Uint8ArrayConstructor;
+  const view = new Uint8Array(plaintext);
+  const plain = new TENC_CTOR(view.length);
+  plain.set(view);
+  return {
+    bundle: plain,
+    packFingerprint: envelope.packFingerprint,
+    expiresAt: envelope.expiresAt,
+  };
+}
+
+function parseEnvelope(bytes: Uint8Array): ReviewEnvelope {
+  let text: string;
+  try {
+    text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    throw new ReviewArchiveMalformedError();
+  }
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    throw new ReviewArchiveMalformedError();
+  }
+  if (!raw || typeof raw !== 'object') {
+    throw new ReviewArchiveMalformedError();
+  }
+  const obj = raw as Record<string, unknown>;
+  if (obj.magic !== MAGIC) {
+    throw new ReviewArchiveMalformedError();
+  }
+  if (typeof obj.version !== 'number') {
+    throw new ReviewArchiveMalformedError('Unsupported review archive version.');
+  }
+  if (
+    typeof obj.packFingerprint !== 'string'
+    || typeof obj.expiresAt !== 'string'
+    || typeof obj.salt !== 'string'
+    || typeof obj.iv !== 'string'
+    || typeof obj.ciphertext !== 'string'
+  ) {
+    throw new ReviewArchiveMalformedError();
+  }
+  return {
+    magic: MAGIC,
+    version: obj.version,
+    packFingerprint: obj.packFingerprint,
+    expiresAt: obj.expiresAt,
+    salt: obj.salt,
+    iv: obj.iv,
+    ciphertext: obj.ciphertext,
+  };
+}
+
+async function deriveKey(passphrase: string, salt: Uint8Array): Promise<CryptoKey> {
+  const material = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(passphrase) as BufferSource,
+    { name: 'PBKDF2' },
+    false,
+    ['deriveKey'],
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: salt as BufferSource,
+      iterations: PBKDF2_ITERATIONS,
+      hash: 'SHA-256',
+    },
+    material,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+function randomBytes(length: number): Uint8Array {
+  const out = new Uint8Array(length);
+  crypto.getRandomValues(out);
+  return out;
+}
+
+function toBase64(bytes: Uint8Array): string {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) {
+    bin += String.fromCharCode(bytes[i] as number);
+  }
+  return btoa(bin);
+}
+
+function fromBase64(b64: string): Uint8Array {
+  let bin: string;
+  try {
+    bin = atob(b64);
+  } catch {
+    throw new ReviewArchiveMalformedError();
+  }
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) {
+    out[i] = bin.charCodeAt(i);
+  }
+  return out;
+}

--- a/app/src/ui/OpenReviewPanel.test.tsx
+++ b/app/src/ui/OpenReviewPanel.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+// Wave 9 Part A — component does not exist yet; failing import is the red
+// signal. The implementer creates `app/src/ui/OpenReviewPanel.tsx`
+// exporting a `OpenReviewPanel` React component with this prop shape:
+//
+//   interface OpenReviewPanelProps {
+//     // Recipient drops a `.lgreview` file. The panel reads its bytes,
+//     // prompts for the passphrase, and calls `onOpen`.
+//     onOpen: (input: {
+//       bytes: Uint8Array;
+//       passphrase: string;
+//     }) => Promise<{ ok: true; archiveId: string; expiresAt: string }
+//                  | { ok: false; reason: 'wrong-passphrase' | 'expired' | 'missing-pack' | 'malformed' }>;
+//   }
+import { OpenReviewPanel } from './OpenReviewPanel';
+
+function file(): File {
+  return new File([new Uint8Array([1, 2, 3, 4])], 'review.lgreview', {
+    type: 'application/octet-stream',
+  });
+}
+
+describe('OpenReviewPanel', () => {
+  it('happy path: drops a file, types passphrase, mounts the lease in review mode', async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn(async () => ({ ok: true as const, archiveId: 'a1', expiresAt: 'z' }));
+    render(<OpenReviewPanel onOpen={onOpen} />);
+    await user.upload(screen.getByLabelText(/file|archive/i) as HTMLInputElement, file());
+    await user.type(screen.getByLabelText(/passphrase/i), 'a-strong-passphrase-12345');
+    await user.click(screen.getByRole('button', { name: /open/i }));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText(/review mode|read-only/i)).toBeInTheDocument();
+  });
+
+  it('surfaces a clear "wrong passphrase" error', async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn(async () => ({ ok: false as const, reason: 'wrong-passphrase' as const }));
+    render(<OpenReviewPanel onOpen={onOpen} />);
+    await user.upload(screen.getByLabelText(/file|archive/i) as HTMLInputElement, file());
+    await user.type(screen.getByLabelText(/passphrase/i), 'wrong-pass-123');
+    await user.click(screen.getByRole('button', { name: /open/i }));
+    expect(await screen.findByText(/wrong|incorrect|passphrase/i)).toBeInTheDocument();
+  });
+
+  it('surfaces a clear "expired" error', async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn(async () => ({ ok: false as const, reason: 'expired' as const }));
+    render(<OpenReviewPanel onOpen={onOpen} />);
+    await user.upload(screen.getByLabelText(/file|archive/i) as HTMLInputElement, file());
+    await user.type(screen.getByLabelText(/passphrase/i), 'a-strong-passphrase-12345');
+    await user.click(screen.getByRole('button', { name: /open/i }));
+    expect(await screen.findByText(/expired/i)).toBeInTheDocument();
+  });
+
+  it('surfaces a clear "missing pack" error when recipient lacks the signed pack', async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn(async () => ({ ok: false as const, reason: 'missing-pack' as const }));
+    render(<OpenReviewPanel onOpen={onOpen} />);
+    await user.upload(screen.getByLabelText(/file|archive/i) as HTMLInputElement, file());
+    await user.type(screen.getByLabelText(/passphrase/i), 'a-strong-passphrase-12345');
+    await user.click(screen.getByRole('button', { name: /open/i }));
+    expect(await screen.findByText(/missing.*pack|install.*pack/i)).toBeInTheDocument();
+  });
+});

--- a/app/src/ui/OpenReviewPanel.tsx
+++ b/app/src/ui/OpenReviewPanel.tsx
@@ -1,0 +1,117 @@
+import { useState, type ChangeEvent, type FormEvent } from 'react';
+
+export type OpenReviewResult =
+  | { ok: true; archiveId: string; expiresAt: string }
+  | { ok: false; reason: 'wrong-passphrase' | 'expired' | 'missing-pack' | 'malformed' };
+
+export interface OpenReviewPanelProps {
+  onOpen: (input: { bytes: Uint8Array; passphrase: string }) => Promise<OpenReviewResult>;
+}
+
+const REASON_MESSAGES: Record<
+  Extract<OpenReviewResult, { ok: false }>['reason'],
+  string
+> = {
+  'wrong-passphrase': 'Wrong or incorrect key — check what you typed.',
+  expired: 'This review archive has expired.',
+  'missing-pack': 'Missing rule pack — install the matching signed pack.',
+  malformed: 'This file is not a LeaseGuard review archive.',
+};
+
+async function readFileBytes(file: File): Promise<Uint8Array> {
+  if (typeof file.arrayBuffer === 'function') {
+    try {
+      return new Uint8Array(await file.arrayBuffer());
+    } catch {
+      // fall through to FileReader
+    }
+  }
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const buf = reader.result;
+      if (buf instanceof ArrayBuffer) resolve(new Uint8Array(buf));
+      else reject(new Error('Could not read file.'));
+    };
+    reader.onerror = () => reject(reader.error ?? new Error('Could not read file.'));
+    reader.readAsArrayBuffer(file);
+  });
+}
+
+export function OpenReviewPanel({ onOpen }: OpenReviewPanelProps): JSX.Element {
+  const [file, setFile] = useState<File | null>(null);
+  const [passphrase, setPassphrase] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<{ archiveId: string; expiresAt: string } | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  function handleFile(event: ChangeEvent<HTMLInputElement>): void {
+    setError(null);
+    setSuccess(null);
+    const next = event.target.files?.[0] ?? null;
+    setFile(next);
+  }
+
+  async function handleSubmit(event: FormEvent): Promise<void> {
+    event.preventDefault();
+    setError(null);
+    if (!file) {
+      setError('Choose a .lgreview file first.');
+      return;
+    }
+    if (!passphrase) {
+      setError('Enter the passphrase.');
+      return;
+    }
+    setBusy(true);
+    try {
+      const bytes = await readFileBytes(file);
+      const result = await onOpen({ bytes, passphrase });
+      if (result.ok) {
+        setSuccess({ archiveId: result.archiveId, expiresAt: result.expiresAt });
+      } else {
+        setError(REASON_MESSAGES[result.reason]);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to open archive.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form className="open-review-panel" onSubmit={handleSubmit} aria-label="Open review">
+      <h3>Open a review archive</h3>
+      <p>
+        Drop a <code>.lgreview</code> file. The lease will mount as a
+        non-editable session — your audit log records this session separately
+        and writes back to the original lease are gated off.
+      </p>
+      <label>
+        Review archive file
+        <input
+          type="file"
+          accept=".lgreview,application/octet-stream"
+          onChange={handleFile}
+        />
+      </label>
+      <input
+        type="password"
+        aria-label="Passphrase"
+        value={passphrase}
+        onChange={(e) => setPassphrase(e.target.value)}
+        autoComplete="current-password"
+      />
+      {error && <p role="alert" className="error">{error}</p>}
+      {success && (
+        <p role="status" className="success">
+          Mounted in review mode (archive {success.archiveId}, expires{' '}
+          {success.expiresAt}).
+        </p>
+      )}
+      <button type="submit" disabled={busy}>
+        {busy ? 'Opening…' : 'Open review'}
+      </button>
+    </form>
+  );
+}

--- a/app/src/ui/ShareReviewPanel.stories.tsx
+++ b/app/src/ui/ShareReviewPanel.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ShareReviewPanel } from './ShareReviewPanel';
+
+const meta = {
+  title: 'UI/ShareReviewPanel',
+  component: ShareReviewPanel,
+  args: {
+    onGenerate: async () => new Uint8Array([1, 2, 3]),
+  },
+} satisfies Meta<typeof ShareReviewPanel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const SignedLeaseReady: Story = {
+  args: {
+    lease: { id: 'lease-1', name: 'Apt 4B Lease.pdf', signedPack: true },
+  },
+};
+
+export const UnsignedLeaseBlocked: Story = {
+  args: {
+    lease: { id: 'lease-2', name: 'Old Lease.pdf', signedPack: false },
+  },
+};
+
+export const NoLeaseSelected: Story = {
+  args: {
+    lease: null,
+  },
+};

--- a/app/src/ui/ShareReviewPanel.test.tsx
+++ b/app/src/ui/ShareReviewPanel.test.tsx
@@ -25,7 +25,10 @@ function lease(over: Partial<{ id: string; name: string; signedPack: boolean }> 
 describe('ShareReviewPanel', () => {
   it('happy path: generates a review archive when passphrase + expiry are valid', async () => {
     const user = userEvent.setup();
-    const onGenerate = vi.fn(async () => new Uint8Array([1, 2, 3]));
+    const onGenerate = vi.fn<
+      [{ leaseId: string; passphrase: string; expiresAt: string }],
+      Promise<Uint8Array>
+    >(async () => new Uint8Array([1, 2, 3]));
     render(<ShareReviewPanel lease={lease()} onGenerate={onGenerate} />);
     await user.type(screen.getByLabelText(/passphrase/i), 'a-strong-passphrase-12345');
     const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)

--- a/app/src/ui/ShareReviewPanel.test.tsx
+++ b/app/src/ui/ShareReviewPanel.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+// Wave 9 Part A — component does not exist yet; failing import is the red
+// signal. The implementer creates `app/src/ui/ShareReviewPanel.tsx`
+// exporting a `ShareReviewPanel` React component with this prop shape:
+//
+//   interface ShareReviewPanelProps {
+//     // The currently-selected lease record. Null means "no lease picked".
+//     lease: { id: string; name: string; signedPack: boolean } | null;
+//     // Called when the user clicks "Generate review link" with a valid
+//     // passphrase + future expiry; receives the encoded `.lgreview` bytes.
+//     onGenerate: (input: {
+//       leaseId: string;
+//       passphrase: string;
+//       expiresAt: string;
+//     }) => Promise<Uint8Array>;
+//   }
+import { ShareReviewPanel } from './ShareReviewPanel';
+
+function lease(over: Partial<{ id: string; name: string; signedPack: boolean }> = {}) {
+  return { id: 'lease-1', name: 'Apt 4B Lease.pdf', signedPack: true, ...over };
+}
+
+describe('ShareReviewPanel', () => {
+  it('happy path: generates a review archive when passphrase + expiry are valid', async () => {
+    const user = userEvent.setup();
+    const onGenerate = vi.fn(async () => new Uint8Array([1, 2, 3]));
+    render(<ShareReviewPanel lease={lease()} onGenerate={onGenerate} />);
+    await user.type(screen.getByLabelText(/passphrase/i), 'a-strong-passphrase-12345');
+    const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    await user.clear(screen.getByLabelText(/expir/i));
+    await user.type(screen.getByLabelText(/expir/i), future);
+    await user.click(screen.getByRole('button', { name: /generate/i }));
+    expect(onGenerate).toHaveBeenCalledTimes(1);
+    expect(onGenerate.mock.calls[0]?.[0]?.leaseId).toBe('lease-1');
+  });
+
+  it('refuses to submit a passphrase that fails the strength check', async () => {
+    const user = userEvent.setup();
+    const onGenerate = vi.fn();
+    render(<ShareReviewPanel lease={lease()} onGenerate={onGenerate} />);
+    await user.type(screen.getByLabelText(/passphrase/i), 'short');
+    await user.click(screen.getByRole('button', { name: /generate/i }));
+    expect(onGenerate).not.toHaveBeenCalled();
+    expect(screen.getByText(/passphrase/i)).toBeInTheDocument();
+  });
+
+  it('refuses to submit an expiry date in the past', async () => {
+    const user = userEvent.setup();
+    const onGenerate = vi.fn();
+    render(<ShareReviewPanel lease={lease()} onGenerate={onGenerate} />);
+    await user.type(screen.getByLabelText(/passphrase/i), 'a-strong-passphrase-12345');
+    await user.clear(screen.getByLabelText(/expir/i));
+    await user.type(screen.getByLabelText(/expir/i), '2000-01-01');
+    await user.click(screen.getByRole('button', { name: /generate/i }));
+    expect(onGenerate).not.toHaveBeenCalled();
+  });
+
+  it('disables generation when the lease is not backed by a signed pack', async () => {
+    const onGenerate = vi.fn();
+    render(<ShareReviewPanel lease={lease({ signedPack: false })} onGenerate={onGenerate} />);
+    expect(screen.getByRole('button', { name: /generate/i })).toBeDisabled();
+  });
+});

--- a/app/src/ui/ShareReviewPanel.tsx
+++ b/app/src/ui/ShareReviewPanel.tsx
@@ -1,0 +1,99 @@
+import { useState, type FormEvent } from 'react';
+
+export interface ShareReviewPanelProps {
+  lease: { id: string; name: string; signedPack: boolean } | null;
+  onGenerate: (input: {
+    leaseId: string;
+    passphrase: string;
+    expiresAt: string;
+  }) => Promise<Uint8Array>;
+}
+
+const MIN_PASSPHRASE_LEN = 16;
+
+function defaultExpiry(): string {
+  return new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+}
+
+export function ShareReviewPanel({ lease, onGenerate }: ShareReviewPanelProps): JSX.Element {
+  const [passphrase, setPassphrase] = useState('');
+  const [expiry, setExpiry] = useState<string>(defaultExpiry());
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const signedPack = lease?.signedPack ?? false;
+  const disabled = !lease || !signedPack || busy;
+
+  async function handleSubmit(event: FormEvent): Promise<void> {
+    event.preventDefault();
+    setError(null);
+    if (!lease) {
+      setError('Pick a lease first.');
+      return;
+    }
+    if (passphrase.length < MIN_PASSPHRASE_LEN) {
+      setError(`Passphrase must be at least ${MIN_PASSPHRASE_LEN} characters.`);
+      return;
+    }
+    const expiresMs = Date.parse(`${expiry}T23:59:59Z`);
+    if (!Number.isFinite(expiresMs) || expiresMs <= Date.now()) {
+      setError('Expiry must be a future date.');
+      return;
+    }
+    setBusy(true);
+    try {
+      await onGenerate({
+        leaseId: lease.id,
+        passphrase,
+        expiresAt: new Date(expiresMs).toISOString(),
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to generate archive.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form className="share-review-panel" onSubmit={handleSubmit} aria-label="Share review">
+      <h3>Share for review</h3>
+      <p>
+        Generates an expiring, key-protected <code>.lgreview</code> file.
+        The recipient opens it locally; nothing leaves your device.
+      </p>
+      {lease ? (
+        <p>
+          Lease: <strong>{lease.name}</strong>
+          {!signedPack && (
+            <>
+              {' '}<span role="alert">Requires a signed pack to share.</span>
+            </>
+          )}
+        </p>
+      ) : (
+        <p role="alert">No lease selected.</p>
+      )}
+      <input
+        type="password"
+        aria-label="Passphrase"
+        value={passphrase}
+        onChange={(e) => setPassphrase(e.target.value)}
+        autoComplete="new-password"
+      />
+      <label>
+        Expires on
+        <input
+          type="date"
+          value={expiry}
+          onChange={(e) => setExpiry(e.target.value)}
+        />
+      </label>
+      {error && <p role="alert" className="error">{error}</p>}
+      <button type="submit" disabled={disabled}>
+        {busy ? 'Generating…' : 'Generate review link'}
+      </button>
+    </form>
+  );
+}

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -289,6 +289,36 @@ table for the authoritative figures):
 - Archive export/import uses WebCrypto AES-GCM. No handshake ever
   leaves the device.
 
+## Collaboration escape hatches
+
+Wave 9 adds three offline-first sharing surfaces. None of them open a
+network socket; archives travel over user-initiated file export, and
+recipients open them by drag/drop. The **review archive** (Part A) is
+the foundational primitive:
+
+- File extension: `.lgreview`. On-disk shape is a UTF-8 JSON envelope:
+  `{ magic: "LGREVIEW", version: 1, packFingerprint, expiresAt, salt,
+  iv, ciphertext }` with `salt`, `iv`, `ciphertext` base64-encoded so
+  the CLI verifier (Part D) can read metadata without a binary parser.
+- Encryption: AES-GCM, 256-bit key, fresh 12-byte random IV per
+  archive. The 128-bit auth tag is the AES-GCM tag baked into the
+  ciphertext output by WebCrypto — there is no separate HMAC. A
+  single-bit flip anywhere in the ciphertext fails decrypt with an
+  authentication error and the archive is rejected.
+- Key derivation: PBKDF2-HMAC-SHA-256, 250 000 iterations, fresh
+  16-byte random salt per archive. Salt is stored in the envelope; the
+  passphrase is held only in memory and is never persisted.
+- Expiry: ISO-8601 timestamp checked against `Date.now()` (or an
+  injected `now` for tests) before decrypt is attempted. Expired
+  archives surface a clear "expired" error.
+- What is NOT included: telemetry, key escrow, IDB dumps beyond the
+  chosen lease's replay bundle, network egress, server-side
+  share-link hosting.
+- Recipient trust model: the recipient sees a read-only review session;
+  audit writes back to the original lease are gated off (Part B may
+  route a separate "review-session" audit log). Possession of the
+  passphrase + a matching signed pack is the only authentication.
+
 ## Performance
 
 - 50-page parse budget 3s (CI measures ~210ms on the synthetic fixture).


### PR DESCRIPTION
## Summary
- AES-GCM-256 + PBKDF2-SHA256 (250k iter) `.lgreview` envelope wrapping a replay bundle (`reviewArchive.ts`)
- `ShareReviewPanel` (passphrase strength + future-expiry validation, signed-pack-required) and `OpenReviewPanel` (drop/upload, passphrase, expiry/pack checks) — read-only review-mode lift via new `useReviewMode` hook
- `SYSTEM_DESIGN.md` "Collaboration escape hatches" subsection: envelope shape, pinned crypto params, no-network claim, recipient-trust model

## Test plan
- [x] 15/15 owned tests green; full app suite green; typecheck + lint clean
- [x] Reviewer subagent: no blocking findings; crypto envelope identical to CLI decoder (Part D)
- [ ] CI green