### PR TITLE
fix(portfolio): correct paragraphShingles default k and hyphen handling

### DIFF
--- a/app/src/portfolio/shingles.ts
+++ b/app/src/portfolio/shingles.ts
@@ -1,39 +1,25 @@
 // Wave 10 — paragraph-shingle similarity primitives.
-//
-// Real implementation written here for Part C test isolation. Part B owns the
-// canonical version on the wave10-clause-similarity branch; when this branch
-// is rebased onto B-merged main, the conflict on this file should be resolved
-// by accepting main's version (B's). Both are pure implementations of the
-// same spec — behaviour is identical.
 
-/**
- * Lower-case, fold whitespace, drop punctuation. Token-level normalization
- * so "non-renewal" and "nonrenewal" cluster together but capitalization /
- * extra spaces don't perturb shingles.
- */
 function normalize(text: string): string {
+  // Strip hyphens with no replacement so "non-renewal" collapses to
+  // "nonrenewal" (matching the unhyphenated variant). Other punctuation
+  // becomes whitespace so words don't fuse across it.
   return text
     .toLowerCase()
+    .replace(/-/g, '')
     .replace(/[^a-z0-9\s]/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 }
 
 /**
- * k-word shingles. Default k=1 (token-level bag) — the comparison layer
- * uses a 0.8 threshold to distinguish near-duplicates from unrelated
- * paragraphs, and at the lengths real lease clauses run to (~30 tokens),
- * even a single dropped or hyphen-collapsed word knocks bigram/trigram
- * Jaccard well below 0.8. Token bag stays comfortably above 0.85 for
- * legitimate near-duplicates and well below 0.2 for unrelated paragraphs,
- * which is what the comparison thresholding actually depends on. For
- * paragraphs shorter than k tokens we emit a single shingle of all tokens
- * so very short text still has something to compare on.
+ * k-word shingles. Default k=5: empirically the threshold where legitimate
+ * lease near-duplicates clear Jaccard 0.8 while unrelated paragraphs sit
+ * well below. Paragraphs shorter than k tokens produce no shingles.
  */
-export function paragraphShingles(text: string, k = 1): string[] {
+export function paragraphShingles(text: string, k = 5): string[] {
   const tokens = normalize(text).split(' ').filter(Boolean);
-  if (tokens.length === 0) return [];
-  if (tokens.length <= k) return [tokens.join(' ')];
+  if (tokens.length < k) return [];
   const out: string[] = [];
   for (let i = 0; i + k <= tokens.length; i++) {
     out.push(tokens.slice(i, i + k).join(' '));


### PR DESCRIPTION
## Summary

- Fix `paragraphShingles` default to `k=5` (matches the test contract and the 0.8 Jaccard threshold the comparison layer depends on).
- Short text now returns `[]` instead of a degenerate single shingle.
- Strip hyphens before tokenizing so "non-renewal" === "nonrenewal", which is what makes legitimate lease near-duplicates clear the 0.8 threshold.

Restores 3 portfolio tests that were failing on \`main\`:
- \`shingles: defaults k to 5\`
- \`shingles: returns an empty array when text has fewer tokens than k\`
- \`clauseClusters: clusters near-duplicates whose Jaccard >= 0.8\`

These regressed during the Wave 10-B/C merge — the file landed with the Part-C "test isolation" placeholder version instead of Part B's canonical implementation.

## Test plan

- [x] \`npx vitest run src/portfolio/shingles.test.ts src/portfolio/clauseClusters.test.ts\` — 17/17
- [x] Full \`npm test\` — 1043/1044 passing (1 pre-existing todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)