### PR TITLE
wave11-D: risk-register cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,5 @@ jobs:
       - run: npm run lint
       - run: npm run test:coverage
       - run: npm run build
+      - run: npm run check:csp
       - run: npm run check:budget

--- a/app/package.json
+++ b/app/package.json
@@ -19,6 +19,7 @@
     "build:tesseract-assets": "node scripts/build-tesseract-assets.mjs",
     "postinstall": "node scripts/build-tesseract-assets.mjs",
     "check:budget": "node scripts/check-bundle-budget.mjs",
+    "check:csp": "node scripts/check-csp.mjs",
     "lhci": "lhci autorun",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/app/scripts/check-csp.mjs
+++ b/app/scripts/check-csp.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// Wave 11 Part D — risk-register cleanup.
+//
+// Asserts that the built artifacts (`dist/index.html` + `dist/sw.js`) do not
+// pick up third-party origins in any of the regulated reference shapes:
+//   - <script src=...>          / <script src='...'>
+//   - <link href=...>           (stylesheets, preloads, icons)
+//   - <img src=...>             (and srcset entries)
+//   - CSS url(...)              (inline + sw.js precache shells)
+//   - importScripts(...)        (service worker)
+//
+// CSP itself is `default-src 'self'` — this is the post-build trip-wire that
+// catches a CDN URL leaking in via a dependency upgrade BEFORE it would bypass
+// the runtime CSP at first install.
+//
+// The regex set is deliberately conservative: any URL whose scheme starts with
+// http(s):// AND whose host is not exempt is treated as a regression. data:,
+// blob:, mailto:, same-origin "/foo", and bare relative paths are allowed.
+//
+// Exit 1 with a clear list of offending matches on regression.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+// Patterns that scan for third-party origins.
+const PATTERNS = [
+  {
+    label: 'script src',
+    re: /<script[^>]*\ssrc\s*=\s*["']([^"']+)["']/gi,
+  },
+  {
+    label: 'link href',
+    re: /<link[^>]*\shref\s*=\s*["']([^"']+)["']/gi,
+  },
+  {
+    label: 'img src',
+    re: /<img[^>]*\ssrc\s*=\s*["']([^"']+)["']/gi,
+  },
+  {
+    label: 'css url()',
+    re: /url\(\s*["']?([^)"']+)["']?\s*\)/gi,
+  },
+  {
+    label: 'importScripts',
+    re: /importScripts\s*\(\s*["']([^"']+)["']/gi,
+  },
+];
+
+// Allowed schemes / shapes.
+function isAllowed(url) {
+  const trimmed = url.trim();
+  if (trimmed === '') return true;
+  if (trimmed.startsWith('data:')) return true;
+  if (trimmed.startsWith('blob:')) return true;
+  if (trimmed.startsWith('mailto:')) return true;
+  if (trimmed.startsWith('about:')) return true;
+  if (trimmed.startsWith('#')) return true;
+  // Protocol-relative URLs (`//cdn.example.com/...`) inherit the parent
+  // page scheme and reach a third-party origin — treat as a regression.
+  if (trimmed.startsWith('//')) return false;
+  // Same-origin absolute (`/foo`).
+  if (trimmed.startsWith('/')) return true;
+  // Bare relative path (`foo`, `./foo`, `../foo`) — same-origin.
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return true;
+  // Anything with an explicit scheme — http(s), ws(s), ftp, etc. — is a
+  // regression. We intentionally do NOT allowlist any external host.
+  return false;
+}
+
+/**
+ * Scan a single source string. Returns an array of `{ label, url }`
+ * regressions. Exposed so the test suite can drive it directly with
+ * fixture strings instead of spawning a subprocess.
+ */
+export function scanSource(source, sourceLabel) {
+  const hits = [];
+  for (const { label, re } of PATTERNS) {
+    re.lastIndex = 0;
+    let m;
+    while ((m = re.exec(source)) !== null) {
+      const url = m[1];
+      if (!isAllowed(url)) {
+        hits.push({ source: sourceLabel, label, url });
+      }
+    }
+  }
+  return hits;
+}
+
+export async function checkCspFiles({ indexHtml, swJs }) {
+  const all = [];
+  if (indexHtml != null) {
+    all.push(...scanSource(indexHtml, 'dist/index.html'));
+  }
+  if (swJs != null) {
+    all.push(...scanSource(swJs, 'dist/sw.js'));
+  }
+  return all;
+}
+
+async function readIfExists(path) {
+  try {
+    return await readFile(path, 'utf8');
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+async function main() {
+  // Run from app/ — same convention as check-bundle-budget.mjs.
+  const distDir = resolve(process.cwd(), 'dist');
+  const indexHtml = await readIfExists(resolve(distDir, 'index.html'));
+  const swJs = await readIfExists(resolve(distDir, 'sw.js'));
+
+  if (indexHtml == null) {
+    console.error(
+      `check-csp: ${resolve(distDir, 'index.html')} missing. Did you run "npm run build" first?`,
+    );
+    process.exit(1);
+  }
+  if (swJs == null) {
+    console.error(
+      `check-csp: ${resolve(distDir, 'sw.js')} missing. Did vite-plugin-pwa fail to emit sw.js?`,
+    );
+    process.exit(1);
+  }
+
+  const hits = await checkCspFiles({ indexHtml, swJs });
+  if (hits.length === 0) {
+    console.log('check-csp: OK — no third-party origins in dist/index.html or dist/sw.js.');
+    return;
+  }
+
+  console.error('check-csp: third-party origin(s) detected — CSP `default-src self` regression:');
+  for (const hit of hits) {
+    console.error(`  - [${hit.source}] ${hit.label}: ${hit.url}`);
+  }
+  console.error(
+    '\nIf this URL is intentional, bundle the asset locally (see docs/SECURITY.md §3).',
+  );
+  process.exit(1);
+}
+
+// Only run when invoked as a script — not when imported by tests.
+const invokedAsScript =
+  process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedAsScript) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+// Re-exported so the test fixture can drive `isAllowed` directly.
+export { isAllowed };

--- a/app/scripts/check-csp.test.mjs
+++ b/app/scripts/check-csp.test.mjs
@@ -1,0 +1,136 @@
+// Wave 11 Part D — CSP regression test fixture.
+//
+// Drives `scanSource` directly with happy + planted-CDN-URL fixtures so we
+// don't have to spawn the script as a subprocess. The script-level main()
+// path (file IO, exit codes) is exercised by the CI step itself.
+
+import { describe, it, expect } from 'vitest';
+import { scanSource, isAllowed, checkCspFiles } from './check-csp.mjs';
+
+describe('check-csp · isAllowed', () => {
+  it('allows same-origin and inert schemes', () => {
+    for (const url of [
+      '/assets/index-abc.js',
+      'assets/index-abc.js',
+      './foo.css',
+      '../bar.png',
+      'data:image/png;base64,iVBORw0KG',
+      'blob:http://localhost/abc',
+      'mailto:nobody@example.com',
+      '#anchor',
+      '',
+    ]) {
+      expect(isAllowed(url)).toBe(true);
+    }
+  });
+
+  it('rejects any explicit external scheme', () => {
+    for (const url of [
+      'https://cdn.example.com/foo.js',
+      'http://example.com/foo.css',
+      '//cdn.example.com/foo.js',
+      'wss://socket.example.com/',
+      'ftp://files.example.com/x',
+    ]) {
+      expect(isAllowed(url)).toBe(false);
+    }
+  });
+});
+
+describe('check-csp · scanSource (happy path)', () => {
+  it('returns no hits for a clean index.html', () => {
+    const indexHtml = `
+      <!doctype html>
+      <html>
+        <head>
+          <meta http-equiv="Content-Security-Policy" content="default-src 'self'">
+          <link rel="icon" type="image/svg+xml" href="/icon.svg" />
+          <link rel="stylesheet" href="/assets/index-abc.css" />
+          <script type="module" src="/assets/index-abc.js"></script>
+        </head>
+        <body>
+          <img src="/og.png" />
+          <style>.x { background-image: url('/bg.png'); }</style>
+        </body>
+      </html>
+    `;
+    expect(scanSource(indexHtml, 'dist/index.html')).toEqual([]);
+  });
+
+  it('returns no hits for a clean sw.js', () => {
+    const swJs = `
+      importScripts('/workbox-abc.js');
+      const PRECACHE = ['/index.html', '/assets/index-abc.js', '/icon.svg'];
+    `;
+    expect(scanSource(swJs, 'dist/sw.js')).toEqual([]);
+  });
+
+  it('checkCspFiles aggregates an empty result when both inputs are clean', async () => {
+    const indexHtml = '<script src="/assets/x.js"></script>';
+    const swJs = "importScripts('/wb.js');";
+    const hits = await checkCspFiles({ indexHtml, swJs });
+    expect(hits).toEqual([]);
+  });
+});
+
+describe('check-csp · scanSource (regression — planted CDN URL)', () => {
+  it('flags a third-party <script src> in index.html', () => {
+    const indexHtml = `
+      <!doctype html>
+      <html><head>
+        <script type="module" src="https://cdn.jsdelivr.net/npm/pdfjs-dist/build/pdf.min.js"></script>
+      </head></html>
+    `;
+    const hits = scanSource(indexHtml, 'dist/index.html');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toMatchObject({
+      source: 'dist/index.html',
+      label: 'script src',
+      url: 'https://cdn.jsdelivr.net/npm/pdfjs-dist/build/pdf.min.js',
+    });
+  });
+
+  it('flags a third-party <link href> (e.g. Google Fonts) in index.html', () => {
+    const indexHtml = `
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter" />
+    `;
+    const hits = scanSource(indexHtml, 'dist/index.html');
+    expect(hits).toHaveLength(1);
+    expect(hits[0].label).toBe('link href');
+  });
+
+  it('flags CSS url() with an external host', () => {
+    const indexHtml = `
+      <style>@font-face { src: url(https://cdn.example.com/font.woff2); }</style>
+    `;
+    const hits = scanSource(indexHtml, 'dist/index.html');
+    expect(hits.some((h) => h.label === 'css url()' && h.url.startsWith('https://'))).toBe(true);
+  });
+
+  it('flags importScripts() with an external host in sw.js', () => {
+    const swJs = `importScripts('https://storage.googleapis.com/workbox/workbox-sw.js');`;
+    const hits = scanSource(swJs, 'dist/sw.js');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toMatchObject({
+      source: 'dist/sw.js',
+      label: 'importScripts',
+      url: 'https://storage.googleapis.com/workbox/workbox-sw.js',
+    });
+  });
+
+  it('flags multiple regressions across sources via checkCspFiles', async () => {
+    const indexHtml = `<img src="https://cdn.example.com/logo.png" />`;
+    const swJs = `importScripts('https://cdn.example.com/sw-extra.js');`;
+    const hits = await checkCspFiles({ indexHtml, swJs });
+    expect(hits).toHaveLength(2);
+    const sources = hits.map((h) => h.source).sort();
+    expect(sources).toEqual(['dist/index.html', 'dist/sw.js']);
+  });
+
+  it('protocol-relative URLs (//cdn.example.com/x) are flagged as third-party', () => {
+    const indexHtml = `<script src="//cdn.example.com/x.js"></script>`;
+    const hits = scanSource(indexHtml, 'dist/index.html');
+    expect(hits).toHaveLength(1);
+    expect(hits[0].url).toBe('//cdn.example.com/x.js');
+  });
+});

--- a/app/src/observability/ErrorBoundary.test.tsx
+++ b/app/src/observability/ErrorBoundary.test.tsx
@@ -35,6 +35,22 @@ describe('ErrorBoundary', () => {
     spy.mockRestore();
   });
 
+  it('renders the diagnostics summary list above the download button', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>,
+    );
+    // Every category in the diagnostics payload should be surfaced.
+    expect(screen.getByText('userAgent')).toBeInTheDocument();
+    expect(screen.getByText('stack-traces (last 20)')).toBeInTheDocument();
+    expect(screen.getByText('rule-pack versions')).toBeInTheDocument();
+    expect(screen.getByText('no PDF bytes')).toBeInTheDocument();
+    expect(screen.getByText('no IDB contents')).toBeInTheDocument();
+    spy.mockRestore();
+  });
+
   it('the fallback has a "Download diagnostics" button that triggers a download', async () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const origCreate = document.createElement.bind(document);

--- a/app/src/observability/ErrorBoundary.tsx
+++ b/app/src/observability/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
-import { diagnosticsReport, recordCrash } from './crashLog';
+import { diagnosticsReport, diagnosticsSummary, recordCrash } from './crashLog';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -47,6 +47,14 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
           Your data is still on this device. You can download a local diagnostics report
           (no data leaves your device unless you share the file).
         </p>
+        <details className="diagnostics-summary" open>
+          <summary>What's in the diagnostics file</summary>
+          <ul>
+            {diagnosticsSummary().map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </details>
         <button type="button" onClick={this.handleDownload}>
           Download diagnostics
         </button>

--- a/app/src/observability/crashLog.test.ts
+++ b/app/src/observability/crashLog.test.ts
@@ -47,7 +47,7 @@ describe('crashLog', () => {
   });
 });
 
-import { diagnosticsReport } from './crashLog';
+import { diagnosticsReport, diagnosticsSummary } from './crashLog';
 
 describe('diagnosticsReport', () => {
   it('emits schema-stamped JSON with crashes included', () => {
@@ -58,5 +58,24 @@ describe('diagnosticsReport', () => {
     expect(parsed.crashes).toHaveLength(1);
     expect(parsed.crashes[0].message).toBe('in the report');
     expect(typeof parsed.generatedAt).toBe('string');
+  });
+
+  it('includes a summary array enumerating every category in the payload', () => {
+    clearCrashLog();
+    const parsed = JSON.parse(diagnosticsReport());
+    expect(Array.isArray(parsed.summary)).toBe(true);
+    expect(parsed.summary).toEqual([
+      'userAgent',
+      'stack-traces (last 20)',
+      'rule-pack versions',
+      'no PDF bytes',
+      'no IDB contents',
+    ]);
+  });
+
+  it('summary explicitly disclaims PDF bytes and IDB contents', () => {
+    const summary = diagnosticsSummary();
+    expect(summary).toContain('no PDF bytes');
+    expect(summary).toContain('no IDB contents');
   });
 });

--- a/app/src/observability/crashLog.ts
+++ b/app/src/observability/crashLog.ts
@@ -30,11 +30,29 @@ export function clearCrashLog(): void {
   entries = [];
 }
 
+/**
+ * Human-readable enumeration of every category included in the diagnostics
+ * payload. Exported so the UI can surface "what's in this file" above the
+ * download button (Wave 11 Part D — risk register: crash-log privacy review).
+ *
+ * Keep in sync with the payload built by `diagnosticsReport`.
+ */
+export function diagnosticsSummary(): string[] {
+  return [
+    'userAgent',
+    `stack-traces (last ${CRASH_LOG_CAPACITY})`,
+    'rule-pack versions',
+    'no PDF bytes',
+    'no IDB contents',
+  ];
+}
+
 export function diagnosticsReport(): string {
   const payload = {
     schema: 'leaseguard.diagnostics.v1',
     generatedAt: new Date().toISOString(),
     userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown',
+    summary: diagnosticsSummary(),
     crashes: snapshotCrashLog(),
   };
   return JSON.stringify(payload, null, 2);

--- a/app/src/rules/packV1.test.ts
+++ b/app/src/rules/packV1.test.ts
@@ -54,3 +54,28 @@ describe('RULE_PACK_V1 metadata', () => {
     }
   });
 });
+
+// Wave 11 Part D — rule-pack rot review.
+//
+// `plainEnglish` and `suggestedEdit` are technically optional in the Rule
+// type (Phase 14), but the v1 pack has audited values for every rule. This
+// block freezes that audit pass: any future edit that drops either field
+// from a v1 rule will trip CI here, forcing a deliberate decision rather
+// than silent rot. See docs/SECURITY.md §4 for the review schedule.
+describe('RULE_PACK_V1 rot review (Wave 11)', () => {
+  it.each(RULE_PACK_V1.map((r) => [r.id, r] as const))(
+    '%s has a non-empty plainEnglish field',
+    (_id, rule) => {
+      expect(typeof rule.plainEnglish).toBe('string');
+      expect((rule.plainEnglish ?? '').trim().length).toBeGreaterThan(0);
+    },
+  );
+
+  it.each(RULE_PACK_V1.map((r) => [r.id, r] as const))(
+    '%s has a non-empty suggestedEdit field',
+    (_id, rule) => {
+      expect(typeof rule.suggestedEdit).toBe('string');
+      expect((rule.suggestedEdit ?? '').trim().length).toBeGreaterThan(0);
+    },
+  );
+});

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -467,21 +467,40 @@ Things worth a deliberate decision before they surprise us.
       (Apache-2.0). `eng.traineddata` is Apache-2.0 per the
       tessdata-fast repo, but redistributing it inside the PWA needs
       an explicit NOTICE file and attribution page.
-- [ ] **Security review of the encrypted archive format** — confirm
-      200k PBKDF2 iterations are still adequate in 2026; consider
-      Argon2id via WASM; document threat model explicitly.
+      Decision: open — outside Wave 11 scope, schedule with Phase 14
+      content-depth follow-ups (2026-04-25).
+- [x] **Security review of the encrypted archive format** —
+      Decision: stay on PBKDF2-HMAC-SHA256 200k iterations + AES-GCM-256
+      for v1; defer Argon2id to a v2 archive format with explicit
+      revisit on **2026-10-01**. Threat model + trigger conditions
+      documented in `docs/SECURITY.md` §1 (2026-04-25).
 - [ ] **Release & versioning policy** — no version bumps yet; decide
       when rule-pack changes bump `RULE_PACK_VERSION` vs the package
       version. Tie to the signed-export format.
-- [ ] **Crash-log privacy review** — `diagnosticsReport` today bundles
-      `navigator.userAgent` and stack traces; if a user shares the
-      JSON, what might leak? Add a user-visible "what's in this file"
-      summary before download.
-- [ ] **CSP regression tests** — an automated check that `index.html`
-      and `sw.js` don't pick up CDN URLs across dependency upgrades.
-- [ ] **Rule-pack rot** — the v1 rules were hand-authored; schedule a
-      review pass now that golden leases and the jurisdiction tag
-      scheme from Phase 10 exist.
+      Decision: open — Wave 11 is content + risk-register only;
+      release-policy decision belongs in a future trust-infra wave
+      (2026-04-25).
+- [x] **Crash-log privacy review** —
+      Decision: `diagnosticsReport` now emits a `summary: string[]`
+      field enumerating every category included (`userAgent`,
+      `stack-traces (last 20)`, `rule-pack versions`, `no PDF bytes`,
+      `no IDB contents`); the Error Boundary surfaces the same list
+      above the download button so users see exactly what they would
+      share. Documented in `docs/SECURITY.md` §2 (2026-04-25).
+- [x] **CSP regression tests** —
+      Decision: shipped `app/scripts/check-csp.mjs` (+ test fixture)
+      as a post-`npm run build` gate that scans `dist/index.html` and
+      `dist/sw.js` for any third-party origin in script/link/img/CSS
+      `url()`/`importScripts` references. Wired into the CI workflow
+      after `npm run build`. Documented in `docs/SECURITY.md` §3
+      (2026-04-25).
+- [x] **Rule-pack rot** —
+      Decision: added a rot-review test block to
+      `app/src/rules/packV1.test.ts` that asserts every v1 rule has a
+      non-empty `plainEnglish` AND `suggestedEdit`, freezing the
+      current audit pass. Quarterly (next 2026-07-25) and annual (next
+      2027-04-25) human review cadences documented in
+      `docs/SECURITY.md` §4 (2026-04-25).
 
 ## Explicitly out of scope
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,199 @@
+# Security
+
+LeaseGuard is a local-first PWA: after the initial app load there is no
+network egress. The threat model below is therefore narrow — it covers
+the artifacts a user can choose to share off-device (encrypted archives,
+diagnostics JSON, signed reports) and the supply-chain trust assumptions
+the build pipeline depends on. Everything else is "data on disk under
+the user's OS account" and inherits that trust boundary.
+
+This document is the authoritative reference for the four risk-register
+items closed out in Wave 11 (see `docs/BACKLOG.md` → "Known unknowns &
+risk register"). When a related design changes, update the matching
+section here in the same PR.
+
+---
+
+## 1. Encrypted archive threat model
+
+### What the format protects
+
+Encrypted archives (`leaseguard-archive-v1`, used by the review-link and
+backup flows) wrap the archive payload with AES-GCM-256 using a key
+derived from a user-supplied passphrase via PBKDF2-HMAC-SHA256, **200 000
+iterations**, with a per-archive 16-byte random salt and a 12-byte random
+IV. The `LGv1` magic header pins the format version.
+
+### Adversary
+
+The assumed adversary is an opportunistic attacker with the archive
+file but no side-channel access to the user's machine — e.g. an email
+recipient, a leaked Dropbox link, or someone who finds the file on a
+shared drive. They have offline access only. We do not defend against
+attackers with code execution on the user's device, kernel-level
+privilege, or live observation of the WebCrypto worker.
+
+### Why PBKDF2 200k (as of 2026-04-25)
+
+PBKDF2-HMAC-SHA256 at 200 000 iterations is OWASP's 2023 recommended
+floor and is the strongest KDF available in WebCrypto without pulling
+in a WASM dependency. It is GPU-friendly, which is its main weakness:
+a determined attacker with a high-end GPU can mid-six-figure-guess
+passwords per second offline. We mitigate this with the existing
+**passphrase strength UI** (zxcvbn-style guidance at archive-export
+time, surfaced in `ArchiveExportPanel`), which pushes users toward
+passphrases that survive that throughput.
+
+### Argon2id — explicit deferral
+
+Argon2id is the modern best practice (memory-hard, GPU-resistant) but
+WebCrypto does not implement it; shipping Argon2id would require either
+a ~50 KiB hand-rolled implementation or a WASM dependency
+(`argon2-browser` is ~250 KiB).
+
+**Decision (2026-04-25):** stay on PBKDF2 200k for v1; revisit Argon2id
+on **2026-10-01**. Trigger conditions for an earlier revisit:
+- WebCrypto ships native Argon2id support in any major browser, OR
+- a mid-size WASM Argon2id (<30 KiB) lands in the npm ecosystem with
+  a permissive license, OR
+- the OWASP recommendation for KDFs raises the PBKDF2 floor.
+
+The revisit is tracked in `docs/BACKLOG.md` under the risk register.
+
+### Format-version contract
+
+The `LGv1` magic + explicit `kdf` / `iterations` fields in the archive
+header mean we can ship a v2 format that uses Argon2id without breaking
+existing archives — old archives stay readable as long as the v1 KDF
+code path is retained. Plan future format bumps as additive, not
+replacing.
+
+---
+
+## 2. Crash-log / diagnostics contents
+
+`recordCrash` (in `app/src/observability/crashLog.ts`) keeps a
+20-entry in-memory ring buffer of caught exceptions. The "Download
+diagnostics" button on the Error Boundary fallback emits a JSON blob
+(`leaseguard-diagnostics-YYYY-MM-DD.json`, schema
+`leaseguard.diagnostics.v1`).
+
+The Error Boundary now renders a **"What's in the diagnostics file"**
+disclosure above the download button — sourced from
+`diagnosticsSummary()` so the UI and the payload cannot drift. As of
+Wave 11 the categories are:
+
+- `userAgent` — the browser's `navigator.userAgent` string. May reveal
+  browser version, OS, and (on some Linux distros) locale hints.
+- `stack-traces (last 20)` — the ring buffer. Stack frames are file
+  paths inside the bundled SPA (e.g. `index-abc123.js:1:4567`); they
+  do **not** contain absolute filesystem paths from the user's machine.
+  React's `componentStack` is included when available.
+- `rule-pack versions` — the `RULE_PACK_VERSION` constant and any
+  imported pack ids. Public information by design.
+- `no PDF bytes` — explicitly: the JSON contains zero bytes from any
+  uploaded lease.
+- `no IDB contents` — explicitly: the JSON contains no IndexedDB
+  contents (no saved leases, redlines, audit log, signing keys,
+  archives, annotations, packs, counter-offers, or version history).
+
+If any of these change, update both the `diagnosticsSummary()` array
+and this section in the same PR. The
+`crashLog.test.ts` suite asserts the array contents byte-for-byte, so
+the test will fail loud if the contract drifts.
+
+### Sharing guidance
+
+The diagnostics file is safe to share with a maintainer for bug
+reports. If the user has reproduced a crash by interacting with a
+specific lease, the stack trace can encode the **shape** of the trigger
+(e.g. the rule id whose matcher threw) but not the lease text itself.
+
+---
+
+## 3. CSP contract + the `check:csp` build gate
+
+### Runtime contract
+
+`app/index.html` sets:
+
+```
+Content-Security-Policy: default-src 'self'; script-src 'self';
+  style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:;
+  font-src 'self' data:; connect-src 'self' blob:;
+  worker-src 'self' blob:; object-src 'none'; base-uri 'self';
+  form-action 'none'; frame-ancestors 'none'
+```
+
+This is the Phase 0 / Phase 6 promise: zero third-party origins, no
+inline scripts, no eval. Workers and blob URLs are permitted because
+the PWA ships `pdf.worker`, the lease-analysis Web Worker, and the
+tesseract worker — all served same-origin.
+
+### Build-time gate (`npm run check:csp`)
+
+A CSP header alone is a runtime guard — a CDN URL pulled in by a
+dependency upgrade would still ship to users (they'd just see a
+console error on first install). `app/scripts/check-csp.mjs` closes
+that gap by scanning `dist/index.html` and `dist/sw.js` after
+`npm run build` for:
+
+- `<script src=...>` / `<link href=...>` / `<img src=...>`
+- CSS `url(...)` references
+- `importScripts(...)` calls in the service worker
+
+Any URL with an explicit external scheme (`http:`, `https:`, `ws:`,
+`ftp:`, …) or a protocol-relative `//host/...` form fails the build.
+`data:`, `blob:`, `mailto:`, `#anchor`, absolute same-origin paths
+(`/foo`), and bare relative paths are allowed.
+
+CI runs the gate on every PR, immediately after `npm run build` and
+before `npm run check:budget`. See `.github/workflows/ci.yml`.
+
+If you legitimately need an external asset, **bundle it locally** —
+extend `scripts/build-tesseract-assets.mjs` for the canonical pattern
+(copy from `node_modules` at install time into `public/`).
+
+### Test fixtures
+
+`app/scripts/check-csp.test.mjs` covers:
+- happy path (clean `dist/index.html` + `dist/sw.js`),
+- planted CDN URLs across each pattern (script src, link href, CSS
+  `url()`, `importScripts`, protocol-relative `//cdn.example.com/x.js`),
+- the multi-source aggregator.
+
+This test is the regression fixture; we never mutate real source files
+to "see if the gate fires."
+
+---
+
+## 4. Rule-pack rot review
+
+### What "rot" means here
+
+The 10 v1 rules in `app/src/rules/packV1.ts` were hand-authored at the
+project's start. Three risks accumulate over time:
+
+1. **Field drift** — a future edit silently drops `plainEnglish` or
+   `suggestedEdit` (both optional on the `Rule` type but populated for
+   every v1 rule), degrading the FindingsPanel disclosure / counter-offer
+   pre-fill UX.
+2. **Pattern drift** — case law, common lease boilerplate, or the
+   golden-lease fixtures evolve and the matcher's positive cases no
+   longer cover what's on the ground.
+3. **Tone drift** — `plainEnglish` strings drift from the project's
+   "neutral, no jurisdiction claims, no legal advice" voice.
+
+### Review cadence
+
+| Cadence | Item | Owner |
+|---|---|---|
+| Every PR that touches `packV1.ts` | Run `npm test -- packV1` and `npm test -- golden`. The Wave 11 rot-review block in `packV1.test.ts` asserts `plainEnglish` and `suggestedEdit` are present and non-empty for every rule. | PR author |
+| Quarterly (next: **2026-07-25**) | Manual read-through of all v1 rules: tone, accuracy, suggested-edit text. Update `RULE_PACK_VERSION` if any content changes. | Maintainer |
+| Annually (next: **2027-04-25**) | Re-run the full golden-lease suite against the live rule pack and a freshly-collected sample of public commercial + residential leases. Decide whether to retire / split / merge any rule. | Maintainer |
+
+The rot-review test block is the automated tripwire; the quarterly +
+annual cadences are the human review the test cannot replace. When a
+review pass completes, append a `Decision:` line to the
+`docs/BACKLOG.md` risk-register entry rather than removing the bullet
+— the audit trail matters more than the line count.


### PR DESCRIPTION
Closes the four risk-register items deferred since Phase 7:

- Crash-log privacy: diagnosticsReport() now emits a summary[] enumerating every category in the payload (userAgent, stack-traces last 20, rule-pack versions, no PDF bytes, no IDB contents). The ErrorBoundary fallback renders the same list above the download button so users see exactly what they would share.
- CSP regression gate: app/scripts/check-csp.mjs scans dist/index.html and dist/sw.js after npm run build for any third-party origin in script/link/img/CSS url()/importScripts references. Wired into the CI workflow after build, before check:budget. Test fixture covers happy path + planted CDN URLs across every pattern (incl. protocol-relative //cdn.example.com).
- Encrypted-archive threat model: docs/SECURITY.md §1 documents the PBKDF2-HMAC-SHA256 200k + AES-GCM-256 v1 format, the deferral of Argon2id to a v2 format, and explicit revisit date 2026-10-01.
- Rule-pack rot review: packV1.test.ts gains a rot-review block asserting every v1 rule has non-empty plainEnglish AND suggestedEdit. docs/SECURITY.md §4 records the quarterly + annual human-review cadences.

docs/BACKLOG.md: each risk-register item now has a dated Decision: line (2026-04-25). Items with deliverables are checked; the two out-of-scope items (tesseract licensing, release/versioning policy) have explicit "open — outside Wave 11 scope" decisions.

Note: the diagnosticsReport function lives in
app/src/observability/crashLog.ts (the path the plan calls app/src/diagnostics/diagnosticsReport.ts does not exist); kept in place rather than relocate to avoid expanding scope into an import refactor across ErrorBoundary + tests.