### PR TITLE
wave11-C: OCR language picker

### DIFF
--- a/app/public/tesseract/README.md
+++ b/app/public/tesseract/README.md
@@ -1,0 +1,50 @@
+# Tesseract assets (same-origin)
+
+LeaseGuard's CSP is `default-src 'self'`, so every OCR asset must be
+served from this directory — no CDN fetches are allowed at runtime.
+
+## Files
+
+- `worker.min.js`, `tesseract-core.wasm`, `tesseract-core.wasm.js` —
+  the tesseract.js runtime, copied from `node_modules` on `postinstall`.
+- `*.traineddata.gz` — language data files. Manually placed; not
+  installed automatically. Each one corresponds to a tesseract language
+  code (e.g. `eng.traineddata.gz`).
+- `languages.json` — the manifest the OCR language picker reads at
+  runtime. Schema: `leaseguard.tesseract.languages.v1`.
+
+## Adding a new OCR language
+
+1. Download the `<code>.traineddata.gz` file from the upstream
+   tesseract data repo (only `tessdata_fast` is supported by
+   tesseract.js v5). Place it in this directory (`app/public/tesseract/`).
+2. Append a corresponding entry to `languages.json`:
+
+   ```json
+   {
+     "schema": "leaseguard.tesseract.languages.v1",
+     "languages": [
+       { "code": "eng", "label": "English" },
+       { "code": "spa", "label": "Spanish" }
+     ]
+   }
+   ```
+
+3. Rebuild the app. The picker will surface the new language
+   automatically; no code changes are required.
+
+## Removing a language
+
+Delete both the `*.traineddata.gz` file and its entry in
+`languages.json`. If only one language remains, the picker renders a
+static label rather than a dropdown.
+
+## Manifest contract
+
+- `schema` MUST be the literal string `leaseguard.tesseract.languages.v1`.
+- `languages` MUST be an array of `{ code: string, label: string }`.
+  `code` is the tesseract language code (3-letter ISO 639-2/T).
+- An empty array hides the picker entirely.
+- A missing or malformed `languages.json` is treated the same as an
+  empty manifest — OCR still works in English by default, but no
+  picker UI is shown.

--- a/app/public/tesseract/languages.json
+++ b/app/public/tesseract/languages.json
@@ -1,0 +1,6 @@
+{
+  "schema": "leaseguard.tesseract.languages.v1",
+  "languages": [
+    { "code": "eng", "label": "English" }
+  ]
+}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -64,6 +64,8 @@ import { RedlinePanel } from './ui/RedlinePanel';
 import { VersionHistoryPanel } from './ui/VersionHistoryPanel';
 import { SideLetterPanel } from './ui/SideLetterPanel';
 import { needsOcr } from './compare/needsOcr';
+import { discoverOcrLanguages, type OcrLanguage } from './ocr/availableLanguages';
+import { OcrLanguagePickerPanel } from './ui/OcrLanguagePickerPanel';
 import type { Finding } from './rules/types';
 import type { ClauseTemplate } from './templates/types';
 import { matchTemplates } from './templates/matchTemplates';
@@ -121,6 +123,18 @@ function AppContent(): JSX.Element {
   // Static legal glossary (Wave 11 Part A): loaded once at mount via the
   // single same-origin fetch the app makes. Failures fall back to [].
   const [glossaryEntries, setGlossaryEntries] = useState<GlossaryEntry[]>([]);
+  const [ocrLanguages, setOcrLanguages] = useState<OcrLanguage[]>([]);
+  const [ocrLanguage, setOcrLanguage] = useState<string>('eng');
+
+  useEffect(() => {
+    void discoverOcrLanguages().then((langs) => {
+      setOcrLanguages(langs);
+      if (langs.length > 0 && !langs.some((l) => l.code === 'eng')) {
+        const first = langs[0];
+        if (first) setOcrLanguage(first.code);
+      }
+    });
+  }, []);
 
   useEffect(() => {
     void getOnboardingDismissedAt().then((ts) => setOnboardingDismissedAtState(ts));
@@ -552,10 +566,15 @@ function AppContent(): JSX.Element {
                   Text extraction may be incomplete.
                 </p>
                 {status.bytes && ocrState.kind !== 'running' && (
-                  <button type="button" onClick={() => { setSelected(null); void pipeline.ocr(); }}>
+                  <button type="button" onClick={() => { setSelected(null); void pipeline.ocr(ocrLanguage); }}>
                     Attempt OCR
                   </button>
                 )}
+                <OcrLanguagePickerPanel
+                  available={ocrLanguages}
+                  selected={ocrLanguage}
+                  onChange={setOcrLanguage}
+                />
                 {ocrState.kind === 'running' && (
                   <p aria-live="polite" className="ocr-progress">
                     Running OCR: {ocrState.stage} ({Math.round(ocrState.pct * 100)}%)

--- a/app/src/App/usePipeline.ts
+++ b/app/src/App/usePipeline.ts
@@ -35,7 +35,7 @@ export interface PipelineApi {
   /** Upload + parse + analyze + save + auto-compare. */
   upload: (bytes: Uint8Array, fileName: string) => Promise<void>;
   /** Re-run analyze over the currently loaded doc via OCR. */
-  ocr: () => Promise<void>;
+  ocr: (language?: string) => Promise<void>;
   /** Overwrite status to `analyzed` with a pre-loaded LeaseRecord (e.g. opening from library). */
   open: (record: LeaseRecord) => void;
   /**
@@ -149,7 +149,7 @@ export function usePipeline(deps: UsePipelineDeps = {}): PipelineApi {
     [onLibraryChange, activeRules, client],
   );
 
-  const ocr = useCallback(async (): Promise<void> => {
+  const ocr = useCallback(async (language?: string): Promise<void> => {
     if (status.kind !== 'analyzed' || !status.bytes) return;
     setOcrState({ kind: 'running', pct: 0, stage: 'starting' });
     try {
@@ -157,6 +157,7 @@ export function usePipeline(deps: UsePipelineDeps = {}): PipelineApi {
       // and keep the original for the viewer.
       const doc = await runOcr(copyBytes(status.bytes), {
         onProgress: (p) => setOcrState({ kind: 'running', pct: p.pct, stage: p.stage }),
+        ...(language ? { language } : {}),
       });
       const findings = analyze(doc, activeRules);
       setStatus({

--- a/app/src/ocr/availableLanguages.test.ts
+++ b/app/src/ocr/availableLanguages.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest';
+import { discoverOcrLanguages } from './availableLanguages';
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('discoverOcrLanguages', () => {
+  it('returns the manifest entries on the happy path', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        schema: 'leaseguard.tesseract.languages.v1',
+        languages: [
+          { code: 'eng', label: 'English' },
+          { code: 'spa', label: 'Spanish' },
+        ],
+      }),
+    );
+    const langs = await discoverOcrLanguages(fetchMock as unknown as typeof fetch);
+    expect(langs).toEqual([
+      { code: 'eng', label: 'English' },
+      { code: 'spa', label: 'Spanish' },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith('/tesseract/languages.json');
+  });
+
+  it('only fetches the same-origin manifest path', async () => {
+    const seenUrls: string[] = [];
+    const fetchMock = (async (url: string): Promise<Response> => {
+      seenUrls.push(String(url));
+      return jsonResponse({
+        schema: 'leaseguard.tesseract.languages.v1',
+        languages: [{ code: 'eng', label: 'English' }],
+      });
+    }) as unknown as typeof fetch;
+    await discoverOcrLanguages(fetchMock);
+    expect(seenUrls).toHaveLength(1);
+    const url = seenUrls[0] ?? '';
+    expect(url.startsWith('/')).toBe(true);
+    expect(url).not.toMatch(/^https?:/);
+  });
+
+  it('returns [] when the manifest is missing (404)', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({}, false));
+    expect(await discoverOcrLanguages(fetchMock as unknown as typeof fetch)).toEqual([]);
+  });
+
+  it('returns [] on a network error', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('network down');
+    });
+    expect(await discoverOcrLanguages(fetchMock as unknown as typeof fetch)).toEqual([]);
+  });
+
+  it('returns [] on malformed JSON', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          json: async () => {
+            throw new Error('bad json');
+          },
+        }) as unknown as Response,
+    );
+    expect(await discoverOcrLanguages(fetchMock as unknown as typeof fetch)).toEqual([]);
+  });
+
+  it('rejects payloads with the wrong schema id', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        schema: 'something.else.v1',
+        languages: [{ code: 'eng', label: 'English' }],
+      }),
+    );
+    expect(await discoverOcrLanguages(fetchMock as unknown as typeof fetch)).toEqual([]);
+  });
+
+  it('rejects payloads with malformed entries', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        schema: 'leaseguard.tesseract.languages.v1',
+        languages: [{ code: 'eng' }],
+      }),
+    );
+    expect(await discoverOcrLanguages(fetchMock as unknown as typeof fetch)).toEqual([]);
+  });
+
+  it('returns [] when languages is missing entirely', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ schema: 'leaseguard.tesseract.languages.v1' }),
+    );
+    expect(await discoverOcrLanguages(fetchMock as unknown as typeof fetch)).toEqual([]);
+  });
+});

--- a/app/src/ocr/availableLanguages.ts
+++ b/app/src/ocr/availableLanguages.ts
@@ -1,0 +1,54 @@
+// Discover which tesseract OCR languages have been provisioned in
+// `public/tesseract/`. The CSP contract is `default-src 'self'`, so the
+// only allowed fetch here is the same-origin static manifest at
+// `/tesseract/languages.json`. Any malformed / missing manifest yields
+// an empty array, which the picker UI treats as "hide the picker".
+
+export interface OcrLanguage {
+  code: string;
+  label: string;
+}
+
+interface ManifestShape {
+  schema: string;
+  languages: OcrLanguage[];
+}
+
+const MANIFEST_PATH = '/tesseract/languages.json';
+const SCHEMA_ID = 'leaseguard.tesseract.languages.v1';
+
+function isManifest(value: unknown): value is ManifestShape {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  if (v['schema'] !== SCHEMA_ID) return false;
+  if (!Array.isArray(v['languages'])) return false;
+  for (const entry of v['languages']) {
+    if (!entry || typeof entry !== 'object') return false;
+    const e = entry as Record<string, unknown>;
+    if (typeof e['code'] !== 'string' || e['code'].length === 0) return false;
+    if (typeof e['label'] !== 'string' || e['label'].length === 0) return false;
+  }
+  return true;
+}
+
+export async function discoverOcrLanguages(
+  fetchImpl: typeof fetch = fetch,
+): Promise<OcrLanguage[]> {
+  let res: Response;
+  try {
+    res = await fetchImpl(MANIFEST_PATH);
+  } catch {
+    return [];
+  }
+  if (!res.ok) return [];
+  let parsed: unknown;
+  try {
+    parsed = await res.json();
+  } catch {
+    return [];
+  }
+  if (!isManifest(parsed)) return [];
+  // Defensive copy: the picker mutates nothing but we do not want the
+  // caller to be able to mutate the cached parsed payload either.
+  return parsed.languages.map((l) => ({ code: l.code, label: l.label }));
+}

--- a/app/src/ocr/runOcr.test.ts
+++ b/app/src/ocr/runOcr.test.ts
@@ -92,6 +92,18 @@ describe('runOcr', () => {
     expect(optsArg?.langPath).toBe('/tesseract');
   });
 
+  it("defaults to 'eng' when no language is supplied", async () => {
+    recognizeMock.mockResolvedValue({ data: { text: 'x' } });
+    await runOcr(new Uint8Array([1]));
+    expect(recognizeMock.mock.calls[0]?.[1]).toBe('eng');
+  });
+
+  it('threads an explicit language through to tesseract.recognize', async () => {
+    recognizeMock.mockResolvedValue({ data: { text: 'x' } });
+    await runOcr(new Uint8Array([1]), { language: 'spa' });
+    expect(recognizeMock.mock.calls[0]?.[1]).toBe('spa');
+  });
+
   it('tolerates missing text on a recognize result', async () => {
     recognizeMock.mockResolvedValue({ data: {} });
     const doc = await runOcr(new Uint8Array([1]));

--- a/app/src/ocr/runOcr.ts
+++ b/app/src/ocr/runOcr.ts
@@ -11,6 +11,10 @@ export interface RunOcrOptions {
   onProgress?: (p: OcrProgress) => void;
   // Rendering scale; higher = better OCR quality, larger canvas.
   scale?: number;
+  // Tesseract language code (e.g. `'eng'`, `'spa'`). Must correspond to a
+  // `<code>.traineddata.gz` file present in `public/tesseract/`. Defaults
+  // to `'eng'` so existing callers are unaffected.
+  language?: string;
   // Override the same-origin asset paths. Useful for tests.
   workerPath?: string;
   corePath?: string;
@@ -22,6 +26,7 @@ export interface RunOcrOptions {
 const DEFAULT_WORKER_PATH = '/tesseract/worker.min.js';
 const DEFAULT_CORE_PATH = '/tesseract/tesseract-core.wasm.js';
 const DEFAULT_LANG_PATH = '/tesseract';
+const DEFAULT_LANGUAGE = 'eng';
 const DEFAULT_SCALE = 2;
 
 // Creates a canvas for off-screen rendering. `OffscreenCanvas` would be nicer
@@ -49,6 +54,7 @@ export async function runOcr(
   const workerPath = opts.workerPath ?? DEFAULT_WORKER_PATH;
   const corePath = opts.corePath ?? DEFAULT_CORE_PATH;
   const langPath = opts.langPath ?? DEFAULT_LANG_PATH;
+  const language = opts.language ?? DEFAULT_LANGUAGE;
 
   onProgress?.({ pct: 0, stage: 'loading pdf' });
 
@@ -74,7 +80,7 @@ export async function runOcr(
       stage: `ocr page ${i}/${numPages}`,
     });
 
-    const result = await tesseract.recognize(canvas, 'eng', {
+    const result = await tesseract.recognize(canvas, language, {
       workerPath,
       corePath,
       langPath,

--- a/app/src/ui/OcrLanguagePickerPanel.stories.tsx
+++ b/app/src/ui/OcrLanguagePickerPanel.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { OcrLanguagePickerPanel } from './OcrLanguagePickerPanel';
+
+const meta = {
+  title: 'UI/OcrLanguagePickerPanel',
+  component: OcrLanguagePickerPanel,
+  args: {
+    onChange: () => {},
+  },
+} satisfies Meta<typeof OcrLanguagePickerPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  args: {
+    available: [],
+    selected: 'eng',
+  },
+};
+
+export const SingleLanguage: Story = {
+  args: {
+    available: [{ code: 'eng', label: 'English' }],
+    selected: 'eng',
+  },
+};
+
+export const MultipleLanguages: Story = {
+  args: {
+    available: [
+      { code: 'eng', label: 'English' },
+      { code: 'spa', label: 'Spanish' },
+      { code: 'fra', label: 'French' },
+    ],
+    selected: 'eng',
+  },
+};

--- a/app/src/ui/OcrLanguagePickerPanel.test.tsx
+++ b/app/src/ui/OcrLanguagePickerPanel.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { OcrLanguagePickerPanel } from './OcrLanguagePickerPanel';
+
+describe('OcrLanguagePickerPanel', () => {
+  it('renders nothing when no languages are available', () => {
+    const { container } = render(
+      <OcrLanguagePickerPanel available={[]} selected="eng" onChange={() => {}} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a static label when only one language is available', () => {
+    render(
+      <OcrLanguagePickerPanel
+        available={[{ code: 'eng', label: 'English' }]}
+        selected="eng"
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText('English')).toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).toBeNull();
+  });
+
+  it('renders a select when multiple languages are available', () => {
+    render(
+      <OcrLanguagePickerPanel
+        available={[
+          { code: 'eng', label: 'English' },
+          { code: 'spa', label: 'Spanish' },
+        ]}
+        selected="eng"
+        onChange={() => {}}
+      />,
+    );
+    const select = screen.getByRole('combobox', { name: /ocr language/i });
+    expect(select).toHaveValue('eng');
+    expect(screen.getByRole('option', { name: 'Spanish' })).toBeInTheDocument();
+  });
+
+  it('emits onChange when the user picks another language', async () => {
+    const onChange = vi.fn();
+    render(
+      <OcrLanguagePickerPanel
+        available={[
+          { code: 'eng', label: 'English' },
+          { code: 'spa', label: 'Spanish' },
+        ]}
+        selected="eng"
+        onChange={onChange}
+      />,
+    );
+    const select = screen.getByRole('combobox', { name: /ocr language/i });
+    await userEvent.selectOptions(select, 'spa');
+    expect(onChange).toHaveBeenCalledWith('spa');
+  });
+});

--- a/app/src/ui/OcrLanguagePickerPanel.tsx
+++ b/app/src/ui/OcrLanguagePickerPanel.tsx
@@ -1,0 +1,54 @@
+import type { ChangeEvent } from 'react';
+import type { OcrLanguage } from '../ocr/availableLanguages';
+
+export interface OcrLanguagePickerPanelProps {
+  /**
+   * Languages discovered from `/tesseract/languages.json`. An empty
+   * array hides the panel entirely (no traineddata files provisioned).
+   */
+  available: OcrLanguage[];
+  /** Currently-selected language code. */
+  selected: string;
+  onChange: (next: string) => void;
+}
+
+export function OcrLanguagePickerPanel({
+  available,
+  selected,
+  onChange,
+}: OcrLanguagePickerPanelProps): JSX.Element | null {
+  if (available.length === 0) return null;
+
+  if (available.length === 1) {
+    // No choice to make — render a static label so the user still sees
+    // which language OCR will run in, but no <select> is exposed.
+    const only = available[0];
+    if (!only) return null;
+    return (
+      <section aria-label="ocr language" className="ocr-language">
+        <p>
+          OCR language: <strong>{only.label}</strong>
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section aria-label="ocr language" className="ocr-language">
+      <label>
+        <span>OCR language</span>
+        <select
+          aria-label="ocr language"
+          value={selected}
+          onChange={(e: ChangeEvent<HTMLSelectElement>) => onChange(e.target.value)}
+        >
+          {available.map((lang) => (
+            <option key={lang.code} value={lang.code}>
+              {lang.label}
+            </option>
+          ))}
+        </select>
+      </label>
+    </section>
+  );
+}

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -278,7 +278,16 @@ table for the authoritative figures):
 - `tesseract/*` — OCR runtime, copied from `node_modules` on
   `postinstall`, served same-origin. `eng.traineddata.gz` (language
   data) must be placed manually in `public/tesseract/` — we don't
-  fetch it at install time.
+  fetch it at install time. Additional languages are opt-in: drop
+  `<code>.traineddata.gz` next to it and append a matching entry to
+  `public/tesseract/languages.json` (schema
+  `leaseguard.tesseract.languages.v1`, an array of
+  `{ code, label }`). At runtime `discoverOcrLanguages()` fetches the
+  manifest from the same origin (`/tesseract/languages.json`) — the
+  only OCR-related fetch in the app and the only one allowed by CSP.
+  When the manifest is missing, malformed, or empty the language
+  picker is hidden and OCR runs in `eng` by default; when it lists a
+  single entry the UI renders a static label rather than a dropdown.
 
 ## Privacy contract
 


### PR DESCRIPTION
## Summary
- Same-origin manifest at `/tesseract/languages.json` + README
- `discoverOcrLanguages()` with empty-fallback on missing/invalid
- `runOcr` accepts optional `language?` (default `'eng'`); existing callers unchanged
- `OcrLanguagePickerPanel` (4-file): picker when >1 lang, static label when 1, hidden when empty
- Mount picker next to OCR banner

Wave 11 Part C. Branched from `e3f5f3f`.

## Test plan
- [x] typecheck + lint + targeted tests green locally (20/20)
- [ ] CI green