### PR TITLE
wave10-D: portfolio-scope severity overrides

### DIFF
--- a/app/src/rules/packStorage.ts
+++ b/app/src/rules/packStorage.ts
@@ -20,7 +20,14 @@ const SIGNATURES = 'signatures';
 
 // Singleton keys inside the SETTINGS store.
 const KEY_JURISDICTIONS = 'selectedJurisdictions';
+// Wave 10 Part D — the legacy `severityOverrides` key holds the portfolio-
+// scope map (Record<ruleId, Severity>). Pre-existing rows (no scope concept)
+// are implicitly portfolio-scope, matching `migrateLegacyOverrides`. Lease-
+// scope overrides live in a sibling key, keyed by leaseId →
+// Record<ruleId, Severity>. No IDB schema bump — both keys live in the
+// existing v3 SETTINGS store.
 const KEY_SEVERITY_OVERRIDES = 'severityOverrides';
+const KEY_SEVERITY_OVERRIDES_BY_LEASE = 'severityOverridesByLease';
 
 export type PackSignatureStatus = 'verified' | 'unsigned' | 'invalid' | 'unknown';
 
@@ -36,9 +43,14 @@ interface PacksSchema extends DBSchema {
   [SETTINGS]: {
     key: string;
     // Heterogeneous singleton store: jurisdictions is string[], severity
-    // overrides is Record<string, Severity>. Keyed by the constants above
+    // overrides is Record<string, Severity>; Wave 10 Part D adds a
+    // Record<leaseId, Record<ruleId, Severity>> entry under the
+    // KEY_SEVERITY_OVERRIDES_BY_LEASE key. Keyed by the constants above
     // so reads narrow the type at the call site.
-    value: string[] | Record<string, Severity>;
+    value:
+      | string[]
+      | Record<string, Severity>
+      | Record<string, Record<string, Severity>>;
   };
   [SIGNATURES]: {
     // Keyed by packId. Value is the full envelope plus the verify result
@@ -272,8 +284,27 @@ function isSeverityMap(v: unknown): v is Record<string, Severity> {
   );
 }
 
-export async function getSeverityOverrides(): Promise<Record<string, Severity>> {
+/**
+ * Read severity overrides. Behavior:
+ *
+ *  - No filter (or `{ scope: 'portfolio' }`) — returns the flat portfolio-
+ *    scope map (legacy rows are implicitly portfolio-scope).
+ *  - `{ scope: 'lease', leaseId }` — returns the override map for that lease
+ *    only. Returns `{}` if no lease-scope rows exist for the given leaseId.
+ *
+ * Schema version is unchanged; lease-scope rows live under a sibling key.
+ */
+export async function getSeverityOverrides(
+  filter?: { scope: 'portfolio' } | { scope: 'lease'; leaseId: string },
+): Promise<Record<string, Severity>> {
   const db = await openPacksDb();
+  if (filter?.scope === 'lease') {
+    const v = await db.get(SETTINGS, KEY_SEVERITY_OVERRIDES_BY_LEASE);
+    if (v === null || typeof v !== 'object' || Array.isArray(v)) return {};
+    const byLease = v as unknown as Record<string, unknown>;
+    const row = byLease[filter.leaseId];
+    return isSeverityMap(row) ? { ...row } : {};
+  }
   const v = await db.get(SETTINGS, KEY_SEVERITY_OVERRIDES);
   return isSeverityMap(v) ? { ...v } : {};
 }

--- a/app/src/rules/portfolioOverrides.test.ts
+++ b/app/src/rules/portfolioOverrides.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  migrateLegacyOverrides,
+  resolveSeverity,
+  type ScopedOverrideEntry,
+} from './portfolioOverrides';
+
+describe('resolveSeverity (lease > portfolio > pack default)', () => {
+  it('returns the pack default when no overrides exist', () => {
+    expect(
+      resolveSeverity('r1', 'high', [], { leaseId: 'L1' }),
+    ).toBe('high');
+  });
+
+  it('applies a portfolio-scope override when no lease-scope override exists', () => {
+    const entries: ScopedOverrideEntry[] = [
+      { ruleId: 'r1', severity: 'low', scope: 'portfolio' },
+    ];
+    expect(resolveSeverity('r1', 'high', entries, { leaseId: 'L1' })).toBe(
+      'low',
+    );
+  });
+
+  it('lease-scope override wins over portfolio-scope override on the same lease', () => {
+    const entries: ScopedOverrideEntry[] = [
+      { ruleId: 'r1', severity: 'low', scope: 'portfolio' },
+      { ruleId: 'r1', severity: 'medium', scope: 'lease', leaseId: 'L1' },
+    ];
+    expect(resolveSeverity('r1', 'high', entries, { leaseId: 'L1' })).toBe(
+      'medium',
+    );
+  });
+
+  it('lease-scope override on a different lease does not affect this lease', () => {
+    const entries: ScopedOverrideEntry[] = [
+      { ruleId: 'r1', severity: 'low', scope: 'portfolio' },
+      { ruleId: 'r1', severity: 'medium', scope: 'lease', leaseId: 'L2' },
+    ];
+    // Portfolio still applies on L1.
+    expect(resolveSeverity('r1', 'high', entries, { leaseId: 'L1' })).toBe(
+      'low',
+    );
+  });
+
+  it('falls back to pack default when neither scope has an entry for this ruleId', () => {
+    const entries: ScopedOverrideEntry[] = [
+      { ruleId: 'other', severity: 'low', scope: 'portfolio' },
+    ];
+    expect(resolveSeverity('r1', 'info', entries, { leaseId: 'L1' })).toBe(
+      'info',
+    );
+  });
+
+  it('removing the portfolio override falls back to the pack default', () => {
+    const before: ScopedOverrideEntry[] = [
+      { ruleId: 'r1', severity: 'low', scope: 'portfolio' },
+    ];
+    const after: ScopedOverrideEntry[] = [];
+    expect(resolveSeverity('r1', 'high', before, { leaseId: 'L1' })).toBe(
+      'low',
+    );
+    expect(resolveSeverity('r1', 'high', after, { leaseId: 'L1' })).toBe(
+      'high',
+    );
+  });
+});
+
+describe('migrateLegacyOverrides', () => {
+  it('returns an empty array when given an empty legacy map', () => {
+    expect(migrateLegacyOverrides({})).toEqual([]);
+  });
+
+  it('migrates pre-existing user severity overrides to portfolio-scope entries', () => {
+    // Pre-Wave-10 overrides were per-user / global with no scope; treat them
+    // as portfolio-scope so behavior carries over.
+    const legacy: Record<string, 'high' | 'medium' | 'low' | 'info'> = {
+      'auto-renewal': 'high',
+      'late-fee': 'low',
+    };
+    const out = migrateLegacyOverrides(legacy);
+    expect(out).toHaveLength(2);
+    for (const entry of out) {
+      expect(entry.scope).toBe('portfolio');
+    }
+    const auto = out.find((e) => e.ruleId === 'auto-renewal');
+    const late = out.find((e) => e.ruleId === 'late-fee');
+    expect(auto?.severity).toBe('high');
+    expect(late?.severity).toBe('low');
+  });
+});

--- a/app/src/rules/portfolioOverrides.ts
+++ b/app/src/rules/portfolioOverrides.ts
@@ -1,5 +1,18 @@
-// Wave 10 Part D — implementation pending.
-// Resolution order: lease-scope > portfolio-scope > pack default.
+// Wave 10 Part D — portfolio-scope severity overrides.
+//
+// Resolution order (highest → lowest priority):
+//   1. lease-scope override matching (ruleId, leaseId)
+//   2. portfolio-scope override matching ruleId (any lease)
+//   3. pack default severity
+//
+// Storage encoding (see `packStorage.getSeverityOverrides` extension):
+//   The pre-Wave-10 record stored at SETTINGS[KEY_SEVERITY_OVERRIDES] is a
+//   flat `Record<ruleId, Severity>`. To avoid an IDB schema bump we keep that
+//   record as the *portfolio-scope* map (legacy rows are implicitly portfolio-
+//   scope per `migrateLegacyOverrides`), and store lease-scope rows under a
+//   sibling key whose value is `Record<leaseId, Record<ruleId, Severity>>`.
+//   The schema version stays at v4; new keys live in the existing SETTINGS
+//   store. Reads of legacy data treat absent scope as portfolio.
 import type { Severity } from './types';
 
 export type OverrideScope = 'lease' | 'portfolio';
@@ -12,17 +25,62 @@ export interface ScopedOverrideEntry {
   leaseId?: string;
 }
 
+/**
+ * Resolve the effective severity for a rule given a flat list of scoped
+ * override entries plus the pack-default severity. Pure function, no I/O.
+ */
 export const resolveSeverity = (
-  _ruleId: string,
-  _packDefault: Severity,
-  _entries: ScopedOverrideEntry[],
-  _opts: { leaseId: string },
+  ruleId: string,
+  packDefault: Severity,
+  entries: readonly ScopedOverrideEntry[],
+  opts: { leaseId: string },
 ): Severity => {
-  throw new Error('resolveSeverity: not implemented');
+  let portfolioHit: Severity | undefined;
+  for (const e of entries) {
+    if (e.ruleId !== ruleId) continue;
+    if (e.scope === 'lease' && e.leaseId === opts.leaseId) {
+      // Lease-scope is highest priority — short-circuit.
+      return e.severity;
+    }
+    if (e.scope === 'portfolio') {
+      portfolioHit = e.severity;
+    }
+  }
+  return portfolioHit ?? packDefault;
 };
 
+/**
+ * Migrate the pre-Wave-10 flat override map (no scope concept) into scoped
+ * entries. Pre-existing user overrides were effectively global / cross-lease,
+ * so they map to portfolio-scope.
+ */
 export const migrateLegacyOverrides = (
-  _legacy: Record<string, Severity>,
+  legacy: Readonly<Record<string, Severity>>,
 ): ScopedOverrideEntry[] => {
-  throw new Error('migrateLegacyOverrides: not implemented');
+  const out: ScopedOverrideEntry[] = [];
+  for (const [ruleId, severity] of Object.entries(legacy)) {
+    out.push({ ruleId, severity, scope: 'portfolio' });
+  }
+  return out;
+};
+
+/**
+ * Build a `Record<ruleId, Severity>` resolver map for a single lease, suitable
+ * for handing to `applySeverityOverrides`. Lease-scope wins over portfolio-
+ * scope; rules with no entry are omitted (caller falls back to pack default).
+ */
+export const buildResolverMapForLease = (
+  entries: readonly ScopedOverrideEntry[],
+  leaseId: string,
+): Record<string, Severity> => {
+  const portfolio: Record<string, Severity> = {};
+  const lease: Record<string, Severity> = {};
+  for (const e of entries) {
+    if (e.scope === 'portfolio') {
+      portfolio[e.ruleId] = e.severity;
+    } else if (e.scope === 'lease' && e.leaseId === leaseId) {
+      lease[e.ruleId] = e.severity;
+    }
+  }
+  return { ...portfolio, ...lease };
 };

--- a/app/src/rules/portfolioOverrides.ts
+++ b/app/src/rules/portfolioOverrides.ts
@@ -1,0 +1,28 @@
+// Wave 10 Part D — implementation pending.
+// Resolution order: lease-scope > portfolio-scope > pack default.
+import type { Severity } from './types';
+
+export type OverrideScope = 'lease' | 'portfolio';
+
+export interface ScopedOverrideEntry {
+  ruleId: string;
+  severity: Severity;
+  scope: OverrideScope;
+  /** Required when scope === 'lease'; ignored when 'portfolio'. */
+  leaseId?: string;
+}
+
+export const resolveSeverity = (
+  _ruleId: string,
+  _packDefault: Severity,
+  _entries: ScopedOverrideEntry[],
+  _opts: { leaseId: string },
+): Severity => {
+  throw new Error('resolveSeverity: not implemented');
+};
+
+export const migrateLegacyOverrides = (
+  _legacy: Record<string, Severity>,
+): ScopedOverrideEntry[] => {
+  throw new Error('migrateLegacyOverrides: not implemented');
+};

--- a/app/src/ui/SeverityOverridesPanel.portfolio.test.tsx
+++ b/app/src/ui/SeverityOverridesPanel.portfolio.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SeverityOverridesPanel } from './SeverityOverridesPanel';
+
+// Wave 10 Part D — SeverityOverridesPanel gains an "Apply across portfolio"
+// toggle next to each row. The new props are additive; existing call sites
+// (no portfolioOverrides prop) keep working unchanged.
+
+const RULES = [
+  { id: 'r1', title: 'Auto-renewal clause', severity: 'warn' as const },
+  { id: 'r2', title: 'Holdover penalty', severity: 'error' as const },
+];
+
+type ExtendedProps = React.ComponentProps<typeof SeverityOverridesPanel> & {
+  portfolioOverrides?: Record<string, 'info' | 'warn' | 'error'>;
+  onScopeChange?: (
+    ruleId: string,
+    scope: 'lease' | 'portfolio',
+  ) => void;
+};
+const Panel = SeverityOverridesPanel as unknown as (
+  p: ExtendedProps,
+) => JSX.Element;
+
+describe('SeverityOverridesPanel + portfolio toggle', () => {
+  it('renders an "Apply across portfolio" toggle per rule when portfolio props are provided', () => {
+    render(
+      <Panel
+        rules={RULES}
+        overrides={{ r1: 'error' }}
+        portfolioOverrides={{}}
+        onChange={() => {}}
+        onScopeChange={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole('checkbox', {
+        name: /apply across portfolio for r1/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', {
+        name: /apply across portfolio for r2/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('reflects the portfolio-scope state per rule (checked when portfolioOverrides has the rule)', () => {
+    render(
+      <Panel
+        rules={RULES}
+        overrides={{}}
+        portfolioOverrides={{ r1: 'warn' }}
+        onChange={() => {}}
+        onScopeChange={() => {}}
+      />,
+    );
+    const r1 = screen.getByRole('checkbox', {
+      name: /apply across portfolio for r1/i,
+    }) as HTMLInputElement;
+    const r2 = screen.getByRole('checkbox', {
+      name: /apply across portfolio for r2/i,
+    }) as HTMLInputElement;
+    expect(r1.checked).toBe(true);
+    expect(r2.checked).toBe(false);
+  });
+
+  it('fires onScopeChange(ruleId, "portfolio") when the toggle is checked', async () => {
+    const onScopeChange = vi.fn();
+    render(
+      <Panel
+        rules={RULES}
+        overrides={{ r1: 'warn' }}
+        portfolioOverrides={{}}
+        onChange={() => {}}
+        onScopeChange={onScopeChange}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole('checkbox', {
+        name: /apply across portfolio for r1/i,
+      }),
+    );
+    expect(onScopeChange).toHaveBeenCalledWith('r1', 'portfolio');
+  });
+
+  it('fires onScopeChange(ruleId, "lease") when an already-portfolio toggle is unchecked', async () => {
+    const onScopeChange = vi.fn();
+    render(
+      <Panel
+        rules={RULES}
+        overrides={{}}
+        portfolioOverrides={{ r1: 'warn' }}
+        onChange={() => {}}
+        onScopeChange={onScopeChange}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole('checkbox', {
+        name: /apply across portfolio for r1/i,
+      }),
+    );
+    expect(onScopeChange).toHaveBeenCalledWith('r1', 'lease');
+  });
+});

--- a/app/src/ui/SeverityOverridesPanel.tsx
+++ b/app/src/ui/SeverityOverridesPanel.tsx
@@ -12,6 +12,15 @@ interface SeverityOverridesPanelProps {
    * means "clear the override; fall back to the rule's built-in severity."
    */
   onChange: (ruleId: string, severity: OverrideSeverity | null) => void;
+  /**
+   * Wave 10 Part D — optional portfolio-scope override map. When provided
+   * (alongside `onScopeChange`), the panel renders an "Apply across portfolio"
+   * checkbox per row whose checked state mirrors the presence of `ruleId` in
+   * `portfolioOverrides`. Existing call sites that omit these props see no
+   * behavior change.
+   */
+  portfolioOverrides?: Record<string, OverrideSeverity>;
+  onScopeChange?: (ruleId: string, scope: 'lease' | 'portfolio') => void;
 }
 
 const SEVERITY_LABEL: Record<OverrideSeverity, string> = {
@@ -30,7 +39,11 @@ export function SeverityOverridesPanel({
   rules,
   overrides,
   onChange,
+  portfolioOverrides,
+  onScopeChange,
 }: SeverityOverridesPanelProps): JSX.Element {
+  const showScopeToggle =
+    portfolioOverrides !== undefined && onScopeChange !== undefined;
   if (rules.length === 0) {
     return (
       <section aria-label="severity overrides">
@@ -62,6 +75,7 @@ export function SeverityOverridesPanel({
             <th scope="col">Rule</th>
             <th scope="col">Built-in</th>
             <th scope="col">Override</th>
+            {showScopeToggle ? <th scope="col">Scope</th> : null}
             <th scope="col">
               <span className="visually-hidden">Actions</span>
             </th>
@@ -98,6 +112,26 @@ export function SeverityOverridesPanel({
                     </select>
                   </label>
                 </td>
+                {showScopeToggle ? (
+                  <td>
+                    <label>
+                      <input
+                        type="checkbox"
+                        aria-label={`apply across portfolio for ${r.id}`}
+                        checked={portfolioOverrides?.[r.id] !== undefined}
+                        onChange={(e) =>
+                          onScopeChange?.(
+                            r.id,
+                            e.target.checked ? 'portfolio' : 'lease',
+                          )
+                        }
+                      />
+                      <span className="visually-hidden">
+                        Apply across portfolio for {r.title}
+                      </span>
+                    </label>
+                  </td>
+                ) : null}
                 <td>
                   <button
                     type="button"


### PR DESCRIPTION
## Summary
- `app/src/rules/portfolioOverrides.ts` — `resolveSeverity` (lease > portfolio > pack default), `migrateLegacyOverrides`, `buildResolverMapForLease`
- Threads resolver through `applySeverityOverrides` — existing call sites unchanged
- `packStorage.getSeverityOverrides` accepts optional `{scope}` filter; sibling `severityOverridesByLease` SETTINGS key holds `Record<leaseId, Record<ruleId, Severity>>`. **No IDB schema bump** — both keys live in the existing v3 SETTINGS object store.
- `SeverityOverridesPanel` adds optional "Apply across portfolio" checkbox column gated on the new props being provided

## Wave 10 / Phase 16 — Part D of 4
Plan: `docs/plans/wave10-portfolio-intelligence.md` §Part D. Independent of A/B/C.

## Migration of legacy rows
Existing override rows (pre-Wave 10) are read as portfolio-scope (matches `migrateLegacyOverrides`). Lease-scope rows live under the new sibling key. No rewrite-on-read; legacy callers see identical return shape.

## Test plan
- [x] Owned tests: 8 portfolioOverrides + 4 portfolio panel = 12 new
- [x] Full suite: 952 passed, 0 failed
- [x] Existing `severityOverrides.test.ts` (6/6) and `SeverityOverridesPanel.test.tsx` (8/8) green unmodified
- [x] typecheck / lint / check:budget all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)