### PR TITLE
wave10-B: failing specs for shingles, clauseClusters, storage v5, Cla…

### DIFF
--- a/app/src/portfolio/clauseClusters.test.ts
+++ b/app/src/portfolio/clauseClusters.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { clusterParagraphs, type ClauseCluster } from './clauseClusters';
+import type { LeaseRecord } from '../storage/storage';
+import type { LeaseDocument } from '../parser/types';
+
+function makeDoc(paragraphs: string[]): LeaseDocument {
+  return {
+    pages: [{ pageNumber: 1, width: 612, height: 792, items: [] }],
+    paragraphs: paragraphs.map((text) => ({ text, page: 1 })),
+    sections: [],
+    raw: paragraphs.join('\n\n'),
+  };
+}
+
+function makeLease(id: string, paragraphs: string[]): LeaseRecord {
+  return {
+    id,
+    name: `${id}.pdf`,
+    createdAt: 1000,
+    updatedAt: 1000,
+    rulePackVersion: '1.0.0',
+    pageCount: 1,
+    findingCount: 0,
+    doc: makeDoc(paragraphs),
+    findings: [],
+  };
+}
+
+const STD_AUTO_RENEW =
+  'This lease shall automatically renew for successive one year terms unless either party provides written notice of non-renewal at least sixty days prior to the end of the then-current term.';
+
+const NEAR_DUP_AUTO_RENEW =
+  'This lease shall automatically renew for successive one year terms unless either party provides written notice of nonrenewal at least sixty days prior to the end of the current term.';
+
+const UNRELATED =
+  'Tenant shall maintain commercial general liability insurance with minimum limits of one million dollars per occurrence covering bodily injury and property damage at all times.';
+
+describe('clusterParagraphs', () => {
+  it('returns an empty array when given no leases', () => {
+    expect(clusterParagraphs([])).toEqual([]);
+  });
+
+  it('clusters identical paragraphs across two leases', () => {
+    const leases = [
+      makeLease('L1', [STD_AUTO_RENEW]),
+      makeLease('L2', [STD_AUTO_RENEW]),
+    ];
+    const out: ClauseCluster[] = clusterParagraphs(leases);
+    const auto = out.find((c) =>
+      c.paragraphs.some((p) => p.leaseId === 'L1'),
+    );
+    expect(auto).toBeDefined();
+    expect(auto?.paragraphs.map((p) => p.leaseId).sort()).toEqual(['L1', 'L2']);
+  });
+
+  it('clusters near-duplicates whose Jaccard >= 0.8', () => {
+    const leases = [
+      makeLease('L1', [STD_AUTO_RENEW]),
+      makeLease('L2', [NEAR_DUP_AUTO_RENEW]),
+    ];
+    const out = clusterParagraphs(leases, { threshold: 0.8 });
+    const merged = out.find((c) => c.paragraphs.length >= 2);
+    expect(merged).toBeDefined();
+    expect(merged?.paragraphs.map((p) => p.leaseId).sort()).toEqual([
+      'L1',
+      'L2',
+    ]);
+  });
+
+  it('does not cluster unrelated paragraphs', () => {
+    const leases = [
+      makeLease('L1', [STD_AUTO_RENEW]),
+      makeLease('L2', [UNRELATED]),
+    ];
+    const out = clusterParagraphs(leases, { threshold: 0.8 });
+    // No cluster has both leases.
+    const cross = out.find(
+      (c) =>
+        c.paragraphs.some((p) => p.leaseId === 'L1') &&
+        c.paragraphs.some((p) => p.leaseId === 'L2'),
+    );
+    expect(cross).toBeUndefined();
+  });
+
+  it('produces a deterministic order across runs', () => {
+    const leases = [
+      makeLease('L1', [STD_AUTO_RENEW, UNRELATED]),
+      makeLease('L2', [STD_AUTO_RENEW]),
+    ];
+    const a = clusterParagraphs(leases, { threshold: 0.8 });
+    const b = clusterParagraphs(leases, { threshold: 0.8 });
+    expect(a.map((c) => c.clusterId)).toEqual(b.map((c) => c.clusterId));
+  });
+
+  it('records leaseId + paragraphIndex for every clustered paragraph', () => {
+    const leases = [
+      makeLease('L1', [UNRELATED, STD_AUTO_RENEW]),
+      makeLease('L2', [STD_AUTO_RENEW]),
+    ];
+    const out = clusterParagraphs(leases, { threshold: 0.8 });
+    const merged = out.find((c) => c.paragraphs.length >= 2);
+    expect(merged).toBeDefined();
+    const l1 = merged?.paragraphs.find((p) => p.leaseId === 'L1');
+    expect(l1?.paragraphIndex).toBe(1);
+    const l2 = merged?.paragraphs.find((p) => p.leaseId === 'L2');
+    expect(l2?.paragraphIndex).toBe(0);
+  });
+});

--- a/app/src/portfolio/clauseClusters.ts
+++ b/app/src/portfolio/clauseClusters.ts
@@ -1,0 +1,15 @@
+// Wave 10 Part B — implementation pending. Tests import from this module.
+import type { LeaseRecord } from '../storage/storage';
+
+export interface ClauseCluster {
+  clusterId: string;
+  paragraphs: { leaseId: string; paragraphIndex: number; text: string }[];
+  representativeText: string;
+}
+
+export const clusterParagraphs = (
+  _leases: LeaseRecord[],
+  _opts?: { threshold?: number },
+): ClauseCluster[] => {
+  throw new Error('clusterParagraphs: not implemented');
+};

--- a/app/src/portfolio/shingles.test.ts
+++ b/app/src/portfolio/shingles.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { paragraphShingles, jaccard } from './shingles';
+
+describe('paragraphShingles', () => {
+  it('returns an empty array for empty input', () => {
+    expect(paragraphShingles('')).toEqual([]);
+  });
+
+  it('returns an empty array when text has fewer tokens than k', () => {
+    expect(paragraphShingles('one two three', 5)).toEqual([]);
+  });
+
+  it('lowercases, collapses whitespace, and strips punctuation before shingling', () => {
+    const a = paragraphShingles('The Quick, Brown Fox Jumps Over!', 5);
+    const b = paragraphShingles('the   quick brown fox jumps over', 5);
+    expect(a).toEqual(b);
+    expect(a.length).toBeGreaterThan(0);
+  });
+
+  it('produces (n - k + 1) shingles for n tokens', () => {
+    // 7 tokens, k=5 -> 3 shingles
+    const out = paragraphShingles('a b c d e f g', 5);
+    expect(out).toHaveLength(3);
+  });
+
+  it('defaults k to 5', () => {
+    const withDefault = paragraphShingles('a b c d e f g h');
+    const explicit = paragraphShingles('a b c d e f g h', 5);
+    expect(withDefault).toEqual(explicit);
+  });
+});
+
+describe('jaccard', () => {
+  it('returns 0 for two empty sets', () => {
+    expect(jaccard([], [])).toBe(0);
+  });
+
+  it('returns 0 when one side is empty and the other is not', () => {
+    expect(jaccard([], ['a', 'b'])).toBe(0);
+    expect(jaccard(['a'], [])).toBe(0);
+  });
+
+  it('returns 1 for identical sets', () => {
+    expect(jaccard(['a', 'b', 'c'], ['a', 'b', 'c'])).toBe(1);
+  });
+
+  it('returns 0 for disjoint sets', () => {
+    expect(jaccard(['a', 'b'], ['c', 'd'])).toBe(0);
+  });
+
+  it('computes |intersection| / |union| for partial overlap', () => {
+    // {a,b,c} ∩ {b,c,d} = {b,c}; union = {a,b,c,d}; 2/4 = 0.5
+    expect(jaccard(['a', 'b', 'c'], ['b', 'c', 'd'])).toBeCloseTo(0.5, 5);
+  });
+
+  it('treats inputs as sets (duplicates do not change the score)', () => {
+    expect(jaccard(['a', 'a', 'b'], ['a', 'b', 'b'])).toBe(1);
+  });
+});

--- a/app/src/portfolio/shingles.ts
+++ b/app/src/portfolio/shingles.ts
@@ -1,0 +1,10 @@
+// Wave 10 Part B — implementation pending. Tests import from this module.
+export const paragraphShingles = (
+  _text: string,
+  _k: number = 5,
+): string[] => {
+  throw new Error('paragraphShingles: not implemented');
+};
+export const jaccard = (_a: string[], _b: string[]): number => {
+  throw new Error('jaccard: not implemented');
+};

--- a/app/src/storage/storage.test.ts
+++ b/app/src/storage/storage.test.ts
@@ -172,6 +172,90 @@ describe('storage', () => {
     expect(loaded?.createdAt).toBeLessThanOrEqual(after);
   });
 
+  it('migrates v4 to v5: adds paragraphShingles store AND preserves by-finding-and-pack index', async () => {
+    // Seed a v4 database with one row + the v4 compound index, then re-open
+    // through the module to drive v4 -> v5 upgrade. After the bump:
+    //   * row survives
+    //   * `by-finding-and-pack` (Wave 7-E) still queryable
+    //   * new `paragraphShingles` store exists, keyed by [leaseId, paragraphIndex]
+    await new Promise<void>((resolve, reject) => {
+      const req = indexedDB.open('leaseguard', 4);
+      req.onupgradeneeded = (): void => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains('leases')) {
+          const store = db.createObjectStore('leases', { keyPath: 'id' });
+          store.createIndex('by-createdAt', 'createdAt');
+          store.createIndex('by-finding-and-pack', [
+            'findingCount',
+            'rulePackVersion',
+          ]);
+        }
+        if (!db.objectStoreNames.contains('settings')) {
+          db.createObjectStore('settings');
+        }
+        if (!db.objectStoreNames.contains('clauseTemplates')) {
+          db.createObjectStore('clauseTemplates', { keyPath: 'id' });
+        }
+      };
+      req.onsuccess = (): void => {
+        const db = req.result;
+        const tx = db.transaction('leases', 'readwrite');
+        tx.objectStore('leases').put({
+          id: 'lease-v4',
+          name: 'Carry.pdf',
+          createdAt: 1000,
+          updatedAt: 1000,
+          rulePackVersion: '1.0.0',
+          pageCount: 1,
+          findingCount: 0,
+          doc: makeDoc(),
+          findings: [],
+        });
+        tx.oncomplete = (): void => {
+          db.close();
+          resolve();
+        };
+        tx.onerror = (): void => reject(tx.error);
+      };
+      req.onerror = (): void => reject(req.error);
+    });
+
+    _resetDbForTests();
+    const db = await openLeaseDb();
+    expect(db.version).toBe(5);
+
+    // Existing row preserved.
+    const survivors = await db.getAll('leases');
+    expect(survivors.map((r) => r.id)).toEqual(['lease-v4']);
+
+    // Wave 7-E compound index still works.
+    const tx = db.transaction('leases', 'readonly');
+    const idx = tx.objectStore('leases').index('by-finding-and-pack');
+    const matches = await idx.getAll(IDBKeyRange.only([0, '1.0.0']));
+    expect(matches.map((r) => r.id)).toEqual(['lease-v4']);
+    await tx.done;
+
+    // New paragraphShingles store exists and accepts compound-key writes.
+    expect(db.objectStoreNames.contains('paragraphShingles')).toBe(true);
+    const tx2 = db.transaction('paragraphShingles', 'readwrite');
+    // Cast through `any` because schema typing for the new store hasn't
+    // been threaded into the DBSchema yet — that lands with the impl.
+    const store = (tx2 as unknown as {
+      objectStore: (n: string) => {
+        put: (v: unknown) => Promise<unknown>;
+        get: (k: unknown) => Promise<unknown>;
+      };
+    }).objectStore('paragraphShingles');
+    await store.put({
+      leaseId: 'lease-v4',
+      paragraphIndex: 0,
+      shingles: ['a b c d e'],
+    });
+    const got = await store.get(['lease-v4', 0]);
+    expect(got).toMatchObject({ leaseId: 'lease-v4', paragraphIndex: 0 });
+    await tx2.done;
+  });
+
   it('migrates a v3 database to v4 without dropping rows and adds the by-finding-and-pack index', async () => {
     // Seed a v3 database directly via raw indexedDB.open so we can prove
     // the v4 upgrade path runs against a populated v3 schema.

--- a/app/src/ui/ClauseSimilarityPanel.test.tsx
+++ b/app/src/ui/ClauseSimilarityPanel.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ClauseSimilarityPanel } from './ClauseSimilarityPanel';
+import type { ClauseCluster } from '../portfolio/clauseClusters';
+
+const CLUSTERS: ClauseCluster[] = [
+  {
+    clusterId: 'c-001',
+    representativeText: 'Auto-renewal clause text representative.',
+    paragraphs: [
+      {
+        leaseId: 'L1',
+        paragraphIndex: 2,
+        text: 'Auto-renewal clause text representative.',
+      },
+      {
+        leaseId: 'L2',
+        paragraphIndex: 4,
+        text: 'Auto-renewal clause text variant.',
+      },
+    ],
+  },
+  {
+    clusterId: 'c-002',
+    representativeText: 'Indemnification clause representative.',
+    paragraphs: [
+      {
+        leaseId: 'L1',
+        paragraphIndex: 5,
+        text: 'Indemnification clause representative.',
+      },
+      {
+        leaseId: 'L3',
+        paragraphIndex: 1,
+        text: 'Indemnification clause variant.',
+      },
+    ],
+  },
+];
+
+describe('ClauseSimilarityPanel', () => {
+  it('renders an empty state when no clusters are present', () => {
+    render(
+      <ClauseSimilarityPanel clusters={[]} onOpenParagraph={() => {}} />,
+    );
+    expect(screen.getByText(/no clause clusters/i)).toBeInTheDocument();
+  });
+
+  it('renders one entry per cluster with the representative text', () => {
+    render(
+      <ClauseSimilarityPanel
+        clusters={CLUSTERS}
+        onOpenParagraph={() => {}}
+      />,
+    );
+    expect(
+      screen.getByText(/Auto-renewal clause text representative/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Indemnification clause representative/i),
+    ).toBeInTheDocument();
+  });
+
+  it('lists each lease+paragraph in a cluster', () => {
+    render(
+      <ClauseSimilarityPanel
+        clusters={CLUSTERS}
+        onOpenParagraph={() => {}}
+      />,
+    );
+    // Both L1 (paragraph 2) and L2 (paragraph 4) should appear via accessible labels.
+    expect(
+      screen.getByRole('button', {
+        name: /open paragraph 2 of L1/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /open paragraph 4 of L2/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('fires onOpenParagraph(leaseId, paragraphIndex) when a paragraph is clicked', async () => {
+    const onOpenParagraph = vi.fn();
+    render(
+      <ClauseSimilarityPanel
+        clusters={CLUSTERS}
+        onOpenParagraph={onOpenParagraph}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /open paragraph 4 of L2/i,
+      }),
+    );
+    expect(onOpenParagraph).toHaveBeenCalledWith('L2', 4);
+  });
+});

--- a/app/src/ui/ClauseSimilarityPanel.tsx
+++ b/app/src/ui/ClauseSimilarityPanel.tsx
@@ -1,0 +1,13 @@
+// Wave 10 Part B — implementation pending. Tests import from this module.
+import type { ClauseCluster } from '../portfolio/clauseClusters';
+
+export interface ClauseSimilarityPanelProps {
+  clusters: ClauseCluster[];
+  onOpenParagraph: (leaseId: string, paragraphIndex: number) => void;
+}
+
+export function ClauseSimilarityPanel(
+  _props: ClauseSimilarityPanelProps,
+): JSX.Element {
+  throw new Error('ClauseSimilarityPanel: not implemented');
+}


### PR DESCRIPTION
…useSimilarityPanel

Adds RED tests for clause-similarity pipeline:
- src/portfolio/shingles.test.ts (paragraphShingles + jaccard: empty, identical, disjoint, overlap, dedupe)
- src/portfolio/clauseClusters.test.ts (synthetic near-dup leases, threshold 0.8, deterministic ordering)
- src/storage/storage.test.ts (extended): v4 -> v5 migration preserves rows + by-finding-and-pack index AND adds paragraphShingles store
- src/ui/ClauseSimilarityPanel.test.tsx (4 cases: empty, populated, per-paragraph buttons, click callback)

Stub modules export typed signatures that throw 'not implemented'. Storage v5 bump + paragraphShingles store land with the impl branch.