### PR TITLE
wave10-D: failing specs for portfolio-scope severity overrides

### DIFF
--- a/app/src/rules/portfolioOverrides.test.ts
+++ b/app/src/rules/portfolioOverrides.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  migrateLegacyOverrides,
+  resolveSeverity,
+  type ScopedOverrideEntry,
+} from './portfolioOverrides';
+
+describe('resolveSeverity (lease > portfolio > pack default)', () => {
+  it('returns the pack default when no overrides exist', () => {
+    expect(
+      resolveSeverity('r1', 'high', [], { leaseId: 'L1' }),
+    ).toBe('high');
+  });
+
+  it('applies a portfolio-scope override when no lease-scope override exists', () => {
+    const entries: ScopedOverrideEntry[] = [
+      { ruleId: 'r1', severity: 'low', scope: 'portfolio' },
+    ];
+    expect(resolveSeverity('r1', 'high', entries, { leaseId: 'L1' })).toBe(
+      'low',
+    );
+  });
+
+  it('lease-scope override wins over portfolio-scope override on the same lease', () => {
+    const entries: ScopedOverrideEntry[] = [
+      { ruleId: 'r1', severity: 'low', scope: 'portfolio' },
+      { ruleId: 'r1', severity: 'medium', scope: 'lease', leaseId: 'L1' },
+    ];
+    expect(resolveSeverity('r1', 'high', entries, { leaseId: 'L1' })).toBe(
+      'medium',
+    );
+  });
+
+  it('lease-scope override on a different lease does not affect this lease', () => {
+    const entries: ScopedOverrideEntry[] = [
+      { ruleId: 'r1', severity: 'low', scope: 'portfolio' },
+      { ruleId: 'r1', severity: 'medium', scope: 'lease', leaseId: 'L2' },
+    ];
+    // Portfolio still applies on L1.
+    expect(resolveSeverity('r1', 'high', entries, { leaseId: 'L1' })).toBe(
+      'low',
+    );
+  });
+
+  it('falls back to pack default when neither scope has an entry for this ruleId', () => {
+    const entries: ScopedOverrideEntry[] = [
+      { ruleId: 'other', severity: 'low', scope: 'portfolio' },
+    ];
+    expect(resolveSeverity('r1', 'info', entries, { leaseId: 'L1' })).toBe(
+      'info',
+    );
+  });
+
+  it('removing the portfolio override falls back to the pack default', () => {
+    const before: ScopedOverrideEntry[] = [
+      { ruleId: 'r1', severity: 'low', scope: 'portfolio' },
+    ];
+    const after: ScopedOverrideEntry[] = [];
+    expect(resolveSeverity('r1', 'high', before, { leaseId: 'L1' })).toBe(
+      'low',
+    );
+    expect(resolveSeverity('r1', 'high', after, { leaseId: 'L1' })).toBe(
+      'high',
+    );
+  });
+});
+
+describe('migrateLegacyOverrides', () => {
+  it('returns an empty array when given an empty legacy map', () => {
+    expect(migrateLegacyOverrides({})).toEqual([]);
+  });
+
+  it('migrates pre-existing user severity overrides to portfolio-scope entries', () => {
+    // Pre-Wave-10 overrides were per-user / global with no scope; treat them
+    // as portfolio-scope so behavior carries over.
+    const legacy: Record<string, 'high' | 'medium' | 'low' | 'info'> = {
+      'auto-renewal': 'high',
+      'late-fee': 'low',
+    };
+    const out = migrateLegacyOverrides(legacy);
+    expect(out).toHaveLength(2);
+    for (const entry of out) {
+      expect(entry.scope).toBe('portfolio');
+    }
+    const auto = out.find((e) => e.ruleId === 'auto-renewal');
+    const late = out.find((e) => e.ruleId === 'late-fee');
+    expect(auto?.severity).toBe('high');
+    expect(late?.severity).toBe('low');
+  });
+});

--- a/app/src/rules/portfolioOverrides.ts
+++ b/app/src/rules/portfolioOverrides.ts
@@ -1,0 +1,28 @@
+// Wave 10 Part D — implementation pending.
+// Resolution order: lease-scope > portfolio-scope > pack default.
+import type { Severity } from './types';
+
+export type OverrideScope = 'lease' | 'portfolio';
+
+export interface ScopedOverrideEntry {
+  ruleId: string;
+  severity: Severity;
+  scope: OverrideScope;
+  /** Required when scope === 'lease'; ignored when 'portfolio'. */
+  leaseId?: string;
+}
+
+export const resolveSeverity = (
+  _ruleId: string,
+  _packDefault: Severity,
+  _entries: ScopedOverrideEntry[],
+  _opts: { leaseId: string },
+): Severity => {
+  throw new Error('resolveSeverity: not implemented');
+};
+
+export const migrateLegacyOverrides = (
+  _legacy: Record<string, Severity>,
+): ScopedOverrideEntry[] => {
+  throw new Error('migrateLegacyOverrides: not implemented');
+};

--- a/app/src/ui/SeverityOverridesPanel.portfolio.test.tsx
+++ b/app/src/ui/SeverityOverridesPanel.portfolio.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SeverityOverridesPanel } from './SeverityOverridesPanel';
+
+// Wave 10 Part D — SeverityOverridesPanel gains an "Apply across portfolio"
+// toggle next to each row. The new props are additive; existing call sites
+// (no portfolioOverrides prop) keep working unchanged.
+
+const RULES = [
+  { id: 'r1', title: 'Auto-renewal clause', severity: 'warn' as const },
+  { id: 'r2', title: 'Holdover penalty', severity: 'error' as const },
+];
+
+type ExtendedProps = React.ComponentProps<typeof SeverityOverridesPanel> & {
+  portfolioOverrides?: Record<string, 'info' | 'warn' | 'error'>;
+  onScopeChange?: (
+    ruleId: string,
+    scope: 'lease' | 'portfolio',
+  ) => void;
+};
+const Panel = SeverityOverridesPanel as unknown as (
+  p: ExtendedProps,
+) => JSX.Element;
+
+describe('SeverityOverridesPanel + portfolio toggle', () => {
+  it('renders an "Apply across portfolio" toggle per rule when portfolio props are provided', () => {
+    render(
+      <Panel
+        rules={RULES}
+        overrides={{ r1: 'error' }}
+        portfolioOverrides={{}}
+        onChange={() => {}}
+        onScopeChange={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole('checkbox', {
+        name: /apply across portfolio for r1/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', {
+        name: /apply across portfolio for r2/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('reflects the portfolio-scope state per rule (checked when portfolioOverrides has the rule)', () => {
+    render(
+      <Panel
+        rules={RULES}
+        overrides={{}}
+        portfolioOverrides={{ r1: 'warn' }}
+        onChange={() => {}}
+        onScopeChange={() => {}}
+      />,
+    );
+    const r1 = screen.getByRole('checkbox', {
+      name: /apply across portfolio for r1/i,
+    }) as HTMLInputElement;
+    const r2 = screen.getByRole('checkbox', {
+      name: /apply across portfolio for r2/i,
+    }) as HTMLInputElement;
+    expect(r1.checked).toBe(true);
+    expect(r2.checked).toBe(false);
+  });
+
+  it('fires onScopeChange(ruleId, "portfolio") when the toggle is checked', async () => {
+    const onScopeChange = vi.fn();
+    render(
+      <Panel
+        rules={RULES}
+        overrides={{ r1: 'warn' }}
+        portfolioOverrides={{}}
+        onChange={() => {}}
+        onScopeChange={onScopeChange}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole('checkbox', {
+        name: /apply across portfolio for r1/i,
+      }),
+    );
+    expect(onScopeChange).toHaveBeenCalledWith('r1', 'portfolio');
+  });
+
+  it('fires onScopeChange(ruleId, "lease") when an already-portfolio toggle is unchecked', async () => {
+    const onScopeChange = vi.fn();
+    render(
+      <Panel
+        rules={RULES}
+        overrides={{}}
+        portfolioOverrides={{ r1: 'warn' }}
+        onChange={() => {}}
+        onScopeChange={onScopeChange}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole('checkbox', {
+        name: /apply across portfolio for r1/i,
+      }),
+    );
+    expect(onScopeChange).toHaveBeenCalledWith('r1', 'lease');
+  });
+});


### PR DESCRIPTION
Adds RED tests for the portfolio-scope severity override model:
- src/rules/portfolioOverrides.test.ts (resolveSeverity: defaults, portfolio-only, lease > portfolio precedence, cross-lease isolation, removal fallback; migrateLegacyOverrides: empty + populated)
- src/ui/SeverityOverridesPanel.portfolio.test.tsx (4 cases: toggle renders, reflects state, fires onScopeChange both directions)

Stub portfolioOverrides.ts exports typed signatures that throw 'not implemented'. SeverityOverridesPanel test uses a typed cast for the new optional props (real prop additions land with the impl).