### PR TITLE
wave12-D: test infra hardening

### DIFF
--- a/app/src/App.panels.test.tsx
+++ b/app/src/App.panels.test.tsx
@@ -2,6 +2,12 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, it, expect, vi } 
 import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+// This file is the panel-smoke aggregate (~20 panels mounted under <App/>)
+// and runs slower than the rest of the suite under v8 coverage
+// instrumentation. Per-file timeout bump only — the global default in
+// `vite.config.ts` stays at 5s. See `docs/TESTING.md` § Coverage thresholds.
+vi.setConfig({ testTimeout: 15_000 });
+
 vi.mock('./ocr/runOcr', () => ({
   runOcr: vi.fn(async () => ({
     pages: [{ pageNumber: 1, width: 612, height: 792, items: [] }],
@@ -750,17 +756,20 @@ describe('App panel wire-ups', () => {
     await waitFor(async () => {
       expect((await listVersionsForLease(lease!.id)).length).toBe(1);
     });
-    // Export — triggers a download.
-    await userEvent.click(screen.getByRole('button', { name: /export version v1/i }));
+    // Export — triggers a download. `findByRole` here (and below) absorbs
+    // the React render tick that follows VersionHistoryPanel's IDB
+    // hydration; the synchronous `getByRole` flaked when the version
+    // row hadn't repainted yet.
+    await userEvent.click(await screen.findByRole('button', { name: /export version v1/i }));
     expect(aClicks.some((n) => n.includes('VersionCrud-redline'))).toBe(true);
     // Restore — no-op on snapshot equal to current state, but exercises path.
-    await userEvent.click(screen.getByRole('button', { name: /restore version v1/i }));
+    await userEvent.click(await screen.findByRole('button', { name: /restore version v1/i }));
     await waitFor(async () => {
       const entries = await listAuditEntries();
       expect(entries.some((e) => e.kind === 'version-restore')).toBe(true);
     });
     // Delete — timeline drops back to empty.
-    await userEvent.click(screen.getByRole('button', { name: /delete version v1/i }));
+    await userEvent.click(await screen.findByRole('button', { name: /delete version v1/i }));
     await waitFor(async () => {
       expect((await listVersionsForLease(lease!.id)).length).toBe(0);
     });

--- a/app/src/parser/testFixtures.ts
+++ b/app/src/parser/testFixtures.ts
@@ -40,6 +40,76 @@ export async function makePdf(
 }
 
 /**
+ * Smaller table-rich commercial lease used by `src/rules/golden.test.ts`
+ * to exercise the rules engine against text that spans an actual rent
+ * schedule + escalator grid (not just inline prose). Pages:
+ *   1 — heading + the four prose clauses that fire commercial-only
+ *       rule ids (rent-escalation, early-termination-fee,
+ *       indemnification, personal-guaranty).
+ *   2 — Schedule 1: rent schedule with monthly amount + escalator %
+ *       columns.
+ *   3 — Escalator-grid table (year × bump %).
+ * The rent-schedule + escalator-grid columns repeat the "$" / "%"
+ * tokens that the rule pack matches on, so the rules-side assertions
+ * cover the table cells in addition to prose.
+ */
+export async function makeCommercialTableLease(
+  opts: { years?: number; baseRent?: number } = {},
+): Promise<Uint8Array> {
+  const years = opts.years ?? 4;
+  const baseRent = opts.baseRent ?? 10_000;
+  const rentRows: PdfTextBlock[] = [];
+  const escRows: PdfTextBlock[] = [];
+  for (let i = 0; i < years; i++) {
+    const yearStart = 2026 + i;
+    const monthly = Math.round(baseRent * Math.pow(1.03, i));
+    rentRows.push({ text: `${yearStart}-01-01 to ${yearStart}-12-31`, x: 72, y: 162 + i * 30 });
+    rentRows.push({ text: `$${monthly.toLocaleString()}.00`, x: 260, y: 162 + i * 30 });
+    rentRows.push({ text: '3%', x: 440, y: 162 + i * 30 });
+    escRows.push({ text: `Year ${i + 1}`, x: 72, y: 162 + i * 30 });
+    escRows.push({ text: '3%', x: 260, y: 162 + i * 30 });
+    escRows.push({ text: `+$${(monthly * 0.03).toFixed(0)}`, x: 440, y: 162 + i * 30 });
+  }
+  return makePdf([
+    {
+      blocks: [
+        { text: 'COMMERCIAL LEASE', x: 72, y: 60 },
+        { text: '1. Rent', x: 72, y: 110 },
+        {
+          text: 'Base rent shall increase by 3% per year per Schedule 1.',
+          x: 72,
+          y: 146,
+        },
+        { text: '2. Termination', x: 72, y: 200 },
+        { text: 'Early termination fee equals three months rent.', x: 72, y: 236 },
+        { text: '3. Liability', x: 72, y: 290 },
+        { text: 'Tenant shall indemnify landlord against all claims.', x: 72, y: 326 },
+        { text: '4. Guaranty', x: 72, y: 380 },
+        { text: 'Signer agrees to be personally guarantor of all obligations.', x: 72, y: 416 },
+      ],
+    },
+    {
+      blocks: [
+        { text: 'Schedule 1 — Rent Schedule', x: 72, y: 60 },
+        { text: 'Period', x: 72, y: 132 },
+        { text: 'Monthly Rent', x: 260, y: 132 },
+        { text: 'Escalator', x: 440, y: 132 },
+        ...rentRows,
+      ],
+    },
+    {
+      blocks: [
+        { text: 'Schedule 2 — Escalator Grid', x: 72, y: 60 },
+        { text: 'Year', x: 72, y: 132 },
+        { text: 'Bump', x: 260, y: 132 },
+        { text: 'Delta', x: 440, y: 132 },
+        ...escRows,
+      ],
+    },
+  ]);
+}
+
+/**
  * Multi-feature synthetic commercial lease used as the canonical golden
  * regression check. Embeds simultaneously:
  *

--- a/app/src/rules/golden.test.ts
+++ b/app/src/rules/golden.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parseLease } from '../parser/parseLease';
-import { makePdf, type PdfFixturePage } from '../parser/testFixtures';
+import { makePdf, makeCommercialTableLease, type PdfFixturePage } from '../parser/testFixtures';
 import { analyze } from './analyze';
 import { RULE_PACK_V1 } from './packV1';
 
@@ -75,5 +75,25 @@ describe('golden fixtures', () => {
     const ids = new Set(analyze(doc, RULE_PACK_V1).map((f) => f.ruleId));
     expect(ids.has('personal-guaranty')).toBe(false);
     expect(ids.has('rent-escalation')).toBe(false);
+  });
+
+  it('commercial-table lease: same commercial rules fire across rent-schedule + escalator-grid pages', async () => {
+    const doc = await parseLease(await makeCommercialTableLease());
+    const ids = new Set(analyze(doc, RULE_PACK_V1).map((f) => f.ruleId));
+    // The four commercial-only ids fire on prose AND survive a multi-page
+    // body whose 2nd and 3rd pages are tables. (Regression guard: a parser
+    // change that drops table cells from the document body would silently
+    // demote rent-escalation back to "prose only".)
+    expect(ids).toContain('rent-escalation');
+    expect(ids).toContain('early-termination-fee');
+    expect(ids).toContain('indemnification');
+    expect(ids).toContain('personal-guaranty');
+    // Same not-in-residential invariant as the textual fixture.
+    const residentialIds = new Set(
+      analyze(await parseLease(await residentialLease()), RULE_PACK_V1).map((f) => f.ruleId),
+    );
+    expect(residentialIds.has('rent-escalation')).toBe(false);
+    expect(residentialIds.has('early-termination-fee')).toBe(false);
+    expect(residentialIds.has('personal-guaranty')).toBe(false);
   });
 });

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -99,6 +99,18 @@ Excludes: test/bench/stories files, barrels (`index.ts`), `main.tsx`,
 `parser/env.d.ts`, `parser/testFixtures.ts`, and
 `worker/leaseWorker.ts` (not reachable from jsdom).
 
+### Per-file timeout exemption
+
+`src/App.panels.test.tsx` is the only file that opts out of the global
+5s per-test default. It mounts the full `<App />` with ~20 panels and
+runs slower under v8 coverage instrumentation. The exemption is set via
+`vi.setConfig({ testTimeout: 15_000 })` at the top of the file and
+applies only to that file — the global default in `vite.config.ts`
+stays at the Vitest 5s baseline. Don't extend this exemption to other
+files without an equivalently explicit reason; the v8-coverage cost is
+roughly proportional to the number of mounted panels per test, so most
+files don't need it.
+
 ## Known flaky / noisy patterns to avoid
 
 - **Don't render `<PdfViewer>` with real bytes in a jsdom test.** The


### PR DESCRIPTION
## Summary
- Three tightly-scoped test-infra fixes from the Wave 12 plan.
- `App.panels.test.tsx` VersionHistoryPanel flake — flips `getByRole` → `findByRole` on three version-action buttons, plus a per-file `vi.setConfig({ testTimeout: 15_000 })` (global 5s default in `vite.config.ts` untouched).
- New commercial-table golden — additive `makeCommercialTableLease(opts)` synthesizer + a new `it()` in `rules/golden.test.ts` covering rent-schedule + escalator-grid pages with the not-in-residential invariant.
- `docs/TESTING.md` documents the per-file timeout exemption.

## Test plan
- [x] `npx vitest run src/rules/golden.test.ts` → 4/4 pass.
- [x] `npx vitest run src/App.panels.test.tsx -t VersionHistoryPanel` → 5 consecutive clean runs.
- [ ] CI: pre-existing typecheck/lint failure on `App.tsx` (Wave 10-C state, Wave 13 owns the fix). This PR doesn't add to those errors.

## Wave 12 status (after this merges)
- A ✅ (#43) — pre-commit hook
- C ✅ (#45) — tesseract licensing
- D (this) — test infra
- B ⏳ — Playwright e2e smoke (last)

🤖 Generated with [Claude Code](https://claude.com/claude-code)