### PR TITLE
fix(cli): drop rootDir from cli/tsconfig.json

### DIFF
--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -11,7 +11,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "outDir": "./dist",
-    "rootDir": "./src",
     "types": ["node", "vitest/globals"],
     "paths": {
       "@app/*": ["../app/src/*"]


### PR DESCRIPTION
## Summary
`cli/tsconfig.json`'s `include` reaches into `../app/src/parser/**` and `../app/src/rules/**` (the cli imports those modules), but `rootDir: "./src"` told tsc those files must live under `cli/src`. Result: TS6059 on ~15 files, breaking the CI `verify` job for cli on every PR since at least Wave 8.

Drop `rootDir`; tsc infers it from the common ancestor of the include set. CI is `tsc -b --noEmit`, so no emit/output layout change.

## Test plan
- [x] `cd cli && rm -f tsconfig.tsbuildinfo && npm run typecheck` — clean locally
- [ ] CI verify (cli) green