### PR TITLE
wave10-B: clause similarity (shingles, clustering, IDB v5)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -59,6 +59,9 @@ import { AnnotationsPanel } from './ui/AnnotationsPanel';
 import { CounterOfferPanel } from './ui/CounterOfferPanel';
 import type { CounterOffer } from './negotiation/counterOffers';
 import { PortfolioPanel } from './ui/PortfolioPanel';
+import { ClauseSimilarityPanel } from './ui/ClauseSimilarityPanel';
+import { clusterParagraphs, type ClauseCluster } from './portfolio/clauseClusters';
+import { paragraphShingles } from './portfolio/shingles';
 import { CustomRuleBuilderPanel } from './ui/CustomRuleBuilderPanel';
 import { RedlinePanel } from './ui/RedlinePanel';
 import { VersionHistoryPanel } from './ui/VersionHistoryPanel';
@@ -83,15 +86,36 @@ import {
   getStandardId,
   listAllLeaseRecords,
   listLeases,
+  putParagraphShingles,
   renameLease,
   setOnboardingDismissedAt,
   setStandardId,
   type LeaseMetadata,
+  type LeaseRecord,
 } from './storage/storage';
 import { OnboardingTour } from './ui/OnboardingTour';
 import { I18nProvider } from './i18n/I18nProvider';
 import { useI18n } from './i18n/I18nContext';
 import { LocalePickerPanel } from './ui/LocalePickerPanel';
+
+async function persistShingles(records: LeaseRecord[]): Promise<void> {
+  for (const record of records) {
+    const paragraphs = record.doc?.paragraphs ?? [];
+    for (let i = 0; i < paragraphs.length; i++) {
+      const text = paragraphs[i]?.text ?? '';
+      const shingles = paragraphShingles(text);
+      try {
+        await putParagraphShingles({
+          leaseId: record.id,
+          paragraphIndex: i,
+          shingles,
+        });
+      } catch {
+        // Ignore individual write failures — clustering already succeeded.
+      }
+    }
+  }
+}
 
 export function App(): JSX.Element {
   return (
@@ -114,6 +138,7 @@ function AppContent(): JSX.Element {
   const [portfolioFindings, setPortfolioFindings] = useState<Map<string, Finding[]>>(
     new Map(),
   );
+  const [clauseClusters, setClauseClusters] = useState<ClauseCluster[]>([]);
   // `undefined` = "not yet loaded from IDB" — we render nothing for the tour
   // until we know, so first-run users don't see a flash-of-modal followed by
   // dismissal. `null` = first run, show the tour. number = already dismissed.
@@ -257,6 +282,19 @@ function AppContent(): JSX.Element {
         const map = new Map<string, Finding[]>();
         for (const r of records) map.set(r.id, r.findings);
         setPortfolioFindings(map);
+        // Wave 10-B: cluster paragraphs and write-through shingles to IDB so
+        // a future cross-cluster pass can read them without re-tokenizing.
+        // Failures are logged and dropped — clustering must not block the
+        // portfolio view.
+        try {
+          const clusters = clusterParagraphs(records);
+          setClauseClusters(clusters);
+          await persistShingles(records);
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn('clause similarity failed', err);
+          setClauseClusters([]);
+        }
       })();
     }
   }, [view, library]);
@@ -457,14 +495,23 @@ function AppContent(): JSX.Element {
       )}
 
       {view === 'portfolio' && (
-        <PortfolioPanel
-          leases={library}
-          findingsByLease={portfolioFindings}
-          onOpenLease={(id) => {
-            setView('current');
-            void onOpenLibrary(id);
-          }}
-        />
+        <>
+          <PortfolioPanel
+            leases={library}
+            findingsByLease={portfolioFindings}
+            onOpenLease={(id) => {
+              setView('current');
+              void onOpenLibrary(id);
+            }}
+          />
+          <ClauseSimilarityPanel
+            clusters={clauseClusters}
+            onOpenParagraph={(leaseId, _paragraphIndex) => {
+              setView('current');
+              void onOpenLibrary(leaseId);
+            }}
+          />
+        </>
       )}
 
       {view === 'redline' && status.kind === 'analyzed' && (

--- a/app/src/portfolio/clauseClusters.test.ts
+++ b/app/src/portfolio/clauseClusters.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { clusterParagraphs, type ClauseCluster } from './clauseClusters';
+import type { LeaseRecord } from '../storage/storage';
+import type { LeaseDocument } from '../parser/types';
+
+function makeDoc(paragraphs: string[]): LeaseDocument {
+  return {
+    pages: [{ pageNumber: 1, width: 612, height: 792, items: [] }],
+    paragraphs: paragraphs.map((text) => ({ text, page: 1 })),
+    sections: [],
+    raw: paragraphs.join('\n\n'),
+  };
+}
+
+function makeLease(id: string, paragraphs: string[]): LeaseRecord {
+  return {
+    id,
+    name: `${id}.pdf`,
+    createdAt: 1000,
+    updatedAt: 1000,
+    rulePackVersion: '1.0.0',
+    pageCount: 1,
+    findingCount: 0,
+    doc: makeDoc(paragraphs),
+    findings: [],
+  };
+}
+
+const STD_AUTO_RENEW =
+  'This lease shall automatically renew for successive one year terms unless either party provides written notice of non-renewal at least sixty days prior to the end of the then-current term.';
+
+const NEAR_DUP_AUTO_RENEW =
+  'This lease shall automatically renew for successive one year terms unless either party provides written notice of nonrenewal at least sixty days prior to the end of the current term.';
+
+const UNRELATED =
+  'Tenant shall maintain commercial general liability insurance with minimum limits of one million dollars per occurrence covering bodily injury and property damage at all times.';
+
+describe('clusterParagraphs', () => {
+  it('returns an empty array when given no leases', () => {
+    expect(clusterParagraphs([])).toEqual([]);
+  });
+
+  it('clusters identical paragraphs across two leases', () => {
+    const leases = [
+      makeLease('L1', [STD_AUTO_RENEW]),
+      makeLease('L2', [STD_AUTO_RENEW]),
+    ];
+    const out: ClauseCluster[] = clusterParagraphs(leases);
+    const auto = out.find((c) =>
+      c.paragraphs.some((p) => p.leaseId === 'L1'),
+    );
+    expect(auto).toBeDefined();
+    expect(auto?.paragraphs.map((p) => p.leaseId).sort()).toEqual(['L1', 'L2']);
+  });
+
+  it('clusters near-duplicates whose Jaccard >= 0.8', () => {
+    const leases = [
+      makeLease('L1', [STD_AUTO_RENEW]),
+      makeLease('L2', [NEAR_DUP_AUTO_RENEW]),
+    ];
+    const out = clusterParagraphs(leases, { threshold: 0.8 });
+    const merged = out.find((c) => c.paragraphs.length >= 2);
+    expect(merged).toBeDefined();
+    expect(merged?.paragraphs.map((p) => p.leaseId).sort()).toEqual([
+      'L1',
+      'L2',
+    ]);
+  });
+
+  it('does not cluster unrelated paragraphs', () => {
+    const leases = [
+      makeLease('L1', [STD_AUTO_RENEW]),
+      makeLease('L2', [UNRELATED]),
+    ];
+    const out = clusterParagraphs(leases, { threshold: 0.8 });
+    // No cluster has both leases.
+    const cross = out.find(
+      (c) =>
+        c.paragraphs.some((p) => p.leaseId === 'L1') &&
+        c.paragraphs.some((p) => p.leaseId === 'L2'),
+    );
+    expect(cross).toBeUndefined();
+  });
+
+  it('produces a deterministic order across runs', () => {
+    const leases = [
+      makeLease('L1', [STD_AUTO_RENEW, UNRELATED]),
+      makeLease('L2', [STD_AUTO_RENEW]),
+    ];
+    const a = clusterParagraphs(leases, { threshold: 0.8 });
+    const b = clusterParagraphs(leases, { threshold: 0.8 });
+    expect(a.map((c) => c.clusterId)).toEqual(b.map((c) => c.clusterId));
+  });
+
+  it('records leaseId + paragraphIndex for every clustered paragraph', () => {
+    const leases = [
+      makeLease('L1', [UNRELATED, STD_AUTO_RENEW]),
+      makeLease('L2', [STD_AUTO_RENEW]),
+    ];
+    const out = clusterParagraphs(leases, { threshold: 0.8 });
+    const merged = out.find((c) => c.paragraphs.length >= 2);
+    expect(merged).toBeDefined();
+    const l1 = merged?.paragraphs.find((p) => p.leaseId === 'L1');
+    expect(l1?.paragraphIndex).toBe(1);
+    const l2 = merged?.paragraphs.find((p) => p.leaseId === 'L2');
+    expect(l2?.paragraphIndex).toBe(0);
+  });
+});

--- a/app/src/portfolio/clauseClusters.ts
+++ b/app/src/portfolio/clauseClusters.ts
@@ -1,15 +1,97 @@
-// Wave 10 Part B — implementation pending. Tests import from this module.
+// Wave 10 Part B — clause clustering across leases.
+//
+// We compute paragraph shingles for every paragraph in every lease, then
+// greedy-cluster paragraphs whose pairwise Jaccard meets the threshold
+// against the cluster's representative. Iteration order is stabilized by
+// sorting leases by id, then by paragraphIndex within a lease, so the
+// cluster ids and ordering are deterministic across runs.
+
 import type { LeaseRecord } from '../storage/storage';
+import { paragraphShingles, jaccard } from './shingles';
+
+export interface ClusterParagraph {
+  leaseId: string;
+  paragraphIndex: number;
+  text: string;
+}
 
 export interface ClauseCluster {
   clusterId: string;
-  paragraphs: { leaseId: string; paragraphIndex: number; text: string }[];
+  paragraphs: ClusterParagraph[];
   representativeText: string;
 }
 
-export const clusterParagraphs = (
-  _leases: LeaseRecord[],
-  _opts?: { threshold?: number },
-): ClauseCluster[] => {
-  throw new Error('clusterParagraphs: not implemented');
-};
+export interface ClusterOptions {
+  threshold?: number;
+  k?: number;
+}
+
+interface InternalEntry extends ClusterParagraph {
+  shingles: string[];
+}
+
+interface InternalCluster {
+  representative: InternalEntry;
+  members: InternalEntry[];
+}
+
+export function clusterParagraphs(
+  leases: LeaseRecord[],
+  opts: ClusterOptions = {},
+): ClauseCluster[] {
+  if (leases.length === 0) return [];
+  const threshold = opts.threshold ?? 0.8;
+  const k = opts.k ?? 5;
+
+  const entries: InternalEntry[] = [];
+  const sortedLeases = [...leases].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  for (const lease of sortedLeases) {
+    const paragraphs = lease.doc?.paragraphs ?? [];
+    paragraphs.forEach((p, idx) => {
+      const text = p.text ?? '';
+      const shingles = paragraphShingles(text, k);
+      entries.push({
+        leaseId: lease.id,
+        paragraphIndex: idx,
+        text,
+        shingles,
+      });
+    });
+  }
+
+  const clusters: InternalCluster[] = [];
+  for (const entry of entries) {
+    let placed = false;
+    for (const cluster of clusters) {
+      if (entry.shingles.length === 0 && cluster.representative.shingles.length === 0) {
+        // Two empty-shingle paragraphs only co-cluster on exact text equality
+        // to avoid lumping every short paragraph together.
+        if (entry.text === cluster.representative.text) {
+          cluster.members.push(entry);
+          placed = true;
+          break;
+        }
+        continue;
+      }
+      const score = jaccard(entry.shingles, cluster.representative.shingles);
+      if (score >= threshold) {
+        cluster.members.push(entry);
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) {
+      clusters.push({ representative: entry, members: [entry] });
+    }
+  }
+
+  return clusters.map((c, idx) => ({
+    clusterId: `cluster-${idx.toString().padStart(4, '0')}`,
+    paragraphs: c.members.map(({ leaseId, paragraphIndex, text }) => ({
+      leaseId,
+      paragraphIndex,
+      text,
+    })),
+    representativeText: c.representative.text,
+  }));
+}

--- a/app/src/portfolio/clauseClusters.ts
+++ b/app/src/portfolio/clauseClusters.ts
@@ -1,0 +1,15 @@
+// Wave 10 Part B — implementation pending. Tests import from this module.
+import type { LeaseRecord } from '../storage/storage';
+
+export interface ClauseCluster {
+  clusterId: string;
+  paragraphs: { leaseId: string; paragraphIndex: number; text: string }[];
+  representativeText: string;
+}
+
+export const clusterParagraphs = (
+  _leases: LeaseRecord[],
+  _opts?: { threshold?: number },
+): ClauseCluster[] => {
+  throw new Error('clusterParagraphs: not implemented');
+};

--- a/app/src/portfolio/shingles.test.ts
+++ b/app/src/portfolio/shingles.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { paragraphShingles, jaccard } from './shingles';
+
+describe('paragraphShingles', () => {
+  it('returns an empty array for empty input', () => {
+    expect(paragraphShingles('')).toEqual([]);
+  });
+
+  it('returns an empty array when text has fewer tokens than k', () => {
+    expect(paragraphShingles('one two three', 5)).toEqual([]);
+  });
+
+  it('lowercases, collapses whitespace, and strips punctuation before shingling', () => {
+    const a = paragraphShingles('The Quick, Brown Fox Jumps Over!', 5);
+    const b = paragraphShingles('the   quick brown fox jumps over', 5);
+    expect(a).toEqual(b);
+    expect(a.length).toBeGreaterThan(0);
+  });
+
+  it('produces (n - k + 1) shingles for n tokens', () => {
+    // 7 tokens, k=5 -> 3 shingles
+    const out = paragraphShingles('a b c d e f g', 5);
+    expect(out).toHaveLength(3);
+  });
+
+  it('defaults k to 5', () => {
+    const withDefault = paragraphShingles('a b c d e f g h');
+    const explicit = paragraphShingles('a b c d e f g h', 5);
+    expect(withDefault).toEqual(explicit);
+  });
+});
+
+describe('jaccard', () => {
+  it('returns 0 for two empty sets', () => {
+    expect(jaccard([], [])).toBe(0);
+  });
+
+  it('returns 0 when one side is empty and the other is not', () => {
+    expect(jaccard([], ['a', 'b'])).toBe(0);
+    expect(jaccard(['a'], [])).toBe(0);
+  });
+
+  it('returns 1 for identical sets', () => {
+    expect(jaccard(['a', 'b', 'c'], ['a', 'b', 'c'])).toBe(1);
+  });
+
+  it('returns 0 for disjoint sets', () => {
+    expect(jaccard(['a', 'b'], ['c', 'd'])).toBe(0);
+  });
+
+  it('computes |intersection| / |union| for partial overlap', () => {
+    // {a,b,c} ∩ {b,c,d} = {b,c}; union = {a,b,c,d}; 2/4 = 0.5
+    expect(jaccard(['a', 'b', 'c'], ['b', 'c', 'd'])).toBeCloseTo(0.5, 5);
+  });
+
+  it('treats inputs as sets (duplicates do not change the score)', () => {
+    expect(jaccard(['a', 'a', 'b'], ['a', 'b', 'b'])).toBe(1);
+  });
+});

--- a/app/src/portfolio/shingles.ts
+++ b/app/src/portfolio/shingles.ts
@@ -1,10 +1,44 @@
-// Wave 10 Part B — implementation pending. Tests import from this module.
-export const paragraphShingles = (
-  _text: string,
-  _k: number = 5,
-): string[] => {
-  throw new Error('paragraphShingles: not implemented');
-};
-export const jaccard = (_a: string[], _b: string[]): number => {
-  throw new Error('jaccard: not implemented');
-};
+// Wave 10 Part B — paragraph shingles + Jaccard similarity.
+//
+// `paragraphShingles` produces order-preserving k-shingles (overlapping
+// k-token windows) over a normalized form of the input: lowercased,
+// punctuation stripped, whitespace collapsed. The output is suitable for
+// set-based similarity scoring via `jaccard`.
+//
+// `jaccard` treats its inputs as sets — duplicates do not change the
+// score. Two empty inputs return 0 (an undefined ratio); we collapse to
+// 0 so callers can safely threshold against >= some value.
+
+export function paragraphShingles(text: string, k: number = 5): string[] {
+  if (!text || k <= 0) return [];
+  const normalized = text
+    .toLowerCase()
+    // Drop hyphens / apostrophes WITHIN words (non-renewal → nonrenewal,
+    // tenant's → tenants) so common typographic variants collapse to the
+    // same token before we strip remaining punctuation.
+    .replace(/(\p{L})[’'-](\p{L})/gu, '$1$2')
+    .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!normalized) return [];
+  const tokens = normalized.split(' ');
+  if (tokens.length < k) return [];
+  const out: string[] = [];
+  for (let i = 0; i <= tokens.length - k; i++) {
+    out.push(tokens.slice(i, i + k).join(' '));
+  }
+  return out;
+}
+
+export function jaccard(a: string[], b: string[]): number {
+  if (a.length === 0 || b.length === 0) return 0;
+  const setA = new Set(a);
+  const setB = new Set(b);
+  let intersection = 0;
+  for (const item of setA) {
+    if (setB.has(item)) intersection++;
+  }
+  const union = setA.size + setB.size - intersection;
+  if (union === 0) return 0;
+  return intersection / union;
+}

--- a/app/src/portfolio/shingles.ts
+++ b/app/src/portfolio/shingles.ts
@@ -1,0 +1,10 @@
+// Wave 10 Part B — implementation pending. Tests import from this module.
+export const paragraphShingles = (
+  _text: string,
+  _k: number = 5,
+): string[] => {
+  throw new Error('paragraphShingles: not implemented');
+};
+export const jaccard = (_a: string[], _b: string[]): number => {
+  throw new Error('jaccard: not implemented');
+};

--- a/app/src/storage/storage.test.ts
+++ b/app/src/storage/storage.test.ts
@@ -172,6 +172,90 @@ describe('storage', () => {
     expect(loaded?.createdAt).toBeLessThanOrEqual(after);
   });
 
+  it('migrates v4 to v5: adds paragraphShingles store AND preserves by-finding-and-pack index', async () => {
+    // Seed a v4 database with one row + the v4 compound index, then re-open
+    // through the module to drive v4 -> v5 upgrade. After the bump:
+    //   * row survives
+    //   * `by-finding-and-pack` (Wave 7-E) still queryable
+    //   * new `paragraphShingles` store exists, keyed by [leaseId, paragraphIndex]
+    await new Promise<void>((resolve, reject) => {
+      const req = indexedDB.open('leaseguard', 4);
+      req.onupgradeneeded = (): void => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains('leases')) {
+          const store = db.createObjectStore('leases', { keyPath: 'id' });
+          store.createIndex('by-createdAt', 'createdAt');
+          store.createIndex('by-finding-and-pack', [
+            'findingCount',
+            'rulePackVersion',
+          ]);
+        }
+        if (!db.objectStoreNames.contains('settings')) {
+          db.createObjectStore('settings');
+        }
+        if (!db.objectStoreNames.contains('clauseTemplates')) {
+          db.createObjectStore('clauseTemplates', { keyPath: 'id' });
+        }
+      };
+      req.onsuccess = (): void => {
+        const db = req.result;
+        const tx = db.transaction('leases', 'readwrite');
+        tx.objectStore('leases').put({
+          id: 'lease-v4',
+          name: 'Carry.pdf',
+          createdAt: 1000,
+          updatedAt: 1000,
+          rulePackVersion: '1.0.0',
+          pageCount: 1,
+          findingCount: 0,
+          doc: makeDoc(),
+          findings: [],
+        });
+        tx.oncomplete = (): void => {
+          db.close();
+          resolve();
+        };
+        tx.onerror = (): void => reject(tx.error);
+      };
+      req.onerror = (): void => reject(req.error);
+    });
+
+    _resetDbForTests();
+    const db = await openLeaseDb();
+    expect(db.version).toBe(5);
+
+    // Existing row preserved.
+    const survivors = await db.getAll('leases');
+    expect(survivors.map((r) => r.id)).toEqual(['lease-v4']);
+
+    // Wave 7-E compound index still works.
+    const tx = db.transaction('leases', 'readonly');
+    const idx = tx.objectStore('leases').index('by-finding-and-pack');
+    const matches = await idx.getAll(IDBKeyRange.only([0, '1.0.0']));
+    expect(matches.map((r) => r.id)).toEqual(['lease-v4']);
+    await tx.done;
+
+    // New paragraphShingles store exists and accepts compound-key writes.
+    expect(db.objectStoreNames.contains('paragraphShingles')).toBe(true);
+    const tx2 = db.transaction('paragraphShingles', 'readwrite');
+    // Cast through `any` because schema typing for the new store hasn't
+    // been threaded into the DBSchema yet — that lands with the impl.
+    const store = (tx2 as unknown as {
+      objectStore: (n: string) => {
+        put: (v: unknown) => Promise<unknown>;
+        get: (k: unknown) => Promise<unknown>;
+      };
+    }).objectStore('paragraphShingles');
+    await store.put({
+      leaseId: 'lease-v4',
+      paragraphIndex: 0,
+      shingles: ['a b c d e'],
+    });
+    const got = await store.get(['lease-v4', 0]);
+    expect(got).toMatchObject({ leaseId: 'lease-v4', paragraphIndex: 0 });
+    await tx2.done;
+  });
+
   it('migrates a v3 database to v4 without dropping rows and adds the by-finding-and-pack index', async () => {
     // Seed a v3 database directly via raw indexedDB.open so we can prove
     // the v4 upgrade path runs against a populated v3 schema.

--- a/app/src/storage/storage.test.ts
+++ b/app/src/storage/storage.test.ts
@@ -308,12 +308,13 @@ describe('storage', () => {
       req.onerror = (): void => reject(req.error);
     });
 
-    // Open via the v4 path. _resetDbForTests ensures we re-open through the
-    // module's upgrade ladder rather than reusing a cached v3 handle.
+    // Open via the latest path. _resetDbForTests ensures we re-open through
+    // the module's upgrade ladder rather than reusing a cached v3 handle.
+    // The v3→v4 migration runs as part of the ladder up to current (v5).
     _resetDbForTests();
     const db = await openLeaseDb();
 
-    expect(db.version).toBe(4);
+    expect(db.version).toBe(5);
     // Existing rows preserved.
     const survivors = await db.getAll('leases');
     expect(survivors).toHaveLength(2);

--- a/app/src/storage/storage.ts
+++ b/app/src/storage/storage.ts
@@ -4,13 +4,20 @@ import type { Finding } from '../rules/types';
 import type { ClauseTemplate } from '../templates/types';
 
 const DB_NAME = 'leaseguard';
-const DB_VERSION = 4;
+const DB_VERSION = 5;
 const STORE = 'leases';
 const SETTINGS = 'settings';
 const STANDARD_KEY = 'standardLeaseId';
 const ONBOARDING_DISMISSED_KEY = 'onboardingDismissedAt';
 export const CLAUSE_TEMPLATES_STORE = 'clauseTemplates';
 export const BY_FINDING_AND_PACK_INDEX = 'by-finding-and-pack';
+export const PARAGRAPH_SHINGLES_STORE = 'paragraphShingles';
+
+export interface ParagraphShinglesRecord {
+  leaseId: string;
+  paragraphIndex: number;
+  shingles: string[];
+}
 
 export interface LeaseRecord {
   id: string;
@@ -50,6 +57,10 @@ interface LeaseGuardSchema extends DBSchema {
   [CLAUSE_TEMPLATES_STORE]: {
     key: string;
     value: ClauseTemplate;
+  };
+  [PARAGRAPH_SHINGLES_STORE]: {
+    key: [string, number];
+    value: ParagraphShinglesRecord;
   };
 }
 
@@ -93,6 +104,17 @@ export async function openLeaseDb(): Promise<IDBPDatabase<LeaseGuardSchema>> {
               'findingCount',
               'rulePackVersion',
             ]);
+          }
+        }
+        // v4 → v5: paragraphShingles store keyed by [leaseId, paragraphIndex].
+        // Populated lazily on first portfolio-similarity render — no
+        // backfill on upgrade. Wave 7-E's compound index on `leases` is
+        // untouched.
+        if (oldVersion < 5) {
+          if (!db.objectStoreNames.contains(PARAGRAPH_SHINGLES_STORE)) {
+            db.createObjectStore(PARAGRAPH_SHINGLES_STORE, {
+              keyPath: ['leaseId', 'paragraphIndex'],
+            });
           }
         }
       },
@@ -158,6 +180,27 @@ export async function clearAll(): Promise<void> {
   await db.clear(STORE);
   await db.clear(SETTINGS);
   await db.clear(CLAUSE_TEMPLATES_STORE);
+  await db.clear(PARAGRAPH_SHINGLES_STORE);
+}
+
+export async function putParagraphShingles(
+  record: ParagraphShinglesRecord,
+): Promise<void> {
+  const db = await openLeaseDb();
+  await db.put(PARAGRAPH_SHINGLES_STORE, record);
+}
+
+export async function getParagraphShingles(
+  leaseId: string,
+  paragraphIndex: number,
+): Promise<ParagraphShinglesRecord | undefined> {
+  const db = await openLeaseDb();
+  return db.get(PARAGRAPH_SHINGLES_STORE, [leaseId, paragraphIndex]);
+}
+
+export async function listParagraphShingles(): Promise<ParagraphShinglesRecord[]> {
+  const db = await openLeaseDb();
+  return db.getAll(PARAGRAPH_SHINGLES_STORE);
 }
 
 export async function listAllLeaseRecords(): Promise<LeaseRecord[]> {

--- a/app/src/ui/ClauseSimilarityPanel.stories.tsx
+++ b/app/src/ui/ClauseSimilarityPanel.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ClauseSimilarityPanel } from './ClauseSimilarityPanel';
+import type { ClauseCluster } from '../portfolio/clauseClusters';
+
+const sampleClusters: ClauseCluster[] = [
+  {
+    clusterId: 'cluster-0001',
+    representativeText:
+      'This lease shall automatically renew for successive one year terms unless either party provides written notice of non-renewal at least sixty days prior to the end of the then-current term.',
+    paragraphs: [
+      {
+        leaseId: 'lease-alpha',
+        paragraphIndex: 3,
+        text: 'This lease shall automatically renew for successive one year terms…',
+      },
+      {
+        leaseId: 'lease-beta',
+        paragraphIndex: 5,
+        text: 'This lease shall automatically renew for successive one year terms…',
+      },
+    ],
+  },
+  {
+    clusterId: 'cluster-0002',
+    representativeText:
+      'Tenant shall maintain commercial general liability insurance with minimum limits of one million dollars per occurrence.',
+    paragraphs: [
+      {
+        leaseId: 'lease-alpha',
+        paragraphIndex: 12,
+        text: 'Tenant shall maintain commercial general liability insurance…',
+      },
+      {
+        leaseId: 'lease-gamma',
+        paragraphIndex: 8,
+        text: 'Tenant shall maintain commercial general liability insurance…',
+      },
+    ],
+  },
+];
+
+const meta: Meta<typeof ClauseSimilarityPanel> = {
+  title: 'Portfolio/ClauseSimilarityPanel',
+  component: ClauseSimilarityPanel,
+};
+export default meta;
+
+type Story = StoryObj<typeof ClauseSimilarityPanel>;
+
+export const Empty: Story = {
+  args: {
+    clusters: [],
+    onOpenParagraph: () => {},
+  },
+};
+
+export const WithClusters: Story = {
+  args: {
+    clusters: sampleClusters,
+    onOpenParagraph: (leaseId, paragraphIndex) => {
+      // eslint-disable-next-line no-console
+      console.log('open', leaseId, paragraphIndex);
+    },
+  },
+};

--- a/app/src/ui/ClauseSimilarityPanel.test.tsx
+++ b/app/src/ui/ClauseSimilarityPanel.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ClauseSimilarityPanel } from './ClauseSimilarityPanel';
+import type { ClauseCluster } from '../portfolio/clauseClusters';
+
+const CLUSTERS: ClauseCluster[] = [
+  {
+    clusterId: 'c-001',
+    representativeText: 'Auto-renewal clause text representative.',
+    paragraphs: [
+      {
+        leaseId: 'L1',
+        paragraphIndex: 2,
+        text: 'Auto-renewal clause text representative.',
+      },
+      {
+        leaseId: 'L2',
+        paragraphIndex: 4,
+        text: 'Auto-renewal clause text variant.',
+      },
+    ],
+  },
+  {
+    clusterId: 'c-002',
+    representativeText: 'Indemnification clause representative.',
+    paragraphs: [
+      {
+        leaseId: 'L1',
+        paragraphIndex: 5,
+        text: 'Indemnification clause representative.',
+      },
+      {
+        leaseId: 'L3',
+        paragraphIndex: 1,
+        text: 'Indemnification clause variant.',
+      },
+    ],
+  },
+];
+
+describe('ClauseSimilarityPanel', () => {
+  it('renders an empty state when no clusters are present', () => {
+    render(
+      <ClauseSimilarityPanel clusters={[]} onOpenParagraph={() => {}} />,
+    );
+    expect(screen.getByText(/no clause clusters/i)).toBeInTheDocument();
+  });
+
+  it('renders one entry per cluster with the representative text', () => {
+    render(
+      <ClauseSimilarityPanel
+        clusters={CLUSTERS}
+        onOpenParagraph={() => {}}
+      />,
+    );
+    expect(
+      screen.getByText(/Auto-renewal clause text representative/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Indemnification clause representative/i),
+    ).toBeInTheDocument();
+  });
+
+  it('lists each lease+paragraph in a cluster', () => {
+    render(
+      <ClauseSimilarityPanel
+        clusters={CLUSTERS}
+        onOpenParagraph={() => {}}
+      />,
+    );
+    // Both L1 (paragraph 2) and L2 (paragraph 4) should appear via accessible labels.
+    expect(
+      screen.getByRole('button', {
+        name: /open paragraph 2 of L1/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /open paragraph 4 of L2/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('fires onOpenParagraph(leaseId, paragraphIndex) when a paragraph is clicked', async () => {
+    const onOpenParagraph = vi.fn();
+    render(
+      <ClauseSimilarityPanel
+        clusters={CLUSTERS}
+        onOpenParagraph={onOpenParagraph}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /open paragraph 4 of L2/i,
+      }),
+    );
+    expect(onOpenParagraph).toHaveBeenCalledWith('L2', 4);
+  });
+});

--- a/app/src/ui/ClauseSimilarityPanel.tsx
+++ b/app/src/ui/ClauseSimilarityPanel.tsx
@@ -1,4 +1,12 @@
-// Wave 10 Part B — implementation pending. Tests import from this module.
+// Wave 10 Part B — Clause Similarity panel.
+//
+// Presentational only — given a list of `ClauseCluster`s and a callback,
+// render each cluster with its representative text and a button per
+// member paragraph that fires `onOpenParagraph(leaseId, paragraphIndex)`.
+// Empty cluster list → friendly empty state. The panel does not fetch
+// or compute anything; the App-level wiring is responsible for both
+// shingle materialization and clustering.
+
 import type { ClauseCluster } from '../portfolio/clauseClusters';
 
 export interface ClauseSimilarityPanelProps {
@@ -6,8 +14,52 @@ export interface ClauseSimilarityPanelProps {
   onOpenParagraph: (leaseId: string, paragraphIndex: number) => void;
 }
 
-export function ClauseSimilarityPanel(
-  _props: ClauseSimilarityPanelProps,
-): JSX.Element {
-  throw new Error('ClauseSimilarityPanel: not implemented');
+export function ClauseSimilarityPanel({
+  clusters,
+  onOpenParagraph,
+}: ClauseSimilarityPanelProps): JSX.Element {
+  if (clusters.length === 0) {
+    return (
+      <section
+        aria-label="Clause similarity"
+        className="clause-similarity-panel clause-similarity-panel--empty"
+      >
+        <h2>Clause similarity</h2>
+        <p>No clause clusters yet — analyze two or more leases to see overlap.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section aria-label="Clause similarity" className="clause-similarity-panel">
+      <h2>Clause similarity</h2>
+      <ul className="clause-similarity-panel__list">
+        {clusters.map((cluster) => (
+          <li
+            key={cluster.clusterId}
+            className="clause-similarity-panel__cluster"
+          >
+            <p className="clause-similarity-panel__representative">
+              {cluster.representativeText}
+            </p>
+            <ul className="clause-similarity-panel__members">
+              {cluster.paragraphs.map((p) => (
+                <li key={`${p.leaseId}:${p.paragraphIndex}`}>
+                  <button
+                    type="button"
+                    onClick={(): void =>
+                      onOpenParagraph(p.leaseId, p.paragraphIndex)
+                    }
+                    aria-label={`Open paragraph ${p.paragraphIndex} of ${p.leaseId}`}
+                  >
+                    {p.leaseId} · paragraph {p.paragraphIndex}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
 }

--- a/app/src/ui/ClauseSimilarityPanel.tsx
+++ b/app/src/ui/ClauseSimilarityPanel.tsx
@@ -1,0 +1,13 @@
+// Wave 10 Part B — implementation pending. Tests import from this module.
+import type { ClauseCluster } from '../portfolio/clauseClusters';
+
+export interface ClauseSimilarityPanelProps {
+  clusters: ClauseCluster[];
+  onOpenParagraph: (leaseId: string, paragraphIndex: number) => void;
+}
+
+export function ClauseSimilarityPanel(
+  _props: ClauseSimilarityPanelProps,
+): JSX.Element {
+  throw new Error('ClauseSimilarityPanel: not implemented');
+}


### PR DESCRIPTION
## Summary
- Pure `paragraphShingles(text, k=5)` + `jaccard(a, b)` in `app/src/portfolio/shingles.ts`
- `clusterParagraphs` in `app/src/portfolio/clauseClusters.ts` with Jaccard ≥ 0.8 threshold, deterministic ordering
- IDB v5 migration adding `paragraphShingles` store keyed by `[leaseId, paragraphIndex]`; v4 `(findingCount, rulePackVersion)` index from Wave 7-E preserved
- `ClauseSimilarityPanel` mounted under existing `portfolio` view-mode

## Wave 10 / Phase 16 — Part B of 4
Plan: `docs/plans/wave10-portfolio-intelligence.md` §Part B.

## Test plan
- [x] Owned tests: shingles (5) + clusters (synthetic near-dup leases) + storage v4→v5 migration + ClauseSimilarityPanel
- [x] Full suite: 962 passed, 0 failed
- [x] typecheck / lint / check:budget all green

## Reviewer notes
- **Spec correction (orchestrator-applied):** `app/src/storage/storage.test.ts` line 316 changed `expect(db.version).toBe(4)` → `toBe(5)`. The pre-existing v3→v4 migration test opens via `openLeaseDb()` which always migrates to latest; the assertion was tracking the schema version, not the v3→v4 migration behavior itself. Migration correctness still validated by row preservation + index queries below it, plus the dedicated v4→v5 test added in this PR. Strict TDD says only spec-author may edit tests — flagging for visibility.
- Privacy contract reaffirmed: clustering runs entirely over IDB-resident data; no new fetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)