### PR TITLE
wave13-A: onboarding tour expansion

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -59,8 +59,6 @@ import { AnnotationsPanel } from './ui/AnnotationsPanel';
 import { CounterOfferPanel } from './ui/CounterOfferPanel';
 import type { CounterOffer } from './negotiation/counterOffers';
 import { PortfolioPanel } from './ui/PortfolioPanel';
-import { ClauseSimilarityPanel } from './ui/ClauseSimilarityPanel';
-import { clusterParagraphs, type ClauseCluster } from './portfolio/clauseClusters';
 import { paragraphShingles } from './portfolio/shingles';
 import { CustomRuleBuilderPanel } from './ui/CustomRuleBuilderPanel';
 import { RedlinePanel } from './ui/RedlinePanel';
@@ -72,12 +70,7 @@ import { OcrLanguagePickerPanel } from './ui/OcrLanguagePickerPanel';
 import type { Finding } from './rules/types';
 import type { ClauseTemplate } from './templates/types';
 import { matchTemplates } from './templates/matchTemplates';
-import {
-  saveTemplate,
-  listTemplates,
-  updateTemplate,
-  deleteTemplate,
-} from './storage/templates';
+import { saveTemplate, listTemplates, updateTemplate, deleteTemplate } from './storage/templates';
 import {
   clearStandardId,
   deleteLease,
@@ -142,9 +135,7 @@ function AppContent(): JSX.Element {
   const [auditEntries, setAuditEntries] = useState<AuditEntry[]>([]);
   const [auditVerification, setAuditVerification] = useState<ChainVerification | null>(null);
   const [view, setView] = useState<'current' | 'portfolio' | 'redline'>('current');
-  const [portfolioFindings, setPortfolioFindings] = useState<Map<string, Finding[]>>(
-    new Map(),
-  );
+  const [portfolioFindings, setPortfolioFindings] = useState<Map<string, Finding[]>>(new Map());
   const [standardSuite, setStandardSuite] = useState<StandardClause[]>([]);
 
   const refreshStandardSuite = useCallback(async (): Promise<void> => {
@@ -294,18 +285,14 @@ function AppContent(): JSX.Element {
         const map = new Map<string, Finding[]>();
         for (const r of records) map.set(r.id, r.findings);
         setPortfolioFindings(map);
-        // Wave 10-B: cluster paragraphs and write-through shingles to IDB so
-        // a future cross-cluster pass can read them without re-tokenizing.
-        // Failures are logged and dropped — clustering must not block the
-        // portfolio view.
+        // Wave 10-B: write-through shingles to IDB so a future cross-cluster
+        // pass can read them without re-tokenizing. Failures are logged and
+        // dropped — shingle persistence must not block the portfolio view.
         try {
-          const clusters = clusterParagraphs(records);
-          setClauseClusters(clusters);
           await persistShingles(records);
         } catch (err) {
           // eslint-disable-next-line no-console
-          console.warn('clause similarity failed', err);
-          setClauseClusters([]);
+          console.warn('shingle persistence failed', err);
         }
       })();
     }
@@ -442,12 +429,12 @@ function AppContent(): JSX.Element {
     [status],
   );
 
-
   return (
     <main>
       {onboardingDismissedAt !== undefined && (
         <OnboardingTour
           dismissedAt={onboardingDismissedAt}
+          viewMode={view}
           onDismiss={() => {
             void dismissOnboarding();
           }}
@@ -463,9 +450,8 @@ function AppContent(): JSX.Element {
             <li>The PDF is parsed entirely in your browser via pdf.js.</li>
             <li>All storage is in IndexedDB on this device. No account, no sync.</li>
             <li>
-              A strict Content-Security-Policy (<code>default-src &apos;self&apos;</code>)
-              blocks this page from loading scripts, fonts, or data from any other
-              origin.
+              A strict Content-Security-Policy (<code>default-src &apos;self&apos;</code>) blocks
+              this page from loading scripts, fonts, or data from any other origin.
             </li>
             <li>LeaseGuard is not legal advice. Findings are heuristic pattern matches.</li>
           </ul>
@@ -483,16 +469,30 @@ function AppContent(): JSX.Element {
             }}
           />
         </label>
-        <button type="button" onClick={() => void onTrySample()}>{t('header.trySample')}</button>
+        <button type="button" onClick={() => void onTrySample()}>
+          {t('header.trySample')}
+        </button>
         <div role="group" aria-label="view mode" className="view-toggle">
-          <button type="button" aria-pressed={view === 'current'} onClick={() => setView('current')}>
+          <button
+            type="button"
+            aria-pressed={view === 'current'}
+            onClick={() => setView('current')}
+          >
             {t('header.view.current')}
           </button>
-          <button type="button" aria-pressed={view === 'portfolio'} onClick={() => setView('portfolio')}>
+          <button
+            type="button"
+            aria-pressed={view === 'portfolio'}
+            onClick={() => setView('portfolio')}
+          >
             {t('header.view.portfolio')}
           </button>
           {status.kind === 'analyzed' && (
-            <button type="button" aria-pressed={view === 'redline'} onClick={() => setView('redline')}>
+            <button
+              type="button"
+              aria-pressed={view === 'redline'}
+              onClick={() => setView('redline')}
+            >
               {t('header.view.redline')}
             </button>
           )}
@@ -500,7 +500,9 @@ function AppContent(): JSX.Element {
       </header>
 
       {view === 'current' && status.kind === 'loading' && (
-        <p role="status" aria-live="polite">Analyzing {status.fileName}…</p>
+        <p role="status" aria-live="polite">
+          Analyzing {status.fileName}…
+        </p>
       )}
       {view === 'current' && status.kind === 'error' && (
         <p role="alert">Could not analyze this file: {status.message}</p>
@@ -536,9 +538,7 @@ function AppContent(): JSX.Element {
             edits={redline.redlineEdits}
             onEditParagraph={(pIdx, after) => {
               const before =
-                status.kind === 'analyzed'
-                  ? (status.result.doc.paragraphs[pIdx]?.text ?? '')
-                  : '';
+                status.kind === 'analyzed' ? (status.result.doc.paragraphs[pIdx]?.text ?? '') : '';
               void redline.editParagraph({ paragraphIndex: pIdx, before, after });
             }}
             onDeleteEdit={(pIdx) => void redline.deleteParagraphEdit(pIdx)}
@@ -598,7 +598,9 @@ function AppContent(): JSX.Element {
       {view === 'current' && status.kind === 'analyzed' && (
         <div className="results">
           <div className="results-actions">
-            <button type="button" onClick={onExportJson}>{t('findings.export.json')}</button>
+            <button type="button" onClick={onExportJson}>
+              {t('findings.export.json')}
+            </button>
             <button
               type="button"
               onClick={() => {
@@ -624,11 +626,17 @@ function AppContent(): JSX.Element {
             return (
               <div role="status" className="ocr-banner">
                 <p>
-                  This PDF looks scanned (avg {Math.round(ocr.avgCharsPerPage)} chars/page).
-                  Text extraction may be incomplete.
+                  This PDF looks scanned (avg {Math.round(ocr.avgCharsPerPage)} chars/page). Text
+                  extraction may be incomplete.
                 </p>
                 {status.bytes && ocrState.kind !== 'running' && (
-                  <button type="button" onClick={() => { setSelected(null); void pipeline.ocr(ocrLanguage); }}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSelected(null);
+                      void pipeline.ocr(ocrLanguage);
+                    }}
+                  >
                     Attempt OCR
                   </button>
                 )}
@@ -649,7 +657,10 @@ function AppContent(): JSX.Element {
           <div className="split">
             <FindingsPanel
               findings={status.result.findings}
-              onSelect={(f) => { setSelected(f); setSelectedPage(f.page); }}
+              onSelect={(f) => {
+                setSelected(f);
+                setSelectedPage(f.page);
+              }}
               definitions={extractLeaseFacts(status.result.doc).definitions}
               glossary={glossaryEntries}
               plainEnglishByRuleId={plainEnglishByRuleId}
@@ -670,7 +681,12 @@ function AppContent(): JSX.Element {
                 void (async (): Promise<void> => {
                   const text = status.result.doc.paragraphs[paragraphIndex]?.text ?? '';
                   const name = text.slice(0, 60).trim() || `Clause from ${leaseId}`;
-                  await promoteToStandard({ name, sourceLeaseId: leaseId, sourceParagraphIndex: paragraphIndex, normalizedText: text });
+                  await promoteToStandard({
+                    name,
+                    sourceLeaseId: leaseId,
+                    sourceParagraphIndex: paragraphIndex,
+                    normalizedText: text,
+                  });
                   await refreshStandardSuite();
                   void refreshAuditLog();
                 })();
@@ -682,7 +698,9 @@ function AppContent(): JSX.Element {
               selectedPage={selectedPage}
               pages={status.result.doc.pages}
               highlight={
-                selected ? (status.result.doc.paragraphs[selected.paragraphIndex]?.bbox ?? null) : null
+                selected
+                  ? (status.result.doc.paragraphs[selected.paragraphIndex]?.bbox ?? null)
+                  : null
               }
             />
           </div>
@@ -797,9 +815,8 @@ function AppContent(): JSX.Element {
       <section aria-label="diff rule pack">
         <h2>Diff rule pack</h2>
         <p>
-          Load a <code>.lgpack.json</code> file to see how it differs from the
-          currently active rule set. Nothing is saved until you import it via
-          the pack manager above.
+          Load a <code>.lgpack.json</code> file to see how it differs from the currently active rule
+          set. Nothing is saved until you import it via the pack manager above.
         </p>
         <label>
           <span className="visually-hidden">Pack file to diff</span>

--- a/app/src/ui/OnboardingTour.stories.tsx
+++ b/app/src/ui/OnboardingTour.stories.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { OnboardingTour } from './OnboardingTour';
 
@@ -16,10 +17,50 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const FirstRun: Story = {
-  args: {
-    dismissedAt: null,
-  },
+/**
+ * Step-N stories click "Next" the right number of times after mount so the
+ * panel renders the requested step without exposing internal state.
+ */
+function AutoAdvance({
+  steps,
+  viewMode,
+}: {
+  steps: number;
+  viewMode?: 'current' | 'portfolio' | 'redline';
+}): JSX.Element {
+  useEffect(() => {
+    for (let i = 0; i < steps; i += 1) {
+      const next = Array.from(
+        document.querySelectorAll<HTMLButtonElement>('.onboarding-tour button'),
+      ).find((b) => b.textContent?.trim() === 'Next');
+      next?.click();
+    }
+  }, [steps]);
+  return <OnboardingTour dismissedAt={null} onDismiss={() => {}} viewMode={viewMode} />;
+}
+
+export const Step1Upload: Story = {
+  args: { dismissedAt: null },
+};
+
+export const Step2Findings: Story = {
+  args: { dismissedAt: null },
+  render: () => <AutoAdvance steps={1} />,
+};
+
+export const Step3PortfolioFromCurrent: Story = {
+  args: { dismissedAt: null, viewMode: 'current' },
+  render: () => <AutoAdvance steps={2} viewMode="current" />,
+};
+
+export const Step3PortfolioFromPortfolio: Story = {
+  args: { dismissedAt: null, viewMode: 'portfolio' },
+  render: () => <AutoAdvance steps={2} viewMode="portfolio" />,
+};
+
+export const Step4AuditAndExport: Story = {
+  args: { dismissedAt: null },
+  render: () => <AutoAdvance steps={3} />,
 };
 
 export const AlreadyDismissed: Story = {

--- a/app/src/ui/OnboardingTour.test.tsx
+++ b/app/src/ui/OnboardingTour.test.tsx
@@ -4,34 +4,41 @@ import userEvent from '@testing-library/user-event';
 import { OnboardingTour } from './OnboardingTour';
 
 describe('OnboardingTour', () => {
-  it('renders the first step on initial mount when dismissedAt is null', () => {
+  it('renders the first step (upload / sample-lease) on initial mount when dismissedAt is null', () => {
     render(<OnboardingTour dismissedAt={null} onDismiss={() => {}} />);
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText(/step 1 of 4/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', { name: /local-first by design/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /upload a lease/i })).toBeInTheDocument();
+    expect(screen.getByText(/try a sample lease/i)).toBeInTheDocument();
   });
 
-  it('walks through all 4 steps via Next and back via Back', async () => {
+  it('walks through all 4 steps via Next, finishing with Done', async () => {
     const user = userEvent.setup();
     render(<OnboardingTour dismissedAt={null} onDismiss={() => {}} />);
     expect(screen.getByText(/step 1 of 4/i)).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /^next$/i }));
     expect(screen.getByText(/step 2 of 4/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /findings.*severity/i })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /^next$/i }));
     expect(screen.getByText(/step 3 of 4/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /portfolio.*rollups/i })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /^next$/i }));
     expect(screen.getByText(/step 4 of 4/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', { name: /ocr is opt-in/i }),
-    ).toBeInTheDocument();
-    // Back returns to step 3.
-    await user.click(screen.getByRole('button', { name: /^back$/i }));
-    expect(screen.getByText(/step 3 of 4/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /audit log.*signed export/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /finish onboarding tour/i })).toBeInTheDocument();
   });
 
-  it('clicking Got it on the last step calls onDismiss', async () => {
+  it('Back returns to the previous step', async () => {
+    const user = userEvent.setup();
+    render(<OnboardingTour dismissedAt={null} onDismiss={() => {}} />);
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    expect(screen.getByText(/step 3 of 4/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /^back$/i }));
+    expect(screen.getByText(/step 2 of 4/i)).toBeInTheDocument();
+  });
+
+  it('clicking Done on the last step calls onDismiss', async () => {
     const user = userEvent.setup();
     const onDismiss = vi.fn();
     render(<OnboardingTour dismissedAt={null} onDismiss={onDismiss} />);
@@ -72,5 +79,32 @@ describe('OnboardingTour', () => {
       expect(btn.getAttribute('tabindex')).not.toBe('-1');
     }
     cleanup();
+  });
+
+  it('portfolio step shows "switch to Portfolio" hint when viewMode is not portfolio', async () => {
+    const user = userEvent.setup();
+    render(<OnboardingTour dismissedAt={null} onDismiss={() => {}} viewMode="current" />);
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    expect(screen.getByText(/step 3 of 4/i)).toBeInTheDocument();
+    expect(screen.getByRole('note')).toHaveTextContent(/click the "portfolio" button/i);
+  });
+
+  it('portfolio step shows "you\'re already here" hint when viewMode is portfolio', async () => {
+    const user = userEvent.setup();
+    render(<OnboardingTour dismissedAt={null} onDismiss={() => {}} viewMode="portfolio" />);
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    expect(screen.getByText(/step 3 of 4/i)).toBeInTheDocument();
+    expect(screen.getByRole('note')).toHaveTextContent(/already on the portfolio view/i);
+  });
+
+  it('omits the contextual hint when viewMode is undefined', async () => {
+    const user = userEvent.setup();
+    render(<OnboardingTour dismissedAt={null} onDismiss={() => {}} />);
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    expect(screen.getByText(/step 3 of 4/i)).toBeInTheDocument();
+    expect(screen.queryByRole('note')).toBeNull();
   });
 });

--- a/app/src/ui/OnboardingTour.tsx
+++ b/app/src/ui/OnboardingTour.tsx
@@ -1,45 +1,65 @@
 import { useCallback, useEffect, useState } from 'react';
 
+export type OnboardingViewMode = 'current' | 'portfolio' | 'redline';
+
 interface OnboardingTourProps {
   /** Existing dismissal timestamp; if non-null, the tour renders nothing. */
   dismissedAt: number | null;
   /** Called when the user dismisses the tour (Got it / Skip / Esc). */
   onDismiss: () => void;
+  /** Current top-level view; lets later steps tell the user where to look. */
+  viewMode?: OnboardingViewMode;
 }
 
 interface Step {
   title: string;
   body: string;
+  /** Optional contextual hint that varies with the active view. */
+  hint?: (view: OnboardingViewMode | undefined) => string | null;
 }
 
 const STEPS: readonly Step[] = [
   {
-    title: 'Local-first by design',
-    body:
-      'LeaseGuard runs entirely in your browser. PDFs are parsed on your device, ' +
-      'findings live in IndexedDB, and nothing leaves your machine.',
-  },
-  {
     title: 'Upload a lease — or try a sample',
     body:
       'Drop a PDF onto the upload control to get started. No PDF handy? Click ' +
-      '"Try a sample lease" to walk through a fully synthetic example.',
+      '"Try a sample lease" to walk through a fully synthetic example. ' +
+      'Everything runs locally in your browser — nothing leaves your machine.',
   },
   {
-    title: 'Click through findings',
+    title: 'Findings: severity + click-to-highlight',
     body:
-      'Each finding links back to the page and clause that triggered it. ' +
-      'Use the sidebar to filter by category or severity.',
+      'Each finding is tagged Critical / Warning / Info and links back to ' +
+      'the page and clause that triggered it. Click a finding to jump to the ' +
+      'matching span in the PDF viewer; filter the list by category or severity.',
   },
   {
-    title: 'OCR is opt-in',
+    title: 'Portfolio: rollups across every saved lease',
     body:
-      'If a lease is a scanned image, LeaseGuard can run OCR locally — but ' +
-      'only after you opt in. The OCR engine ships with the app; no upload happens.',
+      'The Portfolio view aggregates rule hits across your saved leases, ' +
+      'flags clauses that drift from your standard suite, and shows ' +
+      'severity overrides scoped to your portfolio.',
+    hint: (view) => {
+      if (view === undefined) return null;
+      return view === 'portfolio'
+        ? "You're already on the Portfolio view."
+        : 'Click the "Portfolio" button at the top of the page to open it.';
+    },
+  },
+  {
+    title: 'Audit log + signed export',
+    body:
+      'Every significant action — analyze, export, pack import — appends to ' +
+      'a hash-chained audit log. Scroll to the Audit Log panel at the bottom ' +
+      'of the page to verify the chain or download a signed handoff bundle.',
   },
 ];
 
-export function OnboardingTour({ dismissedAt, onDismiss }: OnboardingTourProps): JSX.Element | null {
+export function OnboardingTour({
+  dismissedAt,
+  onDismiss,
+  viewMode,
+}: OnboardingTourProps): JSX.Element | null {
   const [stepIndex, setStepIndex] = useState(0);
   const total = STEPS.length;
   const isLast = stepIndex === total - 1;
@@ -65,6 +85,7 @@ export function OnboardingTour({ dismissedAt, onDismiss }: OnboardingTourProps):
 
   const step = STEPS[stepIndex];
   if (!step) return null;
+  const hint = step.hint?.(viewMode) ?? null;
 
   return (
     <div
@@ -77,10 +98,12 @@ export function OnboardingTour({ dismissedAt, onDismiss }: OnboardingTourProps):
       <div className="onboarding-tour__panel">
         <h2 id="onboarding-tour-title">{step.title}</h2>
         <p>{step.body}</p>
-        <p
-          className="onboarding-tour__progress"
-          aria-label={`step ${stepIndex + 1} of ${total}`}
-        >
+        {hint !== null && (
+          <p className="onboarding-tour__hint" role="note">
+            {hint}
+          </p>
+        )}
+        <p className="onboarding-tour__progress" aria-label={`step ${stepIndex + 1} of ${total}`}>
           Step {stepIndex + 1} of {total}
         </p>
         <div className="onboarding-tour__actions">
@@ -107,7 +130,7 @@ export function OnboardingTour({ dismissedAt, onDismiss }: OnboardingTourProps):
               onClick={handleDismiss}
               aria-label="finish onboarding tour"
             >
-              Got it
+              Done
             </button>
           ) : (
             <button

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -298,6 +298,11 @@ table for the authoritative figures):
 - `vite-plugin-pwa` service worker precaches assets for offline use.
 - Archive export/import uses WebCrypto AES-GCM. No handshake ever
   leaves the device.
+- The first-run onboarding tour (`OnboardingTour`) is purely
+  client-side: copy is bundled into the component, the dismissal
+  timestamp is persisted to IndexedDB via
+  `getOnboardingDismissedAt` / `setOnboardingDismissedAt`, and no
+  step issues network requests or telemetry events.
 
 ## i18n (Wave 11 / Phase 14)
 


### PR DESCRIPTION
## Summary

- Replace the prior 4-step tour (local-first / upload / findings / OCR) with the Wave 13 walkthrough: upload + sample, findings (severity + click-to-highlight), portfolio (rollups + standard suite), audit log + signed export.
- `OnboardingTour` accepts an optional `viewMode` prop so step 3 tells the user whether they need to switch to the Portfolio view.
- No new IDB keys, no schema bump — dismissal still uses `getOnboardingDismissedAt` / `setOnboardingDismissedAt`.
- Drive-by fix: removed orphaned `ClauseSimilarityPanel` / `ClauseCluster` imports and dead `setClauseClusters` references in `App.tsx` that were already breaking typecheck + lint on `main` (Wave 12-A merged red). Shingle persistence is preserved.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npx vitest run src/ui/OnboardingTour.test.tsx` — 11/11 passing (added hint-variant coverage)
- [ ] Full `npm test` — 1041/1044 passing. The 3 remaining failures (`portfolio/shingles.test.ts` ×2, `portfolio/clauseClusters.test.ts` ×1) are **pre-existing on `origin/main`** — `paragraphShingles` is producing 1-token n-grams instead of 5-token, which is real source rot but out of Wave 13-A scope.
- [ ] Storybook walk: 6 OnboardingTour stories (one per step + dismissed) — manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)