### PR TITLE
docs: post-merge sync for Wave 10 + Wave 11

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -16,11 +16,11 @@ enough to land in one PR.
 
 | Axis | Value | Gate |
 |------|-------|------|
-| Source | 117 non-test files (~13.0k LOC) + 91 test files (~12.5k LOC) | `find app/src -name '*.ts' -o -name '*.tsx'` |
-| Tests | ~890 passing across 121 files (app) + 8 in `cli/` | `npm test` |
-| Coverage | 97.02% stmt · 88.06% branch · 93.21% func · 97.02% line | `npm run test:coverage` (thresholds 90/85/90/90) |
+| Source | ~135 non-test files + ~105 test files | `find app/src -name '*.ts' -o -name '*.tsx'` |
+| Tests | ~960 passing (app) + 8 in `cli/` | `npm test` |
+| Coverage | thresholds 90/85/90/90 (see `docs/TESTING.md` for current numbers) | `npm run test:coverage` |
 | Bundles | app shell ~290 KiB (`index-*.js` + split) · pdf.js api 400 KiB · pdf.worker 1.3 MiB · leaseWorker ~8 KiB · tesseract runtime 8 MiB (opt-in) | `npm run check:budget` |
-| IndexedDB | main `leaseguard` v3 (`leases` + `settings` + `clauseTemplates`); 8 side dbs: `leaseguard-packs` v3 (adds `signatures` store), `leaseguard-annotations` v1, `leaseguard-counters` v1, `leaseguard-signing` **v2** (multi-key store, post Wave 8-D), `leaseguard-audit` v1 (entries gain optional `signedByKeyId`), `leaseguard-redlines` v1, `leaseguard-versions` v1, `leaseguard-bulk-dedup` v1 | migrations tested |
+| IndexedDB | main `leaseguard` **v5** (`leases` + `settings` + `clauseTemplates` + `paragraphShingles`, post Wave 10-B); 9 side dbs: `leaseguard-packs` v3 (`signatures` store), `leaseguard-annotations` v1, `leaseguard-counters` v1, `leaseguard-signing` **v2** (multi-key, post Wave 8-D), `leaseguard-audit` v1 (entries gain optional `signedByKeyId`), `leaseguard-redlines` v1, `leaseguard-versions` v1, `leaseguard-bulk-dedup` v1, `leaseguard-standards` **v1** (Wave 10-C). `leaseguard-packs` `settings` store also gains a `severityOverridesByLease` key (Wave 10-D) without a schema bump. | migrations tested |
 | App.tsx | decomposed into per-panel containers around `usePipeline` (Wave 7-D) | — |
 | CLI | `leaseguard-verify` (Node, no browser, no network) — `cli/` workspace, 3 tests | `cd cli && npm test` |
 | Build | Vite 5 + vite-plugin-pwa → `dist/` with `sw.js`; Web Worker chunk for parse+analyze | `npm run build` |
@@ -371,15 +371,18 @@ Local-only, CSP-compatible.
       counter-offer flow. Landed wave 2 — field in
       `src/rules/types.ts`; CounterOfferPanel pre-fills its textarea
       with `rule.suggestedEdit` (wave2-wireup).
-- [ ] Static legal-term glossary at `app/public/glossary/v1.json`;
-      consumed by the defined-terms tooltip in
-      `src/ui/highlightDefinedTerms.ts`. Directory does not yet exist.
-- [ ] i18n scaffold: lift UI strings to a typed `messages` object;
-      locale picker; pilot with en + one other locale. Today the app
-      has no `i18n/` module; only `toLocaleDateString` sprinkled
-      through panels.
-- [ ] OCR language picker once a second `*.traineddata.gz` lands —
-      today `runOcr` is hard-coded to English.
+- [x] Static legal-term glossary at `app/public/glossary/v1.json`,
+      surfaced via `src/ui/highlightDefinedTerms.ts` over the existing
+      tooltip. Landed Wave 11-A (PR #33).
+- [x] i18n scaffold: hand-rolled typed `messages` catalog
+      (`src/i18n/messages.ts`) with en baseline + es stub via
+      `satisfies Partial<Messages>`; `I18nProvider` wraps `<App>` and
+      `LocalePickerPanel` exposes the locale toggle. Landed Wave 11-B
+      (PR #34). See "i18n" in `docs/SYSTEM_DESIGN.md`.
+- [x] OCR language picker — `discoverOcrLanguages()` lists every
+      `*.traineddata.gz` present under `public/tesseract/`;
+      `OcrLanguagePickerPanel` lets the user pick before kicking off
+      OCR. Landed Wave 11-C (PR #35).
 
 ## Wave 7 — Ship-readiness
 
@@ -419,6 +422,52 @@ format.
 - [x] Wave 9 Part B — Counter-sign-and-return (`wave9-counter-sign`, PR #20)
 - [x] Wave 9 Part C — Delta packets (`wave9-delta-packets`, PR #19)
 - [x] Wave 9 Part D — Review-archive CLI verifier + privacy review (`wave9-privacy-review`, PR #22)
+
+## Phase 16 — Multi-lease intelligence
+
+Plan: [`plans/wave10-portfolio-intelligence.md`](./plans/wave10-portfolio-intelligence.md).
+Turns the portfolio grid (Phase 11) and per-user severity overrides (Phase
+10) into actual analytical leverage across a tenant's library.
+
+- [x] Portfolio-wide rule rollups — `app/src/portfolio/ruleRollups.ts` +
+      `PortfolioRollupsPanel` with severity-resolved aggregation and
+      drill-through filtering of the existing grid.
+- [x] Clause similarity — `shingles.ts` (5-shingles + Jaccard) +
+      `clauseClusters.ts` clustering at threshold ≥ 0.8;
+      `ClauseSimilarityPanel`. IDB v5 adds the `paragraphShingles`
+      store keyed by `[leaseId, paragraphIndex]`.
+- [x] "My standard" clause suite — new `leaseguard-standards` v1 IDB,
+      `compareToStandard.ts`, `StandardSuitePanel`, additive
+      `onPromoteToStandard` callback on `FindingsPanel`. Audit kinds
+      `standard-promote` / `standard-delete`.
+- [x] Portfolio-scope severity overrides — `portfolioOverrides.ts`
+      with lease > portfolio > pack-default resolution; sibling
+      `severityOverridesByLease` SETTINGS key (no IDB schema bump);
+      "Apply across portfolio" toggle on `SeverityOverridesPanel`.
+
+## Wave 10 — Multi-lease intelligence (Phase 16)
+
+Plan: [`plans/wave10-portfolio-intelligence.md`](./plans/wave10-portfolio-intelligence.md).
+Four parallel-safe parts run via TDD dispatch (per-story spec branches +
+isolated implementer worktrees).
+
+- [x] Wave 10 Part A — Portfolio rule rollups (`tdd-wave/10/a-rule-rollups`, PR #37)
+- [x] Wave 10 Part B — Clause similarity + IDB v5 (`tdd-wave/10/b-clause-similarity`, PR #38)
+- [x] Wave 10 Part C — "My standard" clause suite (`tdd-wave/10/c-standard-suite`, PR #39)
+- [x] Wave 10 Part D — Portfolio-scope severity overrides (`tdd-wave/10/d-portfolio-overrides`, PR #40)
+
+## Wave 11 — Content depth + risk register (Phase 14 + risk closeout)
+
+Plan: [`plans/wave11-content-and-risk.md`](./plans/wave11-content-and-risk.md).
+Closes the remaining Phase 14 content-depth items and four entries from
+the risk register.
+
+- [x] Wave 11 Part A — Static legal glossary (`wave11-glossary`, PR #33)
+- [x] Wave 11 Part B — i18n scaffold (en + es stub) (`wave11-i18n`, PR #34)
+- [x] Wave 11 Part C — OCR language picker (`wave11-ocr-language`, PR #35)
+- [x] Wave 11 Part D — Risk-register closeout: encrypted-archive review,
+      crash-log privacy review, CSP regression test, rule-pack rot
+      review (`wave11-risk-register`, PR #31). See `docs/SECURITY.md`.
 
 ## Cross-cutting tech debt
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -75,12 +75,10 @@ Each phase links to its backlog section.
 | 11 | Workflow & integrations | Done |
 | 12 | Trust & verification | Done |
 | 13 | Performance & scale | Done |
-| 14 | Content depth | Substantially done — static glossary JSON, i18n scaffold, OCR language picker open |
+| 14 | Content depth | Done — Wave 11 shipped static glossary, i18n scaffold (en + es stub), OCR language picker |
 | 15 | Collaboration escape hatches | Done — Wave 9 shipped review links, counter-sign, delta packets, CLI verifier |
+| 16 | Multi-lease intelligence | Done — Wave 10 shipped portfolio rule rollups, clause similarity (IDB v5), "my standard" suite, portfolio-scope severity overrides |
 | 17 | Trust infrastructure | Done — Wave 8 shipped marketplace, deviation warnings, repro CLI, key rotation |
-
-"Substantially done" means the phase's primary surface is built and wired;
-the open items are scoped follow-ups rather than net-new work.
 
 ---
 
@@ -89,15 +87,6 @@ the open items are scoped follow-ups rather than net-new work.
 The roadmap below is organized by where the product is heading, not by
 phase number. Each bullet points to the backlog section that tracks the
 tickets.
-
-### Content depth — more useful without phoning home
-
-- Static legal glossary shipped at `public/glossary/v1.json`, surfaced
-  via the existing hover-tooltip. (Phase 14)
-- i18n scaffold: externalize UI strings, ship an English baseline, wire
-  a locale picker. (Phase 14)
-- OCR language picker — activates once a second `*.traineddata.gz`
-  lands in `public/ocr/`. (Phase 14)
 
 ### Tech debt — keep the codebase honest
 
@@ -111,10 +100,11 @@ list.
 
 ### Risk register — review before 1.0
 
-Tracked in [`BACKLOG.md`](./BACKLOG.md#known-unknowns--risk-register):
-tesseract licensing audit, archive-format security review, release /
-versioning policy, crash-log privacy review, CSP regression tests,
-rule-pack rot review.
+Tracked in [`BACKLOG.md`](./BACKLOG.md#known-unknowns--risk-register).
+Wave 11-D closed the encrypted-archive security review, crash-log
+privacy review, CSP regression tests, and rule-pack rot review (see
+[`SECURITY.md`](./SECURITY.md)). Open: tesseract licensing audit,
+release / versioning policy.
 
 ---
 
@@ -147,23 +137,31 @@ and the "Collaboration escape hatches" section of
   `SYSTEM_DESIGN.md` documents the privacy contract (no telemetry, no
   key escrow, no IDB dump beyond the chosen lease, no network).
 
-### Phase 16 — Multi-lease intelligence
+### Phase 16 — Multi-lease intelligence (shipped, Wave 10)
 
-The portfolio grid shipped in Phase 11 makes the library visible.
-Phase 16 makes it analytical.
+The portfolio grid shipped in Phase 11 made the library visible. Wave 10
+made it analytical. See "Multi-lease intelligence" in
+[`SYSTEM_DESIGN.md`](./SYSTEM_DESIGN.md).
 
-- **Portfolio-wide rule rollups** — "12 of 18 leases have auto-renewal;
-  4 waive jury trial" with drill-through to the individual findings.
-  Extends the `PortfolioPanel`.
-- **Clause similarity across leases** — shingled / normalized hashing
-  to cluster near-identical clauses across the library; useful for
-  "which of my leases share this bad indemnification paragraph."
-- **"My standard" clause suite** — promote any clause from any lease
-  into a named standard; compare future leases against the suite the
-  way rule findings are currently surfaced.
-- **Portfolio-level rule overrides** — extend the per-user severity
-  override model so a tenant can say "treat this rule as High across
-  my whole portfolio" without re-declaring it per lease.
+- **Portfolio-wide rule rollups** — `app/src/portfolio/ruleRollups.ts`
+  aggregates findings across the library with severity-override
+  resolution; `PortfolioRollupsPanel` renders a sortable table with
+  drill-through filtering of the existing grid by `leaseIds[]`.
+- **Clause similarity across leases** — `app/src/portfolio/shingles.ts`
+  (5-shingles + Jaccard) and `clauseClusters.ts` cluster
+  near-identical paragraphs across the library at threshold ≥ 0.8.
+  IDB v5 adds a `paragraphShingles` store keyed by
+  `[leaseId, paragraphIndex]`, populated lazily on first
+  similarity-panel render.
+- **"My standard" clause suite** — `app/src/clauseStandard/standardSuite.ts`
+  owns a new `leaseguard-standards` v1 IDB; FindingsPanel gains an
+  optional "Promote to standard" button; `compareToStandard.ts`
+  surfaces matches above 0.8 against the suite. Audit kinds
+  `standard-promote` / `standard-delete`.
+- **Portfolio-level rule overrides** — `portfolioOverrides.ts`
+  introduces a `scope: 'lease' | 'portfolio'` discriminator. Resolution
+  order: lease > portfolio > pack default. Encoded as a sibling
+  `severityOverridesByLease` SETTINGS key — no IDB schema bump.
 
 ### Phase 17 — Trust infrastructure (shipped, Wave 8)
 

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -147,21 +147,22 @@ compiled inline, already-compiled arrays skip the step.
 
 ## IndexedDB landscape
 
-Nine databases, each with an independent migration history and an
+Ten databases, each with an independent migration history and an
 `_reset<Name>DbForTests` hook. Separation is deliberate: a schema bump
 in one concern never forces a migration on another.
 
-| DB name                    | Version | Stores                                     | Purpose |
-|----------------------------|--------:|--------------------------------------------|---------|
-| `leaseguard`               | v3      | `leases`, `settings`, `clauseTemplates`    | Primary lease library + standard-lease pointer + clause templates |
-| `leaseguard-packs`         | v3      | `packs`, `enabled`, `settings`, `signatures` | Installed rule packs, enabled flags, jurisdiction / severity settings, signed-envelope records |
-| `leaseguard-annotations`   | v1      | `annotations`                              | Per-paragraph user annotations |
-| `leaseguard-counters`      | v1      | `counters`                                 | User's counter-offer library |
-| `leaseguard-redlines`      | v1      | `edits`                                    | Redline paragraph replacements |
-| `leaseguard-versions`      | v1      | `versions`                                 | Lease version snapshots |
-| `leaseguard-audit`         | v1      | `entries`                                  | Append-only hash-chained audit log |
-| `leaseguard-signing`       | v2      | `keypair`                                  | Ed25519 keypairs (multi-key, see "Key rotation"); private key passphrase-wrapped |
-| `leaseguard-bulk-dedup`    | v1      | `hashes`                                   | SHA-256 content hashes for bulk-import dedup |
+| DB name                    | Version | Stores                                                                | Purpose |
+|----------------------------|--------:|-----------------------------------------------------------------------|---------|
+| `leaseguard`               | **v5**  | `leases`, `settings`, `clauseTemplates`, `paragraphShingles`          | Primary lease library + standard-lease pointer + clause templates. v4 added the `(findingCount, rulePackVersion)` index on `leases` (Wave 7-E). v5 added the `paragraphShingles` store keyed by `[leaseId, paragraphIndex]`, populated lazily on first portfolio-similarity render (Wave 10-B). |
+| `leaseguard-packs`         | v3      | `packs`, `enabled`, `settings`, `signatures`                          | Installed rule packs, enabled flags, jurisdiction / severity settings, signed-envelope records. The `settings` store now holds both `severityOverrides` (portfolio-scope flat map; legacy rows are implicitly portfolio-scope) and a sibling `severityOverridesByLease` key keyed `Record<leaseId, Record<ruleId, Severity>>` (Wave 10-D). No schema bump. |
+| `leaseguard-annotations`   | v1      | `annotations`                                                         | Per-paragraph user annotations |
+| `leaseguard-counters`      | v1      | `counters`                                                            | User's counter-offer library |
+| `leaseguard-redlines`      | v1      | `edits`                                                               | Redline paragraph replacements |
+| `leaseguard-versions`      | v1      | `versions`                                                            | Lease version snapshots |
+| `leaseguard-audit`         | v1      | `entries`                                                             | Append-only hash-chained audit log |
+| `leaseguard-signing`       | v2      | `keypair`                                                             | Ed25519 keypairs (multi-key, see "Key rotation"); private key passphrase-wrapped |
+| `leaseguard-bulk-dedup`    | v1      | `hashes`                                                              | SHA-256 content hashes for bulk-import dedup |
+| `leaseguard-standards`     | v1      | `standards`                                                           | "My standard" clause suite — promoted paragraphs as named standards (Wave 10-C) |
 
 ## Signing
 
@@ -323,6 +324,50 @@ The Wave 11 scaffold migrates ~10 representative `App.tsx` strings
 (header, view-mode toggle, top-level export buttons, footer
 clear-all). Full panel-by-panel migration is a tracked Phase 14
 follow-up.
+
+## Multi-lease intelligence (Wave 10 / Phase 16)
+
+Phase 16 promotes the portfolio grid (Phase 11) from a list view into an
+analytical surface. All four pieces run entirely over IDB-resident data;
+there is no new network egress.
+
+**Rule rollups.** `app/src/portfolio/ruleRollups.ts` exports a pure
+`aggregateFindings(leases) -> RuleRollup[]` returning
+`{ ruleId, leaseCount, severityCounts, leaseIds[] }`, sorted
+deterministically by `leaseCount desc, ruleId asc`. Severity overrides
+are resolved through the same path `FindingsPanel` uses, so a portfolio
+rollup sees the same severities a single-lease view would.
+`PortfolioRollupsPanel` renders the table above the existing grid; clicking
+a row passes `filterLeaseIds` back into `PortfolioPanel`.
+
+**Clause similarity.** `app/src/portfolio/shingles.ts` exports
+`paragraphShingles(text, k=5)` (lowercased, whitespace-collapsed,
+punctuation-stripped) and `jaccard(a, b)`. `clauseClusters.ts` clusters
+paragraphs across leases at Jaccard ≥ 0.8 with deterministic ordering.
+The `paragraphShingles` IDB store (`leaseguard` v5) is populated lazily
+on first `ClauseSimilarityPanel` render — the lease-save path is
+unchanged. Hashing is applied to original `LeaseDocument.paragraphs`
+only; redlined edits are intentionally out of scope.
+
+**"My standard" clause suite.** `leaseguard-standards` v1 holds promoted
+clauses (`{ id, name, sourceLeaseId, sourceParagraphIndex,
+normalizedText, createdAt }`). `compareToStandard.ts` reuses
+`shingles.jaccard` to surface matches above 0.8 against the suite.
+`FindingsPanel` accepts an optional `onPromoteToStandard` callback — when
+absent, behavior is identical to pre-Wave-10. `safeAudit` records
+`standard-promote` and `standard-delete` entries.
+
+**Portfolio-scope severity overrides.** `app/src/rules/portfolioOverrides.ts`
+extends the existing per-user override model with a
+`scope: 'lease' | 'portfolio'` discriminator. Resolution order is **lease
+> portfolio > pack default**; `applySeverityOverrides` threads the resolver
+internally so existing call sites are unchanged. Storage encoding lives in
+`packStorage`: portfolio-scope rows in the existing `severityOverrides`
+SETTINGS key (so legacy rows read as portfolio-scope), lease-scope rows in
+the new sibling `severityOverridesByLease` key. Both keys live in the v3
+SETTINGS store — no IDB schema bump. The `SeverityOverridesPanel` adds an
+"Apply across portfolio" toggle column gated on the new props being
+provided.
 
 ## Collaboration escape hatches (Wave 9 / Phase 15)
 


### PR DESCRIPTION
## Summary
Docs-only sync to reflect Wave 10 (Phase 16 — multi-lease intelligence) and Wave 11 (Phase 14 content depth + risk-register closeout) now that all 8 PRs (#33, #34, #35, #37, #38, #39, #40, #31) have landed on main.

- **ROADMAP.md** — Phase 14 + 16 promoted to Done; risk-register section narrowed to what Wave 11-D didn't close (tesseract licensing + release/versioning policy still open); Phase 16 forward-phase entry rewritten in past tense with module paths.
- **BACKLOG.md** — footprint refreshed (leaseguard v3→v5 + `paragraphShingles`, new `leaseguard-standards` v1, `severityOverridesByLease` SETTINGS key, ~960 tests). New Phase 16 + Wave 10 + Wave 11 sections; remaining Phase 14 items ticked with PR refs.
- **SYSTEM_DESIGN.md** — IDB landscape table bumped to ten databases with the v5 store + dual SETTINGS keys documented; new "Multi-lease intelligence (Wave 10 / Phase 16)" subsection covering rollups, similarity, standard suite, and portfolio-scope overrides with their resolution + storage encoding.

## Test plan
- [x] No code changes — typecheck/lint/test gates not applicable
- [ ] Reviewer eyeballs that wave10/11 PR refs in the new sections match the actual merge commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)