### PR TITLE
wave10-C: failing specs for "my standard" clause suite

### DIFF
--- a/app/src/clauseStandard/compareToStandard.test.ts
+++ b/app/src/clauseStandard/compareToStandard.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import {
+  compareToStandard,
+  type StandardComparison,
+} from './compareToStandard';
+import type { StandardClause } from './standardSuite';
+import type { LeaseRecord } from '../storage/storage';
+import type { LeaseDocument } from '../parser/types';
+
+function makeDoc(paragraphs: string[]): LeaseDocument {
+  return {
+    pages: [{ pageNumber: 1, width: 612, height: 792, items: [] }],
+    paragraphs: paragraphs.map((text) => ({ text, page: 1 })),
+    sections: [],
+    raw: paragraphs.join('\n\n'),
+  };
+}
+function makeLease(id: string, paragraphs: string[]): LeaseRecord {
+  return {
+    id,
+    name: `${id}.pdf`,
+    createdAt: 1,
+    updatedAt: 1,
+    rulePackVersion: '1.0.0',
+    pageCount: 1,
+    findingCount: 0,
+    doc: makeDoc(paragraphs),
+    findings: [],
+  };
+}
+
+const STD_AUTO_RENEW =
+  'This lease shall automatically renew for successive one year terms unless either party provides written notice of non-renewal at least sixty days prior to the end of the then-current term.';
+const NEAR_DUP_AUTO_RENEW =
+  'This lease shall automatically renew for successive one year terms unless either party provides written notice of nonrenewal at least sixty days prior to the end of the current term.';
+const UNRELATED =
+  'Tenant shall maintain commercial general liability insurance with minimum limits of one million dollars per occurrence covering bodily injury and property damage at all times.';
+
+function makeStandard(id: string, text: string): StandardClause {
+  return {
+    id,
+    name: id,
+    sourceLeaseId: 'origin',
+    sourceParagraphIndex: 0,
+    normalizedText: text,
+    createdAt: 1,
+  };
+}
+
+describe('compareToStandard', () => {
+  it('returns an empty array when the suite is empty', () => {
+    expect(compareToStandard(makeLease('L1', [STD_AUTO_RENEW]), [])).toEqual(
+      [],
+    );
+  });
+
+  it('returns one row per standard, with paragraphIndex null + similarity 0 when nothing matches', () => {
+    const lease = makeLease('L1', [UNRELATED]);
+    const suite = [makeStandard('s-auto', STD_AUTO_RENEW)];
+    const out: StandardComparison[] = compareToStandard(lease, suite, {
+      threshold: 0.8,
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]?.standardId).toBe('s-auto');
+    expect(out[0]?.paragraphIndex).toBeNull();
+    expect(out[0]?.similarity).toBeLessThan(0.8);
+  });
+
+  it('matches a standard when a lease paragraph is identical', () => {
+    const lease = makeLease('L1', [UNRELATED, STD_AUTO_RENEW]);
+    const suite = [makeStandard('s-auto', STD_AUTO_RENEW)];
+    const out = compareToStandard(lease, suite, { threshold: 0.8 });
+    const auto = out.find((r) => r.standardId === 's-auto');
+    expect(auto?.paragraphIndex).toBe(1);
+    expect(auto?.similarity).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it('matches near-duplicates above the 0.8 threshold', () => {
+    const lease = makeLease('L1', [NEAR_DUP_AUTO_RENEW]);
+    const suite = [makeStandard('s-auto', STD_AUTO_RENEW)];
+    const out = compareToStandard(lease, suite, { threshold: 0.8 });
+    const auto = out.find((r) => r.standardId === 's-auto');
+    expect(auto?.paragraphIndex).toBe(0);
+    expect(auto?.similarity).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it('returns one row per standard in suite order', () => {
+    const lease = makeLease('L1', [STD_AUTO_RENEW]);
+    const suite = [
+      makeStandard('s-auto', STD_AUTO_RENEW),
+      makeStandard('s-other', UNRELATED),
+    ];
+    const out = compareToStandard(lease, suite, { threshold: 0.8 });
+    expect(out.map((r) => r.standardId)).toEqual(['s-auto', 's-other']);
+  });
+});

--- a/app/src/clauseStandard/compareToStandard.ts
+++ b/app/src/clauseStandard/compareToStandard.ts
@@ -1,0 +1,17 @@
+// Wave 10 Part C — implementation pending.
+import type { LeaseRecord } from '../storage/storage';
+import type { StandardClause } from './standardSuite';
+
+export interface StandardComparison {
+  standardId: string;
+  paragraphIndex: number | null;
+  similarity: number;
+}
+
+export const compareToStandard = (
+  _lease: LeaseRecord,
+  _suite: StandardClause[],
+  _opts?: { threshold?: number },
+): StandardComparison[] => {
+  throw new Error('compareToStandard: not implemented');
+};

--- a/app/src/clauseStandard/standardSuite.test.ts
+++ b/app/src/clauseStandard/standardSuite.test.ts
@@ -1,0 +1,116 @@
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, it, expect } from 'vitest';
+import {
+  _resetStandardsDbForTests,
+  deleteStandard,
+  listStandards,
+  promoteToStandard,
+} from './standardSuite';
+import {
+  AUDIT_DB_NAME,
+  listAuditEntries,
+  _resetAuditDbForTests,
+} from '../audit/auditLog';
+
+const STANDARDS_DB_NAME = 'leaseguard-standards';
+
+async function wipeStandards(): Promise<void> {
+  _resetStandardsDbForTests();
+  await new Promise<void>((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(STANDARDS_DB_NAME);
+    req.onsuccess = (): void => resolve();
+    req.onerror = (): void => reject(req.error);
+    req.onblocked = (): void => resolve();
+  });
+}
+
+async function wipeAudit(): Promise<void> {
+  _resetAuditDbForTests();
+  await new Promise<void>((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(AUDIT_DB_NAME);
+    req.onsuccess = (): void => resolve();
+    req.onerror = (): void => reject(req.error);
+    req.onblocked = (): void => resolve();
+  });
+}
+
+describe('standardSuite', () => {
+  beforeEach(async () => {
+    await wipeStandards();
+    await wipeAudit();
+  });
+
+  it('listStandards is empty on a fresh db', async () => {
+    expect(await listStandards()).toEqual([]);
+  });
+
+  it('promoteToStandard adds a row that listStandards returns', async () => {
+    const created = await promoteToStandard({
+      name: 'Auto-renewal standard',
+      sourceLeaseId: 'L1',
+      sourceParagraphIndex: 2,
+      normalizedText: 'auto renewal clause text',
+    });
+    expect(created.id).toMatch(/.+/);
+    expect(created.createdAt).toBeGreaterThan(0);
+    const list = await listStandards();
+    expect(list).toHaveLength(1);
+    expect(list[0]?.name).toBe('Auto-renewal standard');
+    expect(list[0]?.sourceLeaseId).toBe('L1');
+    expect(list[0]?.sourceParagraphIndex).toBe(2);
+  });
+
+  it('deleteStandard removes the matching row without orphaning others', async () => {
+    const a = await promoteToStandard({
+      name: 'A',
+      sourceLeaseId: 'L1',
+      sourceParagraphIndex: 0,
+      normalizedText: 'a',
+    });
+    const b = await promoteToStandard({
+      name: 'B',
+      sourceLeaseId: 'L2',
+      sourceParagraphIndex: 1,
+      normalizedText: 'b',
+    });
+    await deleteStandard(a.id);
+    const list = await listStandards();
+    expect(list.map((s) => s.id)).toEqual([b.id]);
+  });
+
+  it('promoteToStandard writes a "standard-promote" audit entry via safeAudit/appendAuditEntry', async () => {
+    await promoteToStandard({
+      name: 'A',
+      sourceLeaseId: 'L1',
+      sourceParagraphIndex: 0,
+      normalizedText: 'a',
+    });
+    const entries = await listAuditEntries();
+    const promote = entries.find((e) => e.kind === 'standard-promote');
+    expect(promote).toBeDefined();
+  });
+
+  it('deleteStandard writes a "standard-delete" audit entry', async () => {
+    const a = await promoteToStandard({
+      name: 'A',
+      sourceLeaseId: 'L1',
+      sourceParagraphIndex: 0,
+      normalizedText: 'a',
+    });
+    await deleteStandard(a.id);
+    const entries = await listAuditEntries();
+    const del = entries.find((e) => e.kind === 'standard-delete');
+    expect(del).toBeDefined();
+  });
+
+  it('_resetStandardsDbForTests allows a fresh open after deleteDatabase', async () => {
+    await promoteToStandard({
+      name: 'A',
+      sourceLeaseId: 'L1',
+      sourceParagraphIndex: 0,
+      normalizedText: 'a',
+    });
+    await wipeStandards();
+    expect(await listStandards()).toEqual([]);
+  });
+});

--- a/app/src/clauseStandard/standardSuite.ts
+++ b/app/src/clauseStandard/standardSuite.ts
@@ -1,0 +1,31 @@
+// Wave 10 Part C — implementation pending.
+export interface StandardClause {
+  id: string;
+  name: string;
+  sourceLeaseId: string;
+  sourceParagraphIndex: number;
+  normalizedText: string;
+  createdAt: number;
+}
+
+export interface PromoteInput {
+  name: string;
+  sourceLeaseId: string;
+  sourceParagraphIndex: number;
+  normalizedText: string;
+}
+
+export const _resetStandardsDbForTests = (): void => {
+  throw new Error('_resetStandardsDbForTests: not implemented');
+};
+export const promoteToStandard = async (
+  _input: PromoteInput,
+): Promise<StandardClause> => {
+  throw new Error('promoteToStandard: not implemented');
+};
+export const listStandards = async (): Promise<StandardClause[]> => {
+  throw new Error('listStandards: not implemented');
+};
+export const deleteStandard = async (_id: string): Promise<void> => {
+  throw new Error('deleteStandard: not implemented');
+};

--- a/app/src/portfolio/shingles.ts
+++ b/app/src/portfolio/shingles.ts
@@ -1,0 +1,8 @@
+// Wave 10 Part B stub for Part C tests — real implementation lands on the
+// wave10-clause-similarity branch. Kept here only so Part C imports resolve.
+export const paragraphShingles = (..._args: unknown[]): string[] => {
+  throw new Error('paragraphShingles: not implemented');
+};
+export const jaccard = (..._args: unknown[]): number => {
+  throw new Error('jaccard: not implemented');
+};

--- a/app/src/ui/FindingsPanel.standard.test.tsx
+++ b/app/src/ui/FindingsPanel.standard.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FindingsPanel } from './FindingsPanel';
+import type { Finding } from '../rules/types';
+
+// Wave 10 Part C — FindingsPanel gains an optional onPromoteToStandard
+// callback. When provided, a "Promote to standard" button renders next to
+// each finding's paragraph; when omitted, behavior is identical to today.
+
+function f(over: Partial<Finding>): Finding {
+  return {
+    ruleId: 'rule',
+    severity: 'medium',
+    category: 'general',
+    title: 'Generic title',
+    explanation: 'Generic explanation.',
+    citation: null,
+    page: 1,
+    paragraphIndex: 3,
+    snippet: 'snippet',
+    span: { start: 0, end: 7 },
+    confidence: 0.9,
+    negated: false,
+    rulePackVersion: '1.0.0',
+    ...over,
+  };
+}
+
+// Cast to bypass TS until the optional prop is added in the impl branch.
+// This is intentional — Vitest runs the JS, TS errors don't fail the suite.
+type ExtendedProps = React.ComponentProps<typeof FindingsPanel> & {
+  onPromoteToStandard?: (leaseId: string, paragraphIndex: number) => void;
+  leaseId?: string;
+};
+const Panel = FindingsPanel as unknown as (
+  props: ExtendedProps,
+) => JSX.Element;
+
+describe('FindingsPanel + onPromoteToStandard', () => {
+  it('does NOT render a promote button when onPromoteToStandard is undefined', () => {
+    render(
+      <Panel
+        findings={[f({ ruleId: 'r1', title: 'Auto-renewal' })]}
+        onSelect={() => {}}
+      />,
+    );
+    expect(
+      screen.queryByRole('button', { name: /promote.*standard/i }),
+    ).toBeNull();
+  });
+
+  it('renders a "Promote to standard" button on each finding when callback is provided', () => {
+    const onPromote = vi.fn();
+    render(
+      <Panel
+        findings={[f({ ruleId: 'r1', title: 'Auto-renewal' })]}
+        onSelect={() => {}}
+        onPromoteToStandard={onPromote}
+        leaseId="L1"
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: /promote.*standard/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('invokes onPromoteToStandard(leaseId, paragraphIndex) on click', async () => {
+    const onPromote = vi.fn();
+    render(
+      <Panel
+        findings={[
+          f({ ruleId: 'r1', title: 'Auto-renewal', paragraphIndex: 7 }),
+        ]}
+        onSelect={() => {}}
+        onPromoteToStandard={onPromote}
+        leaseId="L1"
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: /promote.*standard/i }),
+    );
+    expect(onPromote).toHaveBeenCalledWith('L1', 7);
+  });
+});

--- a/app/src/ui/StandardSuitePanel.test.tsx
+++ b/app/src/ui/StandardSuitePanel.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StandardSuitePanel } from './StandardSuitePanel';
+import type { StandardClause } from '../clauseStandard/standardSuite';
+
+const SUITE: StandardClause[] = [
+  {
+    id: 's1',
+    name: 'Auto-renewal standard',
+    sourceLeaseId: 'L1',
+    sourceParagraphIndex: 2,
+    normalizedText: 'auto renewal text',
+    createdAt: 1,
+  },
+  {
+    id: 's2',
+    name: 'Indemnification standard',
+    sourceLeaseId: 'L2',
+    sourceParagraphIndex: 5,
+    normalizedText: 'indemnification text',
+    createdAt: 2,
+  },
+];
+
+describe('StandardSuitePanel', () => {
+  it('renders an empty state when no standards exist', () => {
+    render(<StandardSuitePanel standards={[]} onDelete={() => {}} />);
+    expect(screen.getByText(/no standards/i)).toBeInTheDocument();
+  });
+
+  it('renders each standard by name', () => {
+    render(<StandardSuitePanel standards={SUITE} onDelete={() => {}} />);
+    expect(screen.getByText(/Auto-renewal standard/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Indemnification standard/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a delete button per standard', () => {
+    render(<StandardSuitePanel standards={SUITE} onDelete={() => {}} />);
+    expect(
+      screen.getByRole('button', { name: /delete Auto-renewal standard/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /delete Indemnification standard/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('fires onDelete(id) when a delete button is clicked', async () => {
+    const onDelete = vi.fn();
+    render(<StandardSuitePanel standards={SUITE} onDelete={onDelete} />);
+    await userEvent.click(
+      screen.getByRole('button', { name: /delete Auto-renewal standard/i }),
+    );
+    expect(onDelete).toHaveBeenCalledWith('s1');
+  });
+});

--- a/app/src/ui/StandardSuitePanel.tsx
+++ b/app/src/ui/StandardSuitePanel.tsx
@@ -1,0 +1,13 @@
+// Wave 10 Part C — implementation pending.
+import type { StandardClause } from '../clauseStandard/standardSuite';
+
+export interface StandardSuitePanelProps {
+  standards: StandardClause[];
+  onDelete: (id: string) => void;
+}
+
+export function StandardSuitePanel(
+  _props: StandardSuitePanelProps,
+): JSX.Element {
+  throw new Error('StandardSuitePanel: not implemented');
+}


### PR DESCRIPTION
Adds RED tests for the standard-suite feature:
- src/clauseStandard/standardSuite.test.ts (CRUD + _resetStandardsDbForTests; audit kinds 'standard-promote' / 'standard-delete')
- src/clauseStandard/compareToStandard.test.ts (empty suite, no-match, exact match, near-dup >= 0.8, suite-order rows)
- src/ui/StandardSuitePanel.test.tsx (4 cases: empty, populated, delete buttons, click)
- src/ui/FindingsPanel.standard.test.tsx (3 cases: default-undefined keeps existing UI, button appears when callback provided, click forwards leaseId+paragraphIndex)

Stubs for clauseStandard modules + a Part B shingles.ts placeholder so imports resolve. Real shingles + real implementations land on their respective wave branches.