### PR TITLE
wave12-B: Playwright e2e smoke

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,47 @@
+name: e2e
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            app/package-lock.json
+      - name: Install root dev deps (Playwright runner)
+        run: npm ci
+      - name: Install app deps
+        working-directory: app
+        run: npm ci
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: ms-playwright-${{ runner.os }}-
+      - name: Install Chromium + system deps
+        run: npx playwright install --with-deps chromium
+      - name: Build app
+        working-directory: app
+        run: npm run build
+      - name: Run e2e smoke
+        env:
+          CI: 'true'
+        run: npm run e2e
+      - name: Upload Playwright HTML report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ coverage
 *.tsbuildinfo
 .claude/
 .codex-runs/
+playwright-report/
+test-results/
+worktrees/

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,25 @@
     "": {
       "name": "lease-analyzer-workspace",
       "devDependencies": {
+        "@playwright/test": "^1.49.1",
         "husky": "^9.1.7",
         "lint-staged": "^15.2.10"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ansi-escapes": {
@@ -223,6 +240,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -565,6 +597,38 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/restore-cursor": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "lease-analyzer-workspace",
   "private": true,
-  "description": "Repo-root package for git hooks (husky + lint-staged). Application code lives in app/.",
+  "description": "Repo-root package for git hooks (husky + lint-staged) and the Playwright e2e runner. Application code lives in app/.",
   "scripts": {
-    "prepare": "husky"
+    "prepare": "husky",
+    "e2e": "playwright test",
+    "e2e:install": "playwright install --with-deps chromium"
   },
   "devDependencies": {
+    "@playwright/test": "^1.49.1",
     "husky": "^9.1.7",
     "lint-staged": "^15.2.10"
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const isCi = process.env.CI === 'true' || process.env.CI === '1';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  forbidOnly: isCi,
+  retries: isCi ? 2 : 0,
+  workers: 1,
+  reporter: isCi ? [['html', { open: 'never' }], ['github']] : 'list',
+  expect: { timeout: 5_000 },
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: isCi ? 'retain-on-failure' : 'off',
+  },
+  webServer: {
+    command: 'npm run preview -- --host 127.0.0.1 --port 4173 --strictPort',
+    cwd: 'app',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !isCi,
+    timeout: 60_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,53 @@
+# Playwright e2e smoke
+
+A single happy-path browser test that exercises the user-facing pipeline
+end-to-end against a real Chromium build:
+
+1. Load the production preview build.
+2. Dismiss the first-run onboarding tour.
+3. Click "Try a sample lease" → parse → analyze.
+4. Assert the findings panel populates with at least one finding.
+5. Click the first finding → assert the selected-finding detail panel mounts.
+6. Toggle to the Portfolio view → assert the portfolio region renders.
+7. Toggle back, refresh the Audit Log → assert at least one entry is visible.
+
+The unit suite under `app/src/**/*.test.tsx` is jsdom-only; the e2e job
+covers the things jsdom can't: real canvas, real Web Worker bootstrap,
+service-worker install, and the preview build's bundle wiring.
+
+## Local
+
+From the repo root:
+
+```bash
+# One-time: install Chromium + system deps.
+npm run e2e:install
+
+# Build the app and run the smoke. Playwright auto-starts `vite preview`
+# on http://127.0.0.1:4173 via the webServer config in playwright.config.ts.
+cd app && npm run build && cd ..
+npm run e2e
+```
+
+`reuseExistingServer` is on outside CI, so an `npm run preview` already
+running on :4173 is reused instead of being torn down.
+
+## CI
+
+`.github/workflows/e2e.yml` runs the same flow on every PR. Failure modes:
+
+- Timeout on findings panel → analyze regression.
+- Selected-finding article missing → click-to-highlight wire-up broke.
+- Portfolio button has no effect → view-toggle regression.
+- Audit-log section absent → audit pipeline regression.
+
+The HTML report is uploaded as a build artifact when the job fails so
+you can replay the trace + screenshots locally.
+
+## Out of scope (deferred to later waves)
+
+- WebKit / Firefox matrix.
+- Visual regression snapshots.
+- e2e for review-link / counter-sign / delta-packet flows (those need
+  filesystem fixtures).
+- Test parallelism beyond Playwright's defaults.

--- a/tests/e2e/golden.spec.ts
+++ b/tests/e2e/golden.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('LeaseGuard happy path', () => {
+  test('analyze sample lease, navigate findings, switch views, see audit entries', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    // First-run onboarding tour intercepts every interaction. Dismiss it.
+    const skipTour = page.getByRole('button', { name: /skip onboarding tour/i });
+    await skipTour.click();
+
+    // Sample-lease button kicks the parse → analyze pipeline.
+    await page.getByRole('button', { name: /try a sample lease/i }).click();
+
+    // Findings panel populates once analyze completes. The sample lease is
+    // hand-tuned to fire several rules; "at least one" is the contract.
+    // Each clickable finding row has the `finding-btn` class — that's the
+    // stable selector (filter / severity / category buttons live in the
+    // same panel).
+    const findings = page.getByRole('complementary', { name: /findings/i });
+    await expect(findings).toBeVisible();
+    const findingButtons = findings.locator('button.finding-btn');
+    await expect(findingButtons.first()).toBeVisible({ timeout: 15_000 });
+
+    // Click the first finding → the "selected finding" detail panel mounts
+    // and the PDF viewer focuses the matching span. Asserting the detail
+    // article is the smallest stable signal the click wired through.
+    await findingButtons.first().click();
+    await expect(page.getByRole('article', { name: /selected finding/i })).toBeVisible();
+
+    // Portfolio toggle → portfolio section renders.
+    await page.getByRole('button', { name: /^portfolio$/i }).click();
+    await expect(page.getByRole('region', { name: /portfolio/i }).first()).toBeVisible();
+
+    // Back to current view so the audit log is rendered alongside.
+    await page.getByRole('button', { name: /^current lease$/i }).click();
+
+    // Audit log: section always exists; assert ≥ 1 entry from the analyze + save
+    // events the sample-lease flow already produced. The panel renders a
+    // <Refresh> control then a list of entries; the entries surface as
+    // either <li> or <tr>, so we look for any visible row of the audit log.
+    const auditSection = page.getByRole('region', { name: /audit log/i });
+    await expect(auditSection).toBeVisible();
+    await page.getByRole('button', { name: /^refresh$/i }).click();
+    // Match any descendant element that looks like an entry row.
+    const auditEntries = auditSection.locator('li, tr');
+    await expect(auditEntries.first()).toBeVisible({ timeout: 10_000 });
+  });
+});


### PR DESCRIPTION
## Summary
- Single happy-path Chromium smoke test against the preview build: load → dismiss onboarding → sample lease → findings populate → click finding → selected-finding article mounts → Portfolio view → audit log entries.
- Closes the long-standing Phase 0 "Playwright smoke test" backlog item; final part of Wave 12 (hygiene infrastructure).

## How it runs
- Local: `cd app && npm run build && cd .. && npm run e2e` (Playwright auto-starts `vite preview` via the webServer config).
- CI: new `.github/workflows/e2e.yml` runs on every PR, 15min timeout, uploads HTML report on failure. Browser cache keyed on `package-lock.json` hash.

## Test plan
- [x] `npx playwright test` passes locally against built `dist/` (~1.8s).
- [x] `npx playwright test --list` enumerates 1 test in `tests/e2e/golden.spec.ts`.
- [ ] First green CI run confirms the workflow gates correctly.

## Out of scope
- WebKit / Firefox matrix (Chromium-only this wave).
- Visual regression snapshots.
- e2e for review-link / counter-sign / delta-packet flows (filesystem fixtures needed).

## Wave 12 status
- A ✅ (#43) — pre-commit hook
- C ✅ (#45) — tesseract licensing
- D ✅ (#47) — test infra
- B (this) — Playwright e2e smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)