### PR TITLE
test(wave9-A): failing acceptance specs for signed review links

### DIFF
--- a/app/src/App/useReviewMode.test.ts
+++ b/app/src/App/useReviewMode.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+// Wave 9 Part A — module does not exist yet; failing import is the red
+// signal. The implementer creates `app/src/App/useReviewMode.ts`
+// exporting a hook + provider with this shape:
+//
+//   type ReviewMode =
+//     | { active: true; archiveId: string; expiresAt: string }
+//     | { active: false };
+//
+//   export function useReviewMode(): {
+//     mode: ReviewMode;
+//     enter(args: { archiveId: string; expiresAt: string }): void;
+//     exit(): void;
+//   };
+//
+//   export function ReviewModeProvider(props: { children: React.ReactNode }):
+//     JSX.Element;
+import { useReviewMode, ReviewModeProvider } from './useReviewMode';
+
+describe('useReviewMode', () => {
+  it('defaults to inactive when no provider state has been set', () => {
+    const { result } = renderHook(() => useReviewMode(), { wrapper: ReviewModeProvider });
+    expect(result.current.mode.active).toBe(false);
+  });
+
+  it('enter() sets active=true with archiveId + expiresAt; exit() returns to inactive', () => {
+    const { result } = renderHook(() => useReviewMode(), { wrapper: ReviewModeProvider });
+    act(() => {
+      result.current.enter({ archiveId: 'arch-1', expiresAt: '2099-01-01T00:00:00Z' });
+    });
+    expect(result.current.mode).toEqual({
+      active: true,
+      archiveId: 'arch-1',
+      expiresAt: '2099-01-01T00:00:00Z',
+    });
+    act(() => {
+      result.current.exit();
+    });
+    expect(result.current.mode.active).toBe(false);
+  });
+});

--- a/app/src/storage/reviewArchive.test.ts
+++ b/app/src/storage/reviewArchive.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+// Wave 9 Part A — module under test does not yet exist. The failing import
+// is the expected red signal until the implementer creates
+// `app/src/storage/reviewArchive.ts` exporting:
+//
+//   exportReviewArchive(input: {
+//     bundle: Uint8Array;          // a Wave 8 replay bundle
+//     packFingerprint: string;     // hex sha-256 of the signed pack
+//     expiresAt: string;           // ISO-8601
+//     passphrase: string;
+//   }): Promise<Uint8Array>        // an AES-GCM envelope (PBKDF2-derived key)
+//
+//   importReviewArchive(bytes: Uint8Array, passphrase: string, opts?: {
+//     now?: Date;
+//   }): Promise<{ bundle: Uint8Array; packFingerprint: string; expiresAt: string }>
+//
+//   The envelope must carry { packFingerprint, expiresAt, ciphertext, iv,
+//   salt, version } and be tamper-evident via AES-GCM auth tag.
+import {
+  exportReviewArchive,
+  importReviewArchive,
+} from './reviewArchive';
+
+const PASSPHRASE = 'correct horse battery staple';
+const FUTURE_EXPIRY = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+const PAST_EXPIRY = new Date(Date.now() - 60_000).toISOString();
+const FAKE_FINGERPRINT = 'a'.repeat(64);
+
+function bundle(): Uint8Array {
+  return new TextEncoder().encode('PKfake-replay-bundle-bytes');
+}
+
+describe('reviewArchive', () => {
+  it('round-trips: encrypt → decrypt yields a byte-identical inner bundle', async () => {
+    const inner = bundle();
+    const envelope = await exportReviewArchive({
+      bundle: inner,
+      packFingerprint: FAKE_FINGERPRINT,
+      expiresAt: FUTURE_EXPIRY,
+      passphrase: PASSPHRASE,
+    });
+    expect(envelope).toBeInstanceOf(Uint8Array);
+    const opened = await importReviewArchive(envelope, PASSPHRASE);
+    expect(opened.bundle).toEqual(inner);
+    expect(opened.packFingerprint).toBe(FAKE_FINGERPRINT);
+    expect(opened.expiresAt).toBe(FUTURE_EXPIRY);
+  });
+
+  it('rejects an expired archive with a clear error', async () => {
+    const envelope = await exportReviewArchive({
+      bundle: bundle(),
+      packFingerprint: FAKE_FINGERPRINT,
+      expiresAt: PAST_EXPIRY,
+      passphrase: PASSPHRASE,
+    });
+    await expect(importReviewArchive(envelope, PASSPHRASE)).rejects.toThrow(/expired/i);
+  });
+
+  it('rejects a wrong passphrase (AES-GCM auth failure)', async () => {
+    const envelope = await exportReviewArchive({
+      bundle: bundle(),
+      packFingerprint: FAKE_FINGERPRINT,
+      expiresAt: FUTURE_EXPIRY,
+      passphrase: PASSPHRASE,
+    });
+    await expect(importReviewArchive(envelope, 'wrong passphrase')).rejects.toThrow();
+  });
+
+  it('rejects a malformed envelope (bytes do not begin with the magic / shape)', async () => {
+    const garbage = new Uint8Array(64).fill(0x42);
+    await expect(importReviewArchive(garbage, PASSPHRASE)).rejects.toThrow();
+  });
+
+  it('rejects a tampered envelope (single bit flip in the ciphertext)', async () => {
+    const envelope = await exportReviewArchive({
+      bundle: bundle(),
+      packFingerprint: FAKE_FINGERPRINT,
+      expiresAt: FUTURE_EXPIRY,
+      passphrase: PASSPHRASE,
+    });
+    const tampered = new Uint8Array(envelope);
+    const idx = tampered.length - 8;
+    tampered[idx] = ((tampered[idx] ?? 0) ^ 0x01) & 0xff;
+    await expect(importReviewArchive(tampered, PASSPHRASE)).rejects.toThrow();
+  });
+});

--- a/app/src/ui/OpenReviewPanel.test.tsx
+++ b/app/src/ui/OpenReviewPanel.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+// Wave 9 Part A — component does not exist yet; failing import is the red
+// signal. The implementer creates `app/src/ui/OpenReviewPanel.tsx`
+// exporting a `OpenReviewPanel` React component with this prop shape:
+//
+//   interface OpenReviewPanelProps {
+//     // Recipient drops a `.lgreview` file. The panel reads its bytes,
+//     // prompts for the passphrase, and calls `onOpen`.
+//     onOpen: (input: {
+//       bytes: Uint8Array;
+//       passphrase: string;
+//     }) => Promise<{ ok: true; archiveId: string; expiresAt: string }
+//                  | { ok: false; reason: 'wrong-passphrase' | 'expired' | 'missing-pack' | 'malformed' }>;
+//   }
+import { OpenReviewPanel } from './OpenReviewPanel';
+
+function file(): File {
+  return new File([new Uint8Array([1, 2, 3, 4])], 'review.lgreview', {
+    type: 'application/octet-stream',
+  });
+}
+
+describe('OpenReviewPanel', () => {
+  it('happy path: drops a file, types passphrase, mounts the lease in review mode', async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn(async () => ({ ok: true as const, archiveId: 'a1', expiresAt: 'z' }));
+    render(<OpenReviewPanel onOpen={onOpen} />);
+    await user.upload(screen.getByLabelText(/file|archive/i) as HTMLInputElement, file());
+    await user.type(screen.getByLabelText(/passphrase/i), 'a-strong-passphrase-12345');
+    await user.click(screen.getByRole('button', { name: /open/i }));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText(/review mode|read-only/i)).toBeInTheDocument();
+  });
+
+  it('surfaces a clear "wrong passphrase" error', async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn(async () => ({ ok: false as const, reason: 'wrong-passphrase' as const }));
+    render(<OpenReviewPanel onOpen={onOpen} />);
+    await user.upload(screen.getByLabelText(/file|archive/i) as HTMLInputElement, file());
+    await user.type(screen.getByLabelText(/passphrase/i), 'wrong-pass-123');
+    await user.click(screen.getByRole('button', { name: /open/i }));
+    expect(await screen.findByText(/wrong|incorrect|passphrase/i)).toBeInTheDocument();
+  });
+
+  it('surfaces a clear "expired" error', async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn(async () => ({ ok: false as const, reason: 'expired' as const }));
+    render(<OpenReviewPanel onOpen={onOpen} />);
+    await user.upload(screen.getByLabelText(/file|archive/i) as HTMLInputElement, file());
+    await user.type(screen.getByLabelText(/passphrase/i), 'a-strong-passphrase-12345');
+    await user.click(screen.getByRole('button', { name: /open/i }));
+    expect(await screen.findByText(/expired/i)).toBeInTheDocument();
+  });
+
+  it('surfaces a clear "missing pack" error when recipient lacks the signed pack', async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn(async () => ({ ok: false as const, reason: 'missing-pack' as const }));
+    render(<OpenReviewPanel onOpen={onOpen} />);
+    await user.upload(screen.getByLabelText(/file|archive/i) as HTMLInputElement, file());
+    await user.type(screen.getByLabelText(/passphrase/i), 'a-strong-passphrase-12345');
+    await user.click(screen.getByRole('button', { name: /open/i }));
+    expect(await screen.findByText(/missing.*pack|install.*pack/i)).toBeInTheDocument();
+  });
+});

--- a/app/src/ui/ShareReviewPanel.test.tsx
+++ b/app/src/ui/ShareReviewPanel.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+// Wave 9 Part A — component does not exist yet; failing import is the red
+// signal. The implementer creates `app/src/ui/ShareReviewPanel.tsx`
+// exporting a `ShareReviewPanel` React component with this prop shape:
+//
+//   interface ShareReviewPanelProps {
+//     // The currently-selected lease record. Null means "no lease picked".
+//     lease: { id: string; name: string; signedPack: boolean } | null;
+//     // Called when the user clicks "Generate review link" with a valid
+//     // passphrase + future expiry; receives the encoded `.lgreview` bytes.
+//     onGenerate: (input: {
+//       leaseId: string;
+//       passphrase: string;
+//       expiresAt: string;
+//     }) => Promise<Uint8Array>;
+//   }
+import { ShareReviewPanel } from './ShareReviewPanel';
+
+function lease(over: Partial<{ id: string; name: string; signedPack: boolean }> = {}) {
+  return { id: 'lease-1', name: 'Apt 4B Lease.pdf', signedPack: true, ...over };
+}
+
+describe('ShareReviewPanel', () => {
+  it('happy path: generates a review archive when passphrase + expiry are valid', async () => {
+    const user = userEvent.setup();
+    const onGenerate = vi.fn(async () => new Uint8Array([1, 2, 3]));
+    render(<ShareReviewPanel lease={lease()} onGenerate={onGenerate} />);
+    await user.type(screen.getByLabelText(/passphrase/i), 'a-strong-passphrase-12345');
+    const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    await user.clear(screen.getByLabelText(/expir/i));
+    await user.type(screen.getByLabelText(/expir/i), future);
+    await user.click(screen.getByRole('button', { name: /generate/i }));
+    expect(onGenerate).toHaveBeenCalledTimes(1);
+    expect(onGenerate.mock.calls[0]?.[0]?.leaseId).toBe('lease-1');
+  });
+
+  it('refuses to submit a passphrase that fails the strength check', async () => {
+    const user = userEvent.setup();
+    const onGenerate = vi.fn();
+    render(<ShareReviewPanel lease={lease()} onGenerate={onGenerate} />);
+    await user.type(screen.getByLabelText(/passphrase/i), 'short');
+    await user.click(screen.getByRole('button', { name: /generate/i }));
+    expect(onGenerate).not.toHaveBeenCalled();
+    expect(screen.getByText(/passphrase/i)).toBeInTheDocument();
+  });
+
+  it('refuses to submit an expiry date in the past', async () => {
+    const user = userEvent.setup();
+    const onGenerate = vi.fn();
+    render(<ShareReviewPanel lease={lease()} onGenerate={onGenerate} />);
+    await user.type(screen.getByLabelText(/passphrase/i), 'a-strong-passphrase-12345');
+    await user.clear(screen.getByLabelText(/expir/i));
+    await user.type(screen.getByLabelText(/expir/i), '2000-01-01');
+    await user.click(screen.getByRole('button', { name: /generate/i }));
+    expect(onGenerate).not.toHaveBeenCalled();
+  });
+
+  it('disables generation when the lease is not backed by a signed pack', async () => {
+    const onGenerate = vi.fn();
+    render(<ShareReviewPanel lease={lease({ signedPack: false })} onGenerate={onGenerate} />);
+    expect(screen.getByRole('button', { name: /generate/i })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
Pin the contract for Wave 9 Part A (review-links) before implementation: reviewArchive round-trip + tamper/expiry/passphrase rejection, ShareReviewPanel + OpenReviewPanel UI gating, and useReviewMode provider semantics. All four files import unimplemented modules and fail at resolve-time — that's the red signal.