### PR TITLE
test(wave9-C): failing acceptance specs for delta packets

### DIFF
--- a/app/src/ui/DeltaPanel.test.tsx
+++ b/app/src/ui/DeltaPanel.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+// Wave 9 Part C — component does not yet exist; failing import is the red
+// signal. The implementer creates `app/src/ui/DeltaPanel.tsx` exporting
+// `DeltaPanel` with this prop shape:
+//
+//   interface DeltaPanelProps {
+//     versions: { id: string; label: string }[];   // history rows
+//     onGenerate: (input: {
+//       baseVersionId: string;
+//       targetVersionId: string;
+//       passphrase: string;
+//     }) => Promise<Uint8Array>;                   // .lgdelta bytes
+//   }
+import { DeltaPanel } from './DeltaPanel';
+
+const versions = [
+  { id: 'v1', label: 'Version 1' },
+  { id: 'v2', label: 'Version 2' },
+];
+
+describe('DeltaPanel', () => {
+  it('renders the history rows and disables generate until base + target are picked', () => {
+    render(<DeltaPanel versions={versions} onGenerate={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /generate|export/i })).toBeDisabled();
+  });
+
+  it('happy path: pick base + target + passphrase invokes onGenerate with those ids', async () => {
+    const user = userEvent.setup();
+    const onGenerate = vi.fn(async () => new Uint8Array([1]));
+    render(<DeltaPanel versions={versions} onGenerate={onGenerate} />);
+    await user.selectOptions(screen.getByLabelText(/base/i), 'v1');
+    await user.selectOptions(screen.getByLabelText(/target/i), 'v2');
+    await user.type(screen.getByLabelText(/passphrase/i), 'a-strong-passphrase-12345');
+    await user.click(screen.getByRole('button', { name: /generate|export/i }));
+    expect(onGenerate).toHaveBeenCalledTimes(1);
+    expect(onGenerate.mock.calls[0]?.[0]?.baseVersionId).toBe('v1');
+    expect(onGenerate.mock.calls[0]?.[0]?.targetVersionId).toBe('v2');
+  });
+});

--- a/app/src/ui/OpenDeltaPanel.test.tsx
+++ b/app/src/ui/OpenDeltaPanel.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+// Wave 9 Part C — component does not yet exist; failing import is the red
+// signal. The implementer creates `app/src/ui/OpenDeltaPanel.tsx`
+// exporting `OpenDeltaPanel` with this prop shape:
+//
+//   interface OpenDeltaPanelProps {
+//     // Recipient drops a `.lgdelta` file. The panel reads its bytes,
+//     // verifies the signature, previews the changes, and on confirm
+//     // calls onApply.
+//     onPreview: (bytes: Uint8Array) => Promise<{ ok: true; preview: string }
+//                                              | { ok: false; reason: string }>;
+//     onApply: () => Promise<void>;
+//   }
+import { OpenDeltaPanel } from './OpenDeltaPanel';
+
+function file(): File {
+  return new File([new Uint8Array([1, 2, 3])], 'patch.lgdelta');
+}
+
+describe('OpenDeltaPanel', () => {
+  it('previews the changes after a successful drop + verify', async () => {
+    const user = userEvent.setup();
+    const onPreview = vi.fn(async () => ({ ok: true as const, preview: '+ rent: 1100' }));
+    render(<OpenDeltaPanel onPreview={onPreview} onApply={vi.fn()} />);
+    await user.upload(screen.getByLabelText(/file|delta/i) as HTMLInputElement, file());
+    expect(await screen.findByText(/\+ rent: 1100/)).toBeInTheDocument();
+  });
+
+  it('surfaces a clear error when verification fails', async () => {
+    const user = userEvent.setup();
+    const onPreview = vi.fn(async () => ({ ok: false as const, reason: 'signature invalid' }));
+    render(<OpenDeltaPanel onPreview={onPreview} onApply={vi.fn()} />);
+    await user.upload(screen.getByLabelText(/file|delta/i) as HTMLInputElement, file());
+    expect(await screen.findByText(/signature invalid/i)).toBeInTheDocument();
+  });
+});

--- a/app/src/versioning/applyDelta.test.ts
+++ b/app/src/versioning/applyDelta.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+// Wave 9 Part C — module under test does not yet exist; failing import is
+// the expected red signal. The implementer creates
+// `app/src/versioning/applyDelta.ts` exporting:
+//
+//   applyDeltaPacket(input: {
+//     packet: DeltaPacket;        // see deltaPacket.ts
+//     localBaseBytes: Uint8Array; // recipient's current lease bytes
+//   }): Promise<{ mergedBytes: Uint8Array }>
+//
+// On success it MUST:
+//  - call verifyDeltaPacket(packet) and refuse on bad signature
+//  - hash localBaseBytes and refuse with a "version mismatch" error if it
+//    doesn't equal packet.baseInputHash
+//  - apply the line-diff in packet.changes and return the merged bytes
+//    that line-equal the original target
+import type { DeltaPacket } from './deltaPacket';
+import { buildDeltaPacket } from './deltaPacket';
+import { applyDeltaPacket } from './applyDelta';
+
+async function genKey(): Promise<CryptoKeyPair> {
+  return (await crypto.subtle.generateKey(
+    { name: 'Ed25519' } as unknown as AlgorithmIdentifier,
+    true,
+    ['sign', 'verify'],
+  )) as CryptoKeyPair;
+}
+
+function bytes(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+describe('applyDeltaPacket', () => {
+  it('round-trip: apply(diff(v1, v2)) on recipient v1 yields exactly v2 bytes', async () => {
+    const key = await genKey();
+    const v1 = bytes('rent: 1000\nterm: 12mo\n');
+    const v2 = bytes('rent: 1100\nterm: 24mo\n');
+    const packet = await buildDeltaPacket({
+      baseBytes: v1,
+      targetBytes: v2,
+      rulePackVersion: '1.0.0',
+      signingKey: key,
+      signedByKeyId: 'key-1',
+    });
+    const { mergedBytes } = await applyDeltaPacket({ packet, localBaseBytes: v1 });
+    expect(new TextDecoder().decode(mergedBytes)).toBe(new TextDecoder().decode(v2));
+  });
+
+  it('refuses with a clear "version mismatch" error when localBaseBytes differs from baseInputHash', async () => {
+    const key = await genKey();
+    const v1 = bytes('rent: 1000\n');
+    const v2 = bytes('rent: 1100\n');
+    const packet = await buildDeltaPacket({
+      baseBytes: v1,
+      targetBytes: v2,
+      rulePackVersion: '1.0.0',
+      signingKey: key,
+      signedByKeyId: 'key-1',
+    });
+    const drifted = bytes('rent: 1234\n');
+    await expect(
+      applyDeltaPacket({ packet, localBaseBytes: drifted }),
+    ).rejects.toThrow(/version mismatch|baseInputHash/i);
+  });
+
+  it('refuses to apply a delta whose signature does not verify', async () => {
+    const key = await genKey();
+    const v1 = bytes('a\n');
+    const v2 = bytes('b\n');
+    const packet = await buildDeltaPacket({
+      baseBytes: v1,
+      targetBytes: v2,
+      rulePackVersion: '1.0.0',
+      signingKey: key,
+      signedByKeyId: 'key-1',
+    });
+    const tampered: DeltaPacket = { ...packet, signature: 'AAAA' };
+    await expect(
+      applyDeltaPacket({ packet: tampered, localBaseBytes: v1 }),
+    ).rejects.toThrow(/signature/i);
+  });
+});

--- a/app/src/versioning/deltaPacket.test.ts
+++ b/app/src/versioning/deltaPacket.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+// Wave 9 Part C — module under test does not yet exist; failing import is
+// the expected red signal. The implementer creates
+// `app/src/versioning/deltaPacket.ts` exporting:
+//
+//   interface DeltaPacket {
+//     baseInputHash: string;        // hex sha-256 of canonical base lease bytes
+//     targetInputHash: string;      // hex sha-256 of canonical target lease bytes
+//     changes: string;              // line-level unified diff (text)
+//     rulePackVersion: string;
+//     signature: string;            // base64
+//     signedByKeyId: string;
+//     signedByPublicKey: string;    // base64 SPKI
+//   }
+//
+//   buildDeltaPacket(input: {
+//     baseBytes: Uint8Array;
+//     targetBytes: Uint8Array;
+//     rulePackVersion: string;
+//     signingKey: CryptoKeyPair;
+//     signedByKeyId: string;
+//   }): Promise<DeltaPacket>
+//
+//   verifyDeltaPacket(packet: DeltaPacket): Promise<{ ok: boolean }>
+import { buildDeltaPacket, verifyDeltaPacket } from './deltaPacket';
+
+async function genKey(): Promise<CryptoKeyPair> {
+  return (await crypto.subtle.generateKey(
+    { name: 'Ed25519' } as unknown as AlgorithmIdentifier,
+    true,
+    ['sign', 'verify'],
+  )) as CryptoKeyPair;
+}
+
+function bytes(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+describe('deltaPacket', () => {
+  it('round-trip: build a signed delta and verify it under the embedded public key', async () => {
+    const key = await genKey();
+    const base = bytes('rent: 1000\nterm: 12mo\n');
+    const target = bytes('rent: 1100\nterm: 12mo\n');
+    const packet = await buildDeltaPacket({
+      baseBytes: base,
+      targetBytes: target,
+      rulePackVersion: '1.0.0',
+      signingKey: key,
+      signedByKeyId: 'key-1',
+    });
+    expect(packet.changes.length).toBeGreaterThan(0);
+    expect(packet.baseInputHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(packet.targetInputHash).toMatch(/^[0-9a-f]{64}$/);
+    const r = await verifyDeltaPacket(packet);
+    expect(r.ok).toBe(true);
+  });
+
+  it('signature still verifies after the signer rotates keys (retired = verify-only)', async () => {
+    // Wave 8-D semantics: a retired key can still verify previously signed
+    // material. We model that by re-running verify on a packet whose key
+    // material is unchanged — verifyDeltaPacket relies only on the embedded
+    // signedByPublicKey, NOT a live key directory.
+    const key = await genKey();
+    const packet = await buildDeltaPacket({
+      baseBytes: bytes('a'),
+      targetBytes: bytes('b'),
+      rulePackVersion: '1.0.0',
+      signingKey: key,
+      signedByKeyId: 'rotated-out-key',
+    });
+    const r = await verifyDeltaPacket(packet);
+    expect(r.ok).toBe(true);
+  });
+
+  it('tampering with changes invalidates the signature', async () => {
+    const key = await genKey();
+    const packet = await buildDeltaPacket({
+      baseBytes: bytes('a'),
+      targetBytes: bytes('b'),
+      rulePackVersion: '1.0.0',
+      signingKey: key,
+      signedByKeyId: 'key-1',
+    });
+    const tampered = { ...packet, changes: packet.changes + '\n+rogue line' };
+    const r = await verifyDeltaPacket(tampered);
+    expect(r.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
Pin the contract for Wave 9 Part C before implementation: deltaPacket build/verify with Ed25519 signature, applyDelta baseInputHash check
+ refusal on version mismatch, and the DeltaPanel / OpenDeltaPanel UI flows. All four files import unimplemented modules and fail at resolve-time.