### PR TITLE
wave12-C: tesseract licensing closeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ Footprint (tests, coverage, bundles, IDB schema versions) is tracked in
 [`docs/BACKLOG.md`](./docs/BACKLOG.md) is the authoritative ticket
 list.
 
+## Third-party assets
+
+The bundled tesseract.js OCR runtime, WebAssembly engine, and English
+trained-data file are Apache License 2.0; attributions live in
+[`app/public/NOTICE`](./app/public/NOTICE) (also reachable at `/NOTICE`
+from any installed instance of the PWA). See
+[`docs/SECURITY.md`](./docs/SECURITY.md) §5 for the redistribution model
+and re-review triggers.
+
 ## Not legal advice
 
 Findings are heuristic pattern matches. LeaseGuard flags things worth a

--- a/app/public/NOTICE
+++ b/app/public/NOTICE
@@ -1,0 +1,88 @@
+LeaseGuard — third-party asset attributions
+============================================
+
+LeaseGuard runs entirely in the browser and bundles a small number of
+third-party runtime assets to keep its CSP (`default-src 'self'`)
+satisfied — no CDN fetches at runtime. This file enumerates the
+attributions required for redistribution.
+
+This NOTICE file is required by Apache License 2.0 §4(d) for the
+tesseract.js OCR runtime and trained-data files. It is shipped as-is
+inside the precached PWA and is reachable at the URL `/NOTICE`.
+
+
+tesseract.js
+------------
+
+- Files:
+  - app/public/tesseract/worker.min.js
+  - (build-time copy from `node_modules/tesseract.js/dist/worker.min.js`)
+- Upstream: https://github.com/naptha/tesseract.js
+- Version: 7.0.0
+- License: Apache License, Version 2.0
+- Source-of-truth license text: https://www.apache.org/licenses/LICENSE-2.0
+
+  Copyright (c) The tesseract.js authors and contributors.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you
+  may not use this file except in compliance with the License. You may
+  obtain a copy of the License at:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied. See the License for the specific language governing
+  permissions and limitations under the License.
+
+  No upstream NOTICE file is published for tesseract.js. This file is
+  copied verbatim from the upstream release artifact.
+
+
+tesseract.js-core (WebAssembly engine)
+--------------------------------------
+
+- Files:
+  - app/public/tesseract/tesseract-core.wasm
+  - app/public/tesseract/tesseract-core.wasm.js
+  - (build-time copies from `node_modules/tesseract.js-core/`)
+- Upstream: https://github.com/naptha/tesseract.js-core
+- Version: 7.0.0
+- License: Apache License, Version 2.0
+
+  Copyright (c) The tesseract.js-core authors and contributors.
+  Licensed under the Apache License, Version 2.0; full text at the URL
+  above. No upstream NOTICE file is published. Files are copied verbatim
+  from the upstream release artifact.
+
+  tesseract.js-core is itself a WebAssembly build of the Tesseract OCR
+  engine (https://github.com/tesseract-ocr/tesseract), which is
+  Apache-2.0 licensed:
+
+      Copyright (c) Google LLC and the Tesseract OCR contributors.
+      Licensed under the Apache License, Version 2.0.
+
+
+Tesseract trained-data files (language models)
+----------------------------------------------
+
+- Files: `app/public/tesseract/<code>.traineddata.gz` for every
+  language code listed in `app/public/tesseract/languages.json`.
+  At time of writing the bundle includes:
+  - `eng.traineddata.gz` — English (Apache-2.0)
+- Upstream: https://github.com/tesseract-ocr/tessdata_fast
+- License: Apache License, Version 2.0
+
+  Copyright (c) Google LLC and the Tesseract OCR contributors.
+  Licensed under the Apache License, Version 2.0. Files are
+  redistributed unmodified.
+
+
+Re-review trigger
+-----------------
+
+This NOTICE must be re-reviewed and updated before any new tesseract
+asset is added to `app/public/tesseract/` (new traineddata language,
+upstream major-version bump, or replacement WebAssembly engine). See
+`docs/SECURITY.md` §5 for the full re-review checklist.

--- a/app/src/security/notice.test.ts
+++ b/app/src/security/notice.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import notice from '../../public/NOTICE?raw';
+
+describe('app/public/NOTICE', () => {
+  it('is non-empty', () => {
+    expect(notice.length).toBeGreaterThan(200);
+  });
+
+  it('cites every Apache-2.0 tesseract asset family', () => {
+    expect(notice).toMatch(/tesseract\.js/);
+    expect(notice).toMatch(/tesseract\.js-core/);
+    expect(notice).toMatch(/traineddata/);
+  });
+
+  it('references the Apache-2.0 license name and canonical URL', () => {
+    expect(notice).toMatch(/Apache License,?\s+Version 2\.0/);
+    expect(notice).toMatch(/apache\.org\/licenses\/LICENSE-2\.0/);
+  });
+
+  it('points re-reviewers at the SECURITY.md section that owns this contract', () => {
+    expect(notice).toMatch(/SECURITY\.md.*5/s);
+  });
+});

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+declare module '*?raw' {
+  const content: string;
+  export default content;
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -511,13 +511,17 @@ the risk register.
 
 Things worth a deliberate decision before they surprise us.
 
-- [ ] **Licensing audit of tesseract assets** — we ship
-      `tesseract-core.wasm` (Apache-2.0) and the worker script
-      (Apache-2.0). `eng.traineddata` is Apache-2.0 per the
-      tessdata-fast repo, but redistributing it inside the PWA needs
-      an explicit NOTICE file and attribution page.
-      Decision: open — outside Wave 11 scope, schedule with Phase 14
-      content-depth follow-ups (2026-04-25).
+- [x] **Licensing audit of tesseract assets** — we ship
+      `tesseract-core.wasm` (Apache-2.0), the tesseract.js worker
+      (Apache-2.0), and `eng.traineddata.gz` (Apache-2.0). Apache-2.0
+      §4(d) attributions now live in `app/public/NOTICE` (precached,
+      reachable at `/NOTICE` from the installed PWA); `docs/SECURITY.md`
+      §5 documents the redistribution model and re-review trigger;
+      `app/src/security/notice.test.ts` is the build-time tripwire so
+      a refactor that drops the file fails CI.
+      Decision: closed — re-review only on new asset addition or
+      tesseract major-version bump; routine eng-only patch bumps
+      inherit the same obligations and need no audit (2026-04-25).
 - [x] **Security review of the encrypted archive format** —
       Decision: stay on PBKDF2-HMAC-SHA256 200k iterations + AES-GCM-256
       for v1; defer Argon2id to a v2 archive format with explicit

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -197,3 +197,61 @@ annual cadences are the human review the test cannot replace. When a
 review pass completes, append a `Decision:` line to the
 `docs/BACKLOG.md` risk-register entry rather than removing the bullet
 — the audit trail matters more than the line count.
+
+## 5. Third-party assets and licensing
+
+### What we redistribute
+
+LeaseGuard's CSP is `default-src 'self'`, which means every runtime
+asset must be served from the app's own origin. The OCR feature is the
+only place where this forces us to redistribute third-party binaries
+inside the PWA bundle:
+
+- `app/public/tesseract/worker.min.js` (tesseract.js, Apache-2.0)
+- `app/public/tesseract/tesseract-core.wasm` and
+  `app/public/tesseract/tesseract-core.wasm.js` (tesseract.js-core,
+  Apache-2.0)
+- `app/public/tesseract/<code>.traineddata.gz` for every entry in
+  `app/public/tesseract/languages.json` (tessdata_fast, Apache-2.0)
+
+All four asset families are Apache-2.0. Apache-2.0 §4(d) requires that
+distributions include a copy of the upstream NOTICE attributions; none
+of the upstreams publish a separate NOTICE file, but we still need to
+preserve the copyright + license-pointer text.
+
+### How we satisfy Apache-2.0 §4(d)
+
+`app/public/NOTICE` enumerates each asset, its upstream, version, and
+the Apache-2.0 attribution text. The file is precached by the service
+worker and reachable at `/NOTICE` from any installed instance of the
+PWA. `README.md` cross-references it from the OCR feature paragraph;
+this section cross-references it from the security/threat-model side.
+
+### What counts as "redistribution" for a precached PWA
+
+A user installing LeaseGuard as a PWA (`Add to home screen`) receives a
+local copy of every precached asset, including the tesseract binaries
+and `/NOTICE`. That installation is a redistribution under Apache-2.0
+§4 — the licence obligations attach to the installed copy, not to the
+HTTP fetch from the host. As long as `/NOTICE` is present in the
+precache manifest and reachable from the installed PWA, §4(d) is
+satisfied.
+
+### Re-review trigger
+
+Re-review this section AND `app/public/NOTICE` whenever any of the
+following changes:
+
+1. A new tesseract trained-data file is added to
+   `app/public/tesseract/` (new language).
+2. `tesseract.js` or `tesseract.js-core` is bumped past a major
+   version, or replaced with a different WebAssembly OCR engine.
+3. A new third-party runtime asset of any kind is precached by the
+   service worker (icon font, model file, etc.).
+
+Routine patch-version bumps of the existing eng-only tesseract bundle
+do not require a re-review — they ship the same Apache-2.0 obligations
+the NOTICE already attributes. The unit test in
+`app/src/security/notice.test.ts` asserts that the NOTICE file is
+reachable at build time and contains the expected attribution
+strings; a refactor that drops or empties the file fails CI.


### PR DESCRIPTION
## Summary
- Closes the long-standing "Licensing audit of tesseract assets" risk-register item.
- Adds `app/public/NOTICE` with Apache-2.0 §4(d) attributions for tesseract.js, tesseract.js-core, and the bundled `eng.traineddata.gz`.
- Cross-referenced from `README.md` and `docs/SECURITY.md` §5 (new section documenting the redistribution model + re-review trigger).
- `app/src/security/notice.test.ts` is the build-time tripwire — asserts every required attribution string is present so a refactor that drops the NOTICE fails CI.

## Test plan
- [x] `npx vitest run src/security/notice.test.ts` → 4/4 passing locally.
- [x] My new files typecheck (`tsc -b --noEmit` clean for the diff).
- [ ] Note: `main` is currently failing typecheck + lint due to pre-existing `App.tsx` issues from Wave 10-C (unrelated; Wave 13 owns the fix). This PR introduces no new App.tsx errors.

## Choice notes
- Used Vite's `?raw` import suffix so the test compiles in a browser-typed project (no `@types/node` available); added a one-line `*?raw` module declaration in `app/src/vite-env.d.ts`.
- In-app link from "Attempt OCR" → `/NOTICE` deferred. The OCR banner lives inline in `App.tsx`, which has uncommitted Wave 13 changes; restructuring would create cross-wave conflict. The README + SECURITY.md cross-references are the auditable trail for now; a UI link can land in a future polish wave.

## Wave 12 status (after this merges)
- A ✅ (#43) — pre-commit hook
- C ✅ (this) — tesseract licensing
- D ⏳ — test infra hardening
- B ⏳ — Playwright e2e smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)