### PR TITLE
wave11-B: i18n scaffold (en + es stub)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -86,8 +86,20 @@ import {
   type LeaseMetadata,
 } from './storage/storage';
 import { OnboardingTour } from './ui/OnboardingTour';
+import { I18nProvider } from './i18n/I18nProvider';
+import { useI18n } from './i18n/I18nContext';
+import { LocalePickerPanel } from './ui/LocalePickerPanel';
 
 export function App(): JSX.Element {
+  return (
+    <I18nProvider>
+      <AppContent />
+    </I18nProvider>
+  );
+}
+
+function AppContent(): JSX.Element {
+  const { t } = useI18n();
   const [selected, setSelected] = useState<Finding | null>(null);
   const [library, setLibrary] = useState<LeaseMetadata[]>([]);
   const [selectedPage, setSelectedPage] = useState<number | null>(null);
@@ -370,10 +382,11 @@ export function App(): JSX.Element {
         />
       )}
       <header>
-        <h1>LeaseGuard</h1>
-        <p>Private, local-first lease analyzer. Nothing leaves your device.</p>
+        <h1>{t('app.title')}</h1>
+        <p>{t('app.tagline')}</p>
+        <LocalePickerPanel />
         <details className="privacy">
-          <summary>Privacy &amp; how this works</summary>
+          <summary>{t('header.privacy.summary')}</summary>
           <ul>
             <li>The PDF is parsed entirely in your browser via pdf.js.</li>
             <li>All storage is in IndexedDB on this device. No account, no sync.</li>
@@ -398,17 +411,17 @@ export function App(): JSX.Element {
             }}
           />
         </label>
-        <button type="button" onClick={() => void onTrySample()}>Try a sample lease</button>
+        <button type="button" onClick={() => void onTrySample()}>{t('header.trySample')}</button>
         <div role="group" aria-label="view mode" className="view-toggle">
           <button type="button" aria-pressed={view === 'current'} onClick={() => setView('current')}>
-            Current lease
+            {t('header.view.current')}
           </button>
           <button type="button" aria-pressed={view === 'portfolio'} onClick={() => setView('portfolio')}>
-            Portfolio
+            {t('header.view.portfolio')}
           </button>
           {status.kind === 'analyzed' && (
             <button type="button" aria-pressed={view === 'redline'} onClick={() => setView('redline')}>
-              Redline
+              {t('header.view.redline')}
             </button>
           )}
         </div>
@@ -501,7 +514,7 @@ export function App(): JSX.Element {
       {view === 'current' && status.kind === 'analyzed' && (
         <div className="results">
           <div className="results-actions">
-            <button type="button" onClick={onExportJson}>Export findings (JSON)</button>
+            <button type="button" onClick={onExportJson}>{t('findings.export.json')}</button>
             <button
               type="button"
               onClick={() => {
@@ -513,11 +526,11 @@ export function App(): JSX.Element {
                 });
               }}
             >
-              Export findings (printable HTML)
+              {t('findings.export.html')}
             </button>
             {signingKey.publicKey !== null && (
               <button type="button" onClick={() => void onExportSignedJson()}>
-                Export findings (signed JSON)
+                {t('findings.export.signed')}
               </button>
             )}
           </div>
@@ -749,7 +762,7 @@ export function App(): JSX.Element {
 
       <footer>
         <button type="button" onClick={() => void exportEncryptedArchiveFlow()}>
-          Export encrypted archive
+          {t('footer.archive.export')}
         </button>
         <label>
           <span className="visually-hidden">Import encrypted archive</span>
@@ -774,7 +787,7 @@ export function App(): JSX.Element {
             });
           }}
         >
-          Clear all saved data
+          {t('footer.clearAll')}
         </button>
       </footer>
     </main>

--- a/app/src/i18n/I18nContext.ts
+++ b/app/src/i18n/I18nContext.ts
@@ -1,0 +1,39 @@
+import { createContext, useContext } from 'react';
+import type { MessageKey } from './messages';
+
+/**
+ * Non-component exports for the i18n provider live here so the `.tsx`
+ * file remains fast-refresh-clean (components only). See `CLAUDE.md`
+ * → "React-refresh discipline".
+ */
+
+export const SUPPORTED_LOCALES = ['en', 'es'] as const;
+export type Locale = (typeof SUPPORTED_LOCALES)[number];
+
+export const LOCALE_STORAGE_KEY = 'leaseguard.locale';
+
+export interface I18nContextValue {
+  locale: Locale;
+  setLocale: (next: Locale) => void;
+  t: (key: MessageKey, params?: Record<string, string | number>) => string;
+}
+
+export const I18nContext = createContext<I18nContextValue | null>(null);
+
+export function useI18n(): I18nContextValue {
+  const ctx = useContext(I18nContext);
+  if (!ctx) throw new Error('useI18n must be used inside <I18nProvider>');
+  return ctx;
+}
+
+// Module-scoped warn dedupe — shared with the provider so the test reset
+// helper and the provider see the same set.
+export const warnedI18nKeys = new Set<string>();
+
+/**
+ * Test-only: reset the module-scoped warned-keys set so a test can
+ * assert the one-time warning behavior independently of test order.
+ */
+export function _resetI18nWarnedKeysForTests(): void {
+  warnedI18nKeys.clear();
+}

--- a/app/src/i18n/I18nProvider.test.tsx
+++ b/app/src/i18n/I18nProvider.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { I18nProvider } from './I18nProvider';
+import {
+  LOCALE_STORAGE_KEY,
+  useI18n,
+  _resetI18nWarnedKeysForTests,
+  type Locale,
+} from './I18nContext';
+import type { MessageKey } from './messages';
+
+function Probe({ msgKey, params }: { msgKey: MessageKey; params?: Record<string, string | number> }): JSX.Element {
+  const { t, locale, setLocale } = useI18n();
+  return (
+    <div>
+      <span data-testid="locale">{locale}</span>
+      <span data-testid="value">{t(msgKey, params)}</span>
+      <button type="button" onClick={() => setLocale('es')}>to-es</button>
+      <button type="button" onClick={() => setLocale('en')}>to-en</button>
+    </div>
+  );
+}
+
+describe('I18nProvider', () => {
+  // jsdom's `localStorage` in this project's test runtime is a stub
+  // without working setItem/getItem (some other harness wins). Install a
+  // simple in-memory shim per-test.
+  function installMemoryLocalStorage(): Map<string, string> {
+    const store = new Map<string, string>();
+    const shim: Storage = {
+      get length() {
+        return store.size;
+      },
+      clear: () => store.clear(),
+      getItem: (k) => (store.has(k) ? (store.get(k) as string) : null),
+      key: (i) => Array.from(store.keys())[i] ?? null,
+      removeItem: (k) => {
+        store.delete(k);
+      },
+      setItem: (k, v) => {
+        store.set(k, String(v));
+      },
+    };
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: shim,
+    });
+    return store;
+  }
+
+  beforeEach(() => {
+    installMemoryLocalStorage();
+    _resetI18nWarnedKeysForTests();
+  });
+
+  it('defaults to en when no locale is stored', () => {
+    render(
+      <I18nProvider>
+        <Probe msgKey="header.trySample" />
+      </I18nProvider>,
+    );
+    expect(screen.getByTestId('locale').textContent).toBe('en');
+    expect(screen.getByTestId('value').textContent).toBe('Try a sample lease');
+  });
+
+  it('reads the persisted locale from localStorage on mount', () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'es');
+    render(
+      <I18nProvider>
+        <Probe msgKey="header.trySample" />
+      </I18nProvider>,
+    );
+    expect(screen.getByTestId('locale').textContent).toBe('es');
+    expect(screen.getByTestId('value').textContent).toBe('Probar un contrato de ejemplo');
+  });
+
+  it('ignores an unknown locale in localStorage and falls back to en', () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'klingon' satisfies string as Locale);
+    render(
+      <I18nProvider>
+        <Probe msgKey="header.trySample" />
+      </I18nProvider>,
+    );
+    expect(screen.getByTestId('locale').textContent).toBe('en');
+  });
+
+  it('updates t and persists when setLocale is called', async () => {
+    const userEvent = (await import('@testing-library/user-event')).default;
+    const user = userEvent.setup();
+    render(
+      <I18nProvider>
+        <Probe msgKey="header.trySample" />
+      </I18nProvider>,
+    );
+    await user.click(screen.getByRole('button', { name: 'to-es' }));
+    expect(screen.getByTestId('locale').textContent).toBe('es');
+    expect(screen.getByTestId('value').textContent).toBe('Probar un contrato de ejemplo');
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('es');
+  });
+
+  it('falls back to en when the active locale is missing a key', () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'es');
+    render(
+      <I18nProvider>
+        {/* `findings.empty` is in en but not in the es stub. */}
+        <Probe msgKey="findings.empty" />
+      </I18nProvider>,
+    );
+    expect(screen.getByTestId('value').textContent).toBe('No findings yet.');
+  });
+
+  it('substitutes params via formatMessage', () => {
+    render(
+      <I18nProvider>
+        <Probe msgKey="status.analyzing" params={{ fileName: 'lease.pdf' }} />
+      </I18nProvider>,
+    );
+    expect(screen.getByTestId('value').textContent).toBe('Analyzing lease.pdf…');
+  });
+
+  it('logs once and returns the key string when missing in both active and en', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    function MissingProbe(): JSX.Element {
+      const { t } = useI18n();
+      // Cast: deliberately probing the missing-key path that real callers
+      // can't hit through types alone.
+      return <span data-testid="missing">{t('not.a.real.key' as unknown as MessageKey)}</span>;
+    }
+    render(
+      <I18nProvider>
+        <MissingProbe />
+      </I18nProvider>,
+    );
+    expect(screen.getByTestId('missing').textContent).toBe('not.a.real.key');
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('throws when useI18n is used outside the provider', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    function Bare(): JSX.Element {
+      useI18n();
+      return <span />;
+    }
+    expect(() => render(<Bare />)).toThrow(/useI18n must be used inside/);
+    errSpy.mockRestore();
+  });
+
+  it('respects initialLocale prop for tests/storybook', () => {
+    render(
+      <I18nProvider initialLocale="es">
+        <Probe msgKey="header.trySample" />
+      </I18nProvider>,
+    );
+    expect(screen.getByTestId('locale').textContent).toBe('es');
+  });
+
+  it('act/setLocale updates downstream consumers', () => {
+    let setLocaleRef: ((l: Locale) => void) | null = null;
+    function Capture(): JSX.Element {
+      const { setLocale, locale } = useI18n();
+      setLocaleRef = setLocale;
+      return <span data-testid="cap-locale">{locale}</span>;
+    }
+    render(
+      <I18nProvider>
+        <Capture />
+      </I18nProvider>,
+    );
+    expect(screen.getByTestId('cap-locale').textContent).toBe('en');
+    act(() => {
+      setLocaleRef?.('es');
+    });
+    expect(screen.getByTestId('cap-locale').textContent).toBe('es');
+  });
+});

--- a/app/src/i18n/I18nProvider.tsx
+++ b/app/src/i18n/I18nProvider.tsx
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import {
+  enMessages,
+  formatMessage,
+  type MessageKey,
+  type Messages,
+} from './messages';
+import { es } from './locales/es';
+import {
+  I18nContext,
+  LOCALE_STORAGE_KEY,
+  SUPPORTED_LOCALES,
+  warnedI18nKeys,
+  type I18nContextValue,
+  type Locale,
+} from './I18nContext';
+
+/**
+ * i18n provider with a strict three-step fallback chain:
+ *   active locale → en → key string (with a one-time console warning).
+ *
+ * Locale is read from `localStorage.leaseguard.locale` and persisted on
+ * change. Default is `'en'`. Storage failures (private browsing, quota)
+ * never throw — the provider falls back to the in-memory value.
+ *
+ * Non-component exports (the context object, `useI18n`, and types) live
+ * in `I18nContext.ts` so this file stays fast-refresh-clean.
+ */
+
+const CATALOGS: Record<Locale, Partial<Messages>> = {
+  en: enMessages,
+  es,
+};
+
+function readStoredLocale(): Locale {
+  try {
+    const raw = window.localStorage.getItem(LOCALE_STORAGE_KEY);
+    if (raw && (SUPPORTED_LOCALES as readonly string[]).includes(raw)) {
+      return raw as Locale;
+    }
+  } catch {
+    // localStorage unavailable (private mode, SSR-ish jsdom edge); fall through.
+  }
+  return 'en';
+}
+
+function writeStoredLocale(locale: Locale): void {
+  try {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+  } catch {
+    // Persistence is best-effort; the in-memory state is authoritative.
+  }
+}
+
+interface I18nProviderProps {
+  children: ReactNode;
+  /** Override the initial locale; primarily for tests + Storybook. */
+  initialLocale?: Locale;
+}
+
+export function I18nProvider({ children, initialLocale }: I18nProviderProps): JSX.Element {
+  const [locale, setLocaleState] = useState<Locale>(() => initialLocale ?? readStoredLocale());
+
+  useEffect(() => {
+    writeStoredLocale(locale);
+  }, [locale]);
+
+  const setLocale = useCallback((next: Locale): void => {
+    setLocaleState(next);
+  }, []);
+
+  const t = useCallback(
+    (key: MessageKey, params?: Record<string, string | number>): string => {
+      const active = CATALOGS[locale];
+      const fromActive = active[key];
+      if (typeof fromActive === 'string') return formatMessage(fromActive, params);
+      const fromEn = enMessages[key];
+      if (typeof fromEn === 'string') return formatMessage(fromEn, params);
+      if (!warnedI18nKeys.has(key)) {
+        warnedI18nKeys.add(key);
+        // eslint-disable-next-line no-console
+        console.warn(`[i18n] missing message for key "${key}" in locale "${locale}" and en fallback`);
+      }
+      return key;
+    },
+    [locale],
+  );
+
+  const value = useMemo<I18nContextValue>(() => ({ locale, setLocale, t }), [locale, setLocale, t]);
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}

--- a/app/src/i18n/locales/es.ts
+++ b/app/src/i18n/locales/es.ts
@@ -1,0 +1,32 @@
+/**
+ * Spanish (es) stub locale.
+ *
+ * Partial coverage is acceptable for Wave 11; missing keys fall back to
+ * `en` per the `I18nProvider` resolution rules. This is a seed — full
+ * translation review is out of scope for the scaffold.
+ */
+
+import type { Messages } from '../messages';
+
+export const es: Partial<Messages> = {
+  'app.title': 'LeaseGuard',
+  'app.tagline': 'Analizador de contratos local y privado. Nada sale de su dispositivo.',
+  'header.privacy.summary': 'Privacidad y cómo funciona',
+  'header.upload.label': 'Cargar contrato',
+  'header.trySample': 'Probar un contrato de ejemplo',
+  'header.view.current': 'Contrato actual',
+  'header.view.portfolio': 'Cartera',
+  'header.view.redline': 'Edición',
+
+  'locale.picker.label': 'Idioma',
+  'locale.picker.en': 'Inglés',
+  'locale.picker.es': 'Español',
+
+  'status.analyzing': 'Analizando {fileName}…',
+  'status.error': 'No se pudo analizar este archivo: {message}',
+
+  'findings.export.json': 'Exportar resultados (JSON)',
+  'findings.export.html': 'Exportar resultados (HTML imprimible)',
+
+  'footer.clearAll': 'Borrar todos los datos guardados',
+};

--- a/app/src/i18n/messages.test.ts
+++ b/app/src/i18n/messages.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { en, enMessages, formatMessage, type MessageKey } from './messages';
+import { es } from './locales/es';
+
+describe('i18n messages', () => {
+  it('every en key has a non-empty string value', () => {
+    for (const [key, value] of Object.entries(enMessages)) {
+      expect(typeof value, `${key} should be a string`).toBe('string');
+      expect(value.length, `${key} should be non-empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('en key set matches the Messages type at runtime', () => {
+    // `enMessages` is typed as `Messages` (a Record over MessageKey),
+    // so the key set is the source of truth. This guards against an
+    // accidental `as` cast hiding a missing key.
+    const enKeys = Object.keys(en).sort();
+    const baselineKeys = Object.keys(enMessages).sort();
+    expect(enKeys).toEqual(baselineKeys);
+  });
+
+  it('es stub uses only known message keys', () => {
+    const enKeys = new Set<string>(Object.keys(en));
+    for (const key of Object.keys(es)) {
+      expect(enKeys.has(key), `es has unknown key "${key}"`).toBe(true);
+    }
+  });
+
+  it('es is intentionally partial — at least one en key is absent (fallback chain matters)', () => {
+    const enKeys = Object.keys(en) as MessageKey[];
+    const esKeys = new Set<string>(Object.keys(es));
+    const missing = enKeys.filter((k) => !esKeys.has(k));
+    expect(missing.length).toBeGreaterThan(0);
+  });
+});
+
+describe('formatMessage', () => {
+  it('returns the template unchanged when no params are supplied', () => {
+    expect(formatMessage('Hello world')).toBe('Hello world');
+  });
+
+  it('substitutes {name} placeholders from params', () => {
+    expect(formatMessage('Hello {who}', { who: 'world' })).toBe('Hello world');
+  });
+
+  it('coerces numeric params to strings', () => {
+    expect(formatMessage('{count} findings', { count: 3 })).toBe('3 findings');
+  });
+
+  it('leaves unknown placeholders untouched so typos are visible', () => {
+    expect(formatMessage('Hello {who}', { other: 'x' })).toBe('Hello {who}');
+  });
+
+  it('substitutes multiple placeholders', () => {
+    expect(formatMessage('{a} + {b}', { a: '1', b: '2' })).toBe('1 + 2');
+  });
+});

--- a/app/src/i18n/messages.ts
+++ b/app/src/i18n/messages.ts
@@ -1,0 +1,70 @@
+/**
+ * i18n message catalog — `en` baseline.
+ *
+ * Keys are flat dotted strings (`findings.empty`, `pack.import.success`).
+ * The `Messages` type is derived from the `en` catalog so every locale is
+ * forced — by `satisfies Partial<Messages>` — to use a known key.
+ *
+ * Locale resolution + fallback live in `I18nProvider.tsx`. The fallback
+ * chain is: active locale → `en` → key string (with a one-time console
+ * warning on a fully-missing key).
+ *
+ * No formatting library; `formatMessage(template, params)` does
+ * `{name}` interpolation only. Pluralization + ICU are explicitly out of
+ * scope for the Wave 11 scaffold.
+ */
+
+export const en = {
+  // Header / nav
+  'app.title': 'LeaseGuard',
+  'app.tagline': 'Private, local-first lease analyzer. Nothing leaves your device.',
+  'header.privacy.summary': 'Privacy & how this works',
+  'header.upload.label': 'Upload lease',
+  'header.trySample': 'Try a sample lease',
+  'header.view.current': 'Current lease',
+  'header.view.portfolio': 'Portfolio',
+  'header.view.redline': 'Redline',
+
+  // Locale picker
+  'locale.picker.label': 'Language',
+  'locale.picker.en': 'English',
+  'locale.picker.es': 'Español',
+
+  // Status / errors
+  'status.analyzing': 'Analyzing {fileName}…',
+  'status.error': 'Could not analyze this file: {message}',
+
+  // Findings actions
+  'findings.export.json': 'Export findings (JSON)',
+  'findings.export.html': 'Export findings (printable HTML)',
+  'findings.export.signed': 'Export findings (signed JSON)',
+  'findings.empty': 'No findings yet.',
+
+  // Pack manager messages (used by future migrations; seeded now)
+  'pack.import.success': 'Pack imported.',
+  'pack.import.failure': 'Pack import failed: {message}',
+
+  // Footer
+  'footer.archive.export': 'Export encrypted archive',
+  'footer.archive.import': 'Import encrypted archive',
+  'footer.clearAll': 'Clear all saved data',
+} as const;
+
+export type MessageKey = keyof typeof en;
+export type Messages = Record<MessageKey, string>;
+
+// `en` must structurally satisfy the full `Messages` record.
+export const enMessages: Messages = en satisfies Messages;
+
+/**
+ * Hand-rolled `{name}` interpolation. No ICU, no pluralization.
+ * Unknown placeholders are left untouched so a typo surfaces in QA
+ * instead of being silently dropped.
+ */
+export function formatMessage(template: string, params?: Record<string, string | number>): string {
+  if (!params) return template;
+  return template.replace(/\{(\w+)\}/g, (match, name: string) => {
+    const value = params[name];
+    return value === undefined ? match : String(value);
+  });
+}

--- a/app/src/ui/LocalePickerPanel.stories.tsx
+++ b/app/src/ui/LocalePickerPanel.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LocalePickerPanel } from './LocalePickerPanel';
+import { I18nProvider } from '../i18n/I18nProvider';
+import type { Locale } from '../i18n/I18nContext';
+
+interface WrapperProps {
+  initialLocale: Locale;
+}
+
+function Wrapper({ initialLocale }: WrapperProps): JSX.Element {
+  return (
+    <I18nProvider initialLocale={initialLocale}>
+      <LocalePickerPanel />
+    </I18nProvider>
+  );
+}
+
+const meta = {
+  title: 'UI/LocalePickerPanel',
+  component: Wrapper,
+  args: {
+    initialLocale: 'en',
+  },
+} satisfies Meta<typeof Wrapper>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const English: Story = {
+  args: { initialLocale: 'en' },
+};
+
+export const Spanish: Story = {
+  args: { initialLocale: 'es' },
+};

--- a/app/src/ui/LocalePickerPanel.test.tsx
+++ b/app/src/ui/LocalePickerPanel.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LocalePickerPanel } from './LocalePickerPanel';
+import { I18nProvider } from '../i18n/I18nProvider';
+import {
+  LOCALE_STORAGE_KEY,
+  useI18n,
+  _resetI18nWarnedKeysForTests,
+} from '../i18n/I18nContext';
+
+function ActiveLocaleProbe(): JSX.Element {
+  const { locale } = useI18n();
+  return <span data-testid="active-locale">{locale}</span>;
+}
+
+describe('LocalePickerPanel', () => {
+  beforeEach(() => {
+    // See note in I18nProvider.test.tsx — install a working in-memory shim.
+    const store = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        get length() {
+          return store.size;
+        },
+        clear: () => store.clear(),
+        getItem: (k: string) => (store.has(k) ? (store.get(k) as string) : null),
+        key: (i: number) => Array.from(store.keys())[i] ?? null,
+        removeItem: (k: string) => {
+          store.delete(k);
+        },
+        setItem: (k: string, v: string) => {
+          store.set(k, String(v));
+        },
+      } satisfies Storage,
+    });
+    _resetI18nWarnedKeysForTests();
+  });
+
+  it('renders a select with both supported locales', () => {
+    render(
+      <I18nProvider>
+        <LocalePickerPanel />
+      </I18nProvider>,
+    );
+    const select = screen.getByRole('combobox', { name: /language/i });
+    expect(select).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'English' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Español' })).toBeInTheDocument();
+  });
+
+  it('reflects the current locale as the selected option', () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'es');
+    render(
+      <I18nProvider>
+        <LocalePickerPanel />
+      </I18nProvider>,
+    );
+    const select = screen.getByRole('combobox', { name: /idioma/i }) as HTMLSelectElement;
+    expect(select.value).toBe('es');
+  });
+
+  it('persists the chosen locale to localStorage and updates the active locale', async () => {
+    const user = userEvent.setup();
+    render(
+      <I18nProvider>
+        <LocalePickerPanel />
+        <ActiveLocaleProbe />
+      </I18nProvider>,
+    );
+    expect(screen.getByTestId('active-locale').textContent).toBe('en');
+    await user.selectOptions(
+      screen.getByRole('combobox', { name: /language/i }),
+      'es',
+    );
+    expect(screen.getByTestId('active-locale').textContent).toBe('es');
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('es');
+  });
+});

--- a/app/src/ui/LocalePickerPanel.tsx
+++ b/app/src/ui/LocalePickerPanel.tsx
@@ -1,0 +1,37 @@
+import type { ChangeEvent } from 'react';
+import {
+  SUPPORTED_LOCALES,
+  useI18n,
+  type Locale,
+} from '../i18n/I18nContext';
+
+/**
+ * Header-mounted locale picker. Reads/writes locale through the i18n
+ * context (which persists to `localStorage.leaseguard.locale`). Renders
+ * as a `<select>` so it stays compact next to the existing nav and is
+ * keyboard-operable for free.
+ */
+export function LocalePickerPanel(): JSX.Element {
+  const { locale, setLocale, t } = useI18n();
+
+  function onChange(e: ChangeEvent<HTMLSelectElement>): void {
+    const next = e.target.value;
+    if ((SUPPORTED_LOCALES as readonly string[]).includes(next)) {
+      setLocale(next as Locale);
+    }
+  }
+
+  return (
+    <label className="locale-picker">
+      <span className="visually-hidden">{t('locale.picker.label')}</span>
+      <select
+        aria-label={t('locale.picker.label')}
+        value={locale}
+        onChange={onChange}
+      >
+        <option value="en">{t('locale.picker.en')}</option>
+        <option value="es">{t('locale.picker.es')}</option>
+      </select>
+    </label>
+  );
+}

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -289,6 +289,32 @@ table for the authoritative figures):
 - Archive export/import uses WebCrypto AES-GCM. No handshake ever
   leaves the device.
 
+## i18n (Wave 11 / Phase 14)
+
+Hand-rolled, dependency-free localization. The `Messages` type in
+`src/i18n/messages.ts` is derived from the `en` baseline catalog so
+every locale is forced — via `satisfies Partial<Messages>` — to use a
+known key. Translation files live at `src/i18n/locales/<code>.ts` and
+may be partial.
+
+`I18nProvider.tsx` exposes `useI18n()` returning `{ locale, setLocale,
+t }`. Resolution chain on each `t(key, params?)` call:
+
+1. Active locale catalog.
+2. `en` baseline.
+3. The key string itself, with a one-time `console.warn` so a
+   missing-in-both case surfaces in QA without console spam.
+
+Locale persists in `localStorage.leaseguard.locale`; default `'en'`.
+`{name}` placeholder substitution is the only formatting affordance —
+no ICU, no pluralization. Date/number formatting still uses the
+platform `toLocaleDateString` / `toLocaleString` APIs.
+
+The Wave 11 scaffold migrates ~10 representative `App.tsx` strings
+(header, view-mode toggle, top-level export buttons, footer
+clear-all). Full panel-by-panel migration is a tracked Phase 14
+follow-up.
+
 ## Collaboration escape hatches (Wave 9 / Phase 15)
 
 Phase 15 adds three user-initiated sharing surfaces on top of the


### PR DESCRIPTION
## Summary
- `messages.ts` (en baseline) + `locales/es.ts` stub with en fallback
- `I18nProvider` (React context, localStorage `leaseguard.locale`, default `en`)
- `LocalePickerPanel` (4-file panel) mounted in header
- Migrate 12 representative App.tsx strings to `t(...)`
- No new deps; hand-rolled `formatMessage(key, params)`

Wave 11 Part B. Branched from `e3f5f3f`.

## Test plan
- [x] typecheck + lint + tests green locally (+22 tests; 912 pass)
- [ ] CI green
- [ ] Locale switch persists across reload (manual)