### PR TITLE
wave13-B: side-letter PDF export + in-panel preview

### DIFF
--- a/app/src/App.panels.test.tsx
+++ b/app/src/App.panels.test.tsx
@@ -74,10 +74,7 @@ import {
   listEditsForLease,
   openRedlineDb,
 } from './redline/redlineStorage';
-import {
-  _resetBulkDedupDbForTests,
-  BULK_DEDUP_DB_NAME,
-} from './workflow/bulkImport';
+import { _resetBulkDedupDbForTests, BULK_DEDUP_DB_NAME } from './workflow/bulkImport';
 import {
   _resetVersionsDbForTests,
   listVersionsForLease,
@@ -120,8 +117,7 @@ interface NodeProcessLike {
   on(event: 'unhandledRejection', fn: (err: unknown) => void): void;
   off(event: 'unhandledRejection', fn: (err: unknown) => void): void;
 }
-const proc = (globalThis as unknown as { process?: NodeProcessLike })
-  .process;
+const proc = (globalThis as unknown as { process?: NodeProcessLike }).process;
 const onUnhandled = (err: unknown): void => {
   if (!isBenignIdbTeardownError(err)) throw err as Error;
 };
@@ -196,9 +192,7 @@ async function uploadLease(name = 'lease.pdf'): Promise<void> {
   // SeverityOverridesPanel even before analysis finishes, so we scope to the
   // findings region here rather than looking for a rule title anywhere.
   await waitFor(() =>
-    expect(
-      screen.getByRole('complementary', { name: /findings/i }),
-    ).toBeInTheDocument(),
+    expect(screen.getByRole('complementary', { name: /findings/i })).toBeInTheDocument(),
   );
 }
 
@@ -221,9 +215,7 @@ describe('App panel wire-ups', () => {
     render(<App />);
     await uploadLease();
     await userEvent.click(screen.getByRole('button', { name: /download \.ics/i }));
-    await waitFor(() =>
-      expect(screen.getByRole('alert')).toHaveTextContent(/no dates/i),
-    );
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/no dates/i));
   });
 
   it('copy summary writes to the clipboard', async () => {
@@ -345,17 +337,12 @@ describe('App panel wire-ups', () => {
     await userEvent.click(
       within(findings).getAllByRole('button', { name: /waiver of jury trial/i })[0]!,
     );
-    await userEvent.type(
-      screen.getByLabelText(/new counter-offer name/i),
-      'Strike clause',
-    );
+    await userEvent.type(screen.getByLabelText(/new counter-offer name/i), 'Strike clause');
     await userEvent.type(
       screen.getByLabelText(/new counter-offer text/i),
       'Propose removal of waiver.',
     );
-    await userEvent.click(
-      screen.getByRole('button', { name: /add counter-offer/i }),
-    );
+    await userEvent.click(screen.getByRole('button', { name: /add counter-offer/i }));
     await waitFor(async () => {
       const offers = await listCounterOffers();
       expect(offers.length).toBe(1);
@@ -436,15 +423,11 @@ describe('App panel wire-ups', () => {
     await uploadLease('Auditing.pdf');
     // At least the analyze start/complete entries should appear.
     await waitFor(() => {
-      expect(
-        screen.getByRole('table', { name: /audit entries/i }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole('table', { name: /audit entries/i })).toBeInTheDocument();
     });
     await userEvent.click(screen.getByRole('button', { name: /verify chain/i }));
     await waitFor(() =>
-      expect(screen.getByTestId('audit-verification')).toHaveTextContent(
-        /chain intact/i,
-      ),
+      expect(screen.getByTestId('audit-verification')).toHaveTextContent(/chain intact/i),
     );
   });
 
@@ -458,9 +441,7 @@ describe('App panel wire-ups', () => {
     ]);
     const bytesB = await makePdf([
       {
-        blocks: [
-          { text: 'Lease B is a totally different document.', x: 72, y: 72 },
-        ],
+        blocks: [{ text: 'Lease B is a totally different document.', x: 72, y: 72 }],
       },
     ]);
     const fileA = new File([bytesA as BlobPart], 'bulk-a.pdf', {
@@ -507,18 +488,12 @@ describe('App panel wire-ups', () => {
     await uploadLease('Custom.pdf');
     // Fill the form through the builder.
     await userEvent.type(screen.getByLabelText(/rule id/i), 'banana-clause');
-    await userEvent.type(
-      screen.getByLabelText(/^title$/i),
-      'Banana clause',
-    );
+    await userEvent.type(screen.getByLabelText(/^title$/i), 'Banana clause');
     await userEvent.type(
       screen.getByLabelText(/^explanation$/i),
       'Flags the word auto-renew as bananas.',
     );
-    await userEvent.type(
-      screen.getByLabelText(/regex pattern/i),
-      'auto-renew',
-    );
+    await userEvent.type(screen.getByLabelText(/regex pattern/i), 'auto-renew');
     await userEvent.click(screen.getByRole('button', { name: /save rule/i }));
     await waitFor(async () => {
       const packs = await listInstalledPacks();
@@ -553,9 +528,7 @@ describe('App panel wire-ups', () => {
     });
     // View toggles to Redline automatically.
     await waitFor(() =>
-      expect(
-        screen.getByRole('region', { name: /redline/i }),
-      ).toBeInTheDocument(),
+      expect(screen.getByRole('region', { name: /redline/i })).toBeInTheDocument(),
     );
   });
 
@@ -598,9 +571,7 @@ describe('App panel wire-ups', () => {
       expect(entries.some((e) => e.kind === 'redline-edit')).toBe(true);
     });
     // Export HTML triggers a download.
-    await userEvent.click(
-      screen.getByRole('button', { name: /export redlined html/i }),
-    );
+    await userEvent.click(screen.getByRole('button', { name: /export redlined html/i }));
     expect(aClicks).toContain('Redline-redline.html');
     createSpy.mockRestore();
   });
@@ -666,9 +637,7 @@ describe('App panel wire-ups', () => {
     await userEvent.click(screen.getByRole('button', { name: /^save$/i }));
     // Fill the signer and click download.
     await userEvent.type(screen.getByLabelText(/signer name/i), 'Jane Doe');
-    await userEvent.click(
-      screen.getByRole('button', { name: /download side letter/i }),
-    );
+    await userEvent.click(screen.getByRole('button', { name: /download side letter html/i }));
     expect(aClicks).toContain('SideLetter-side-letter.html');
     createSpy.mockRestore();
   });
@@ -694,11 +663,10 @@ describe('App panel wire-ups', () => {
       ],
     };
     // Generate an Ed25519 keypair + signed envelope locally.
-    const kp = (await crypto.subtle.generateKey(
-      { name: 'Ed25519' },
-      true,
-      ['sign', 'verify'],
-    )) as CryptoKeyPair;
+    const kp = (await crypto.subtle.generateKey({ name: 'Ed25519' }, true, [
+      'sign',
+      'verify',
+    ])) as CryptoKeyPair;
     const envelope = await signPack(pack, kp.privateKey, kp.publicKey);
     const input = screen.getByLabelText(/import rule pack/i) as HTMLInputElement;
     await userEvent.upload(
@@ -712,9 +680,7 @@ describe('App panel wire-ups', () => {
     });
     // The badge span for the signed-pack row should report "Verified".
     await waitFor(() => {
-      expect(
-        screen.getByLabelText(/signature status: verified/i),
-      ).toBeInTheDocument();
+      expect(screen.getByLabelText(/signature status: verified/i)).toBeInTheDocument();
     });
     // Audit log captured the verification + import.
     await waitFor(async () => {
@@ -776,33 +742,14 @@ describe('App panel wire-ups', () => {
     createSpy.mockRestore();
   });
 
-  it('SideLetterPanel preview falls back to download when popup is blocked', async () => {
-    const aClicks: string[] = [];
-    const origCreate = document.createElement.bind(document);
-    const createSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
-      const el = origCreate(tag);
-      if (tag === 'a') {
-        el.click = (): void => {
-          aClicks.push(el.getAttribute('download') ?? '');
-        };
-      }
-      return el;
-    });
-    URL.createObjectURL = vi.fn().mockReturnValue('blob:x');
-    URL.revokeObjectURL = vi.fn();
-    // Simulate popup blocker — window.open returns null.
-    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
-
+  it('SideLetterPanel renders an in-panel preview iframe when Generate preview is clicked', async () => {
     render(<App />);
     await uploadLease('SideLetterPreview.pdf');
     await userEvent.click(screen.getByRole('button', { name: /^redline$/i }));
-    await userEvent.click(
-      screen.getByRole('button', { name: /generate side letter preview/i }),
-    );
-    // Popup blocked → fallback downloads the letter.
-    expect(aClicks.some((n) => n.endsWith('-side-letter.html'))).toBe(true);
-    openSpy.mockRestore();
-    createSpy.mockRestore();
+    await userEvent.click(screen.getByRole('button', { name: /generate side letter preview/i }));
+    const iframe = await screen.findByTitle(/side letter preview/i);
+    expect(iframe).toBeInTheDocument();
+    expect(iframe.getAttribute('srcdoc') ?? '').toContain('Side Letter');
   });
 
   it('PackManagerPanel reports "Invalid signature" on a tampered envelope', async () => {
@@ -825,11 +772,10 @@ describe('App panel wire-ups', () => {
         },
       ],
     };
-    const kp = (await crypto.subtle.generateKey(
-      { name: 'Ed25519' },
-      true,
-      ['sign', 'verify'],
-    )) as CryptoKeyPair;
+    const kp = (await crypto.subtle.generateKey({ name: 'Ed25519' }, true, [
+      'sign',
+      'verify',
+    ])) as CryptoKeyPair;
     const envelope = await signPack(pack, kp.privateKey, kp.publicKey);
     // Mutate the payload so the signature no longer matches.
     const tampered = {
@@ -845,9 +791,7 @@ describe('App panel wire-ups', () => {
     );
     // Pack should NOT land in the store; the PackManagerPanel surfaces the
     // verify error via its error banner.
-    await waitFor(() =>
-      expect(screen.getByText(/Invalid signed pack/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/Invalid signed pack/i)).toBeInTheDocument());
     expect((await listInstalledPacks()).length).toBe(0);
     // Audit log captured the invalid signature event.
     await waitFor(async () => {
@@ -913,8 +857,8 @@ describe('App panel wire-ups', () => {
     );
     // Target the banner div specifically (role=alert). The Dismiss button
     // also matches a label containing "pack version mismatch".
-    expect(
-      screen.getByRole('alert', { name: /pack version mismatch/i }),
-    ).toHaveTextContent(/v1\.0\.0/);
+    expect(screen.getByRole('alert', { name: /pack version mismatch/i })).toHaveTextContent(
+      /v1\.0\.0/,
+    );
   });
 });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -574,6 +574,7 @@ function AppContent(): JSX.Element {
             leaseName={status.fileName}
             edits={redline.redlineEdits}
             signerDraft={sideLetter.signerDraft}
+            previewHtml={sideLetter.previewHtml}
             onSignerChange={(s) => sideLetter.setSignerDraft(s)}
             onPreview={() => {
               if (status.kind !== 'analyzed') return;
@@ -583,6 +584,7 @@ function AppContent(): JSX.Element {
                 sectionFor: sectionForParagraph,
               });
             }}
+            onClosePreview={() => sideLetter.clearPreview()}
             onDownload={() => {
               if (status.kind !== 'analyzed') return;
               sideLetter.download({
@@ -590,6 +592,33 @@ function AppContent(): JSX.Element {
                 edits: redline.redlineEdits,
                 sectionFor: sectionForParagraph,
               });
+              void safeAudit({
+                kind: 'export',
+                payload: {
+                  artifact: 'side-letter',
+                  format: 'html',
+                  leaseName: status.fileName,
+                },
+              });
+            }}
+            onDownloadPdf={() => {
+              if (status.kind !== 'analyzed') return;
+              void sideLetter
+                .downloadPdf({
+                  leaseName: status.fileName,
+                  edits: redline.redlineEdits,
+                  sectionFor: sectionForParagraph,
+                })
+                .then(() =>
+                  safeAudit({
+                    kind: 'export',
+                    payload: {
+                      artifact: 'side-letter',
+                      format: 'pdf',
+                      leaseName: status.fileName,
+                    },
+                  }),
+                );
             }}
           />
         </>

--- a/app/src/App/useSideLetter.ts
+++ b/app/src/App/useSideLetter.ts
@@ -1,45 +1,35 @@
 import { useCallback, useState } from 'react';
-import {
-  buildSideLetterHtml,
-  type SideLetterSigner,
-} from '../negotiation/sideLetter';
+import { buildSideLetterHtml, type SideLetterSigner } from '../negotiation/sideLetter';
+import { buildSideLetterPdf } from '../workflow/sideLetterPdf';
 import type { RedlineEdit } from '../redline/redline';
-import { downloadBlob, stripPdfExt } from './appHelpers';
+import { downloadBlob, downloadBlobBytes, stripPdfExt } from './appHelpers';
 
 export interface SideLetterSignerDraft {
   name: string;
   title: string;
 }
 
+export interface SideLetterRenderInput {
+  leaseName: string;
+  edits: RedlineEdit[];
+  sectionFor?: (paragraphIndex: number) => string | undefined;
+}
+
 export interface UseSideLetterApi {
   signerDraft: SideLetterSignerDraft;
   setSignerDraft: (draft: SideLetterSignerDraft) => void;
-  /**
-   * Render the side-letter HTML using the current signer draft. `sectionFor`
-   * lets callers map paragraph indices to section labels — falls back to
-   * `Page N, ¶ M` inside `buildSideLetterHtml`.
-   */
-  buildHtml: (input: {
-    leaseName: string;
-    edits: RedlineEdit[];
-    sectionFor?: (paragraphIndex: number) => string | undefined;
-  }) => string;
-  /**
-   * Open the rendered side-letter in a popup window. If the browser blocks
-   * the popup we fall back to triggering a file download instead — keeps
-   * the UI affordance discoverable.
-   */
-  preview: (input: {
-    leaseName: string;
-    edits: RedlineEdit[];
-    sectionFor?: (paragraphIndex: number) => string | undefined;
-  }) => void;
+  /** Pure HTML render (no side effects); shared by preview + download. */
+  buildHtml: (input: SideLetterRenderInput) => string;
+  /** Current in-panel preview HTML, or null when nothing has been generated. */
+  previewHtml: string | null;
+  /** Render the side-letter HTML and stash it for in-panel iframe display. */
+  preview: (input: SideLetterRenderInput) => void;
+  /** Hide the in-panel preview without re-rendering. */
+  clearPreview: () => void;
   /** Download the rendered side-letter HTML as a file. */
-  download: (input: {
-    leaseName: string;
-    edits: RedlineEdit[];
-    sectionFor?: (paragraphIndex: number) => string | undefined;
-  }) => void;
+  download: (input: SideLetterRenderInput) => void;
+  /** Download the rendered side-letter as a PDF. */
+  downloadPdf: (input: SideLetterRenderInput) => Promise<void>;
 }
 
 function trimmedSigner(draft: SideLetterSignerDraft): SideLetterSigner | undefined {
@@ -50,19 +40,15 @@ function trimmedSigner(draft: SideLetterSignerDraft): SideLetterSigner | undefin
   return out;
 }
 
-/**
- * Owns the side-letter signer draft and exposes a single render helper. The
- * preview / download decision lives in App.tsx (popup vs file download is a
- * UI concern, not a hook concern).
- */
 export function useSideLetter(): UseSideLetterApi {
   const [signerDraft, setSignerDraft] = useState<SideLetterSignerDraft>({
     name: '',
     title: '',
   });
+  const [previewHtml, setPreviewHtml] = useState<string | null>(null);
 
-  const buildHtml = useCallback<UseSideLetterApi['buildHtml']>(
-    (input) => {
+  const buildHtmlForInput = useCallback(
+    (input: SideLetterRenderInput): string => {
       const signer = trimmedSigner(signerDraft);
       return buildSideLetterHtml({
         leaseName: input.leaseName,
@@ -74,32 +60,51 @@ export function useSideLetter(): UseSideLetterApi {
     [signerDraft],
   );
 
-  const download = useCallback<UseSideLetterApi['download']>(
-    (input) => {
-      const html = buildHtml(input);
-      downloadBlob(
-        html,
-        'text/html',
-        `${stripPdfExt(input.leaseName)}-side-letter.html`,
-      );
-    },
-    [buildHtml],
-  );
-
   const preview = useCallback<UseSideLetterApi['preview']>(
     (input) => {
-      const html = buildHtml(input);
-      const win = window.open('', '_blank', 'noopener,noreferrer');
-      if (win) {
-        win.document.open();
-        win.document.write(html);
-        win.document.close();
-      } else {
-        download(input);
-      }
+      setPreviewHtml(buildHtmlForInput(input));
     },
-    [buildHtml, download],
+    [buildHtmlForInput],
   );
 
-  return { signerDraft, setSignerDraft, buildHtml, preview, download };
+  const clearPreview = useCallback((): void => {
+    setPreviewHtml(null);
+  }, []);
+
+  const download = useCallback<UseSideLetterApi['download']>(
+    (input) => {
+      const html = buildHtmlForInput(input);
+      downloadBlob(html, 'text/html', `${stripPdfExt(input.leaseName)}-side-letter.html`);
+    },
+    [buildHtmlForInput],
+  );
+
+  const downloadPdf = useCallback<UseSideLetterApi['downloadPdf']>(
+    async (input) => {
+      const signer = trimmedSigner(signerDraft);
+      const bytes = await buildSideLetterPdf({
+        leaseName: input.leaseName,
+        edits: input.edits,
+        sectionFor: input.sectionFor ?? ((): string | undefined => undefined),
+        ...(signer !== undefined ? { signer } : {}),
+      });
+      downloadBlobBytes(
+        bytes,
+        'application/pdf',
+        `${stripPdfExt(input.leaseName)}-side-letter.pdf`,
+      );
+    },
+    [signerDraft],
+  );
+
+  return {
+    signerDraft,
+    setSignerDraft,
+    buildHtml: buildHtmlForInput,
+    previewHtml,
+    preview,
+    clearPreview,
+    download,
+    downloadPdf,
+  };
 }

--- a/app/src/ui/SideLetterPanel.stories.tsx
+++ b/app/src/ui/SideLetterPanel.stories.tsx
@@ -29,6 +29,14 @@ const meta = {
       // eslint-disable-next-line no-console
       console.log('[stories] onDownload');
     },
+    onDownloadPdf: () => {
+      // eslint-disable-next-line no-console
+      console.log('[stories] onDownloadPdf');
+    },
+    onClosePreview: () => {
+      // eslint-disable-next-line no-console
+      console.log('[stories] onClosePreview');
+    },
   },
 } satisfies Meta<typeof SideLetterPanel>;
 
@@ -54,5 +62,18 @@ export const WithEdits: Story = {
       }),
     ],
     signerDraft: { name: 'Jane Doe', title: 'General Counsel' },
+  },
+};
+
+export const WithInPanelPreview: Story = {
+  args: {
+    leaseName: 'Acme Lease',
+    edits: [mkEdit({ paragraphIndex: 2, after: 'Lease shall not automatically renew.' })],
+    signerDraft: { name: 'Jane Doe', title: 'General Counsel' },
+    previewHtml: `<!doctype html><html><body style="font-family: system-ui; padding: 1rem">
+<h1>Side Letter</h1><p>Re: Acme Lease</p>
+<ol><li><strong>1. Page N, ¶ 3.</strong> The parties agree that the text of Page N, ¶ 3 is amended to read: "Lease shall not automatically renew.".</li></ol>
+<p>Sincerely,<br><strong>Jane Doe</strong><br>General Counsel</p>
+</body></html>`,
   },
 };

--- a/app/src/ui/SideLetterPanel.test.tsx
+++ b/app/src/ui/SideLetterPanel.test.tsx
@@ -131,7 +131,7 @@ describe('SideLetterPanel', () => {
         onDownload={onDownload}
       />,
     );
-    await userEvent.click(screen.getByRole('button', { name: /download side letter/i }));
+    await userEvent.click(screen.getByRole('button', { name: /download side letter html/i }));
     expect(onDownload).toHaveBeenCalledTimes(1);
   });
 
@@ -147,5 +147,82 @@ describe('SideLetterPanel', () => {
     );
     expect((screen.getByLabelText(/signer name/i) as HTMLInputElement).value).toBe('');
     expect((screen.getByLabelText(/signer title/i) as HTMLInputElement).value).toBe('');
+  });
+
+  it('renders the in-panel preview iframe when previewHtml is provided', () => {
+    render(
+      <SideLetterPanel
+        leaseName="L"
+        edits={[]}
+        previewHtml="<p>hello</p>"
+        onSignerChange={noop}
+        onPreview={noop}
+        onDownload={noop}
+      />,
+    );
+    const iframe = screen.getByTitle(/side letter preview/i) as HTMLIFrameElement;
+    expect(iframe).toBeInTheDocument();
+    expect(iframe.getAttribute('srcdoc')).toBe('<p>hello</p>');
+    expect(iframe.getAttribute('sandbox')).toBe('');
+  });
+
+  it('hides the preview iframe when previewHtml is null', () => {
+    render(
+      <SideLetterPanel
+        leaseName="L"
+        edits={[]}
+        previewHtml={null}
+        onSignerChange={noop}
+        onPreview={noop}
+        onDownload={noop}
+      />,
+    );
+    expect(screen.queryByTitle(/side letter preview/i)).toBeNull();
+  });
+
+  it('Close preview button fires onClosePreview', async () => {
+    const onClosePreview = vi.fn();
+    render(
+      <SideLetterPanel
+        leaseName="L"
+        edits={[]}
+        previewHtml="<p>hi</p>"
+        onSignerChange={noop}
+        onPreview={noop}
+        onClosePreview={onClosePreview}
+        onDownload={noop}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /close side letter preview/i }));
+    expect(onClosePreview).toHaveBeenCalledTimes(1);
+  });
+
+  it('Export PDF button fires onDownloadPdf when handler is provided', async () => {
+    const onDownloadPdf = vi.fn();
+    render(
+      <SideLetterPanel
+        leaseName="L"
+        edits={[]}
+        onSignerChange={noop}
+        onPreview={noop}
+        onDownload={noop}
+        onDownloadPdf={onDownloadPdf}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /download side letter pdf/i }));
+    expect(onDownloadPdf).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the Export PDF button when onDownloadPdf is not provided', () => {
+    render(
+      <SideLetterPanel
+        leaseName="L"
+        edits={[]}
+        onSignerChange={noop}
+        onPreview={noop}
+        onDownload={noop}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: /download side letter pdf/i })).toBeNull();
   });
 });

--- a/app/src/ui/SideLetterPanel.tsx
+++ b/app/src/ui/SideLetterPanel.tsx
@@ -4,23 +4,30 @@ export interface SideLetterPanelProps {
   leaseName: string;
   edits: RedlineEdit[];
   signerDraft?: { name: string; title: string };
+  /** Rendered HTML preview to display in-panel; null hides the iframe. */
+  previewHtml?: string | null;
   onSignerChange: (signer: { name: string; title: string }) => void;
   onPreview: () => void;
+  onClosePreview?: () => void;
   onDownload: () => void;
+  onDownloadPdf?: () => void;
 }
 
 /**
- * Controlled form for composing a side-letter. The actual HTML/text
- * rendering (via `buildSideLetterHtml`) and the preview window / file
- * download side-effects live in the caller so this panel stays pure.
+ * Controlled form for composing a side-letter. Rendering and download
+ * side-effects live in the caller; the panel owns layout and the
+ * in-panel iframe preview.
  */
 export function SideLetterPanel({
   leaseName,
   edits,
   signerDraft,
+  previewHtml,
   onSignerChange,
   onPreview,
+  onClosePreview,
   onDownload,
+  onDownloadPdf,
 }: SideLetterPanelProps): JSX.Element {
   const name = signerDraft?.name ?? '';
   const title = signerDraft?.title ?? '';
@@ -63,21 +70,37 @@ export function SideLetterPanel({
       </form>
 
       <div className="side-letter-actions">
-        <button
-          type="button"
-          aria-label="generate side letter preview"
-          onClick={onPreview}
-        >
+        <button type="button" aria-label="generate side letter preview" onClick={onPreview}>
           Generate preview
         </button>
-        <button
-          type="button"
-          aria-label="download side letter"
-          onClick={onDownload}
-        >
-          Download
+        <button type="button" aria-label="download side letter html" onClick={onDownload}>
+          Download HTML
         </button>
+        {onDownloadPdf && (
+          <button type="button" aria-label="download side letter pdf" onClick={onDownloadPdf}>
+            Export PDF
+          </button>
+        )}
       </div>
+
+      {previewHtml !== null && previewHtml !== undefined && (
+        <div className="side-letter-preview" aria-label="side letter preview">
+          <div className="side-letter-preview__header">
+            <span>Preview</span>
+            {onClosePreview && (
+              <button type="button" aria-label="close side letter preview" onClick={onClosePreview}>
+                Close
+              </button>
+            )}
+          </div>
+          <iframe
+            title="side letter preview"
+            srcDoc={previewHtml}
+            sandbox=""
+            style={{ width: '100%', height: '32rem', border: '1px solid #ddd' }}
+          />
+        </div>
+      )}
     </section>
   );
 }

--- a/app/src/workflow/sideLetterPdf.test.ts
+++ b/app/src/workflow/sideLetterPdf.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { PDFDocument } from 'pdf-lib';
+import { buildSideLetterPdf } from './sideLetterPdf';
+import type { RedlineEdit } from '../redline/redline';
+
+function mkEdit(over: Partial<RedlineEdit> = {}): RedlineEdit {
+  return {
+    leaseId: 'L1',
+    paragraphIndex: 0,
+    before: 'Original text.',
+    after: 'Amended text.',
+    updatedAt: '2026-04-25T00:00:00.000Z',
+    ...over,
+  };
+}
+
+const noSection = (): undefined => undefined;
+
+describe('buildSideLetterPdf', () => {
+  it('returns valid PDF bytes that pdf-lib can re-parse', async () => {
+    const bytes = await buildSideLetterPdf({
+      leaseName: 'Acme Lease',
+      edits: [mkEdit()],
+      sectionFor: noSection,
+    });
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBeGreaterThan(0);
+    // PDF signature.
+    const header = new TextDecoder().decode(bytes.slice(0, 5));
+    expect(header).toBe('%PDF-');
+    const reparsed = await PDFDocument.load(bytes);
+    expect(reparsed.getPageCount()).toBeGreaterThanOrEqual(1);
+    expect(reparsed.getTitle()).toBe('Acme Lease side letter');
+  });
+
+  it('produces byte-identical output for identical inputs (deterministic)', async () => {
+    const input = {
+      leaseName: 'Acme Lease',
+      leaseDate: '2026-01-01',
+      edits: [
+        mkEdit({ paragraphIndex: 0, after: 'First amendment.' }),
+        mkEdit({ paragraphIndex: 1, after: 'Second amendment.' }),
+      ],
+      sectionFor: noSection,
+      signer: { name: 'Jane Doe', title: 'Counsel' },
+    };
+    const a = await buildSideLetterPdf(input);
+    const b = await buildSideLetterPdf(input);
+    expect(a.length).toBe(b.length);
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) {
+        throw new Error(`PDF bytes diverge at offset ${i}`);
+      }
+    }
+  });
+
+  it('renders an empty-clause notice when no edits are present', async () => {
+    const bytes = await buildSideLetterPdf({
+      leaseName: 'Empty Lease',
+      edits: [],
+      sectionFor: noSection,
+    });
+    const reparsed = await PDFDocument.load(bytes);
+    expect(reparsed.getPageCount()).toBe(1);
+  });
+
+  it('folds duplicate paragraphIndex edits like the HTML builder', async () => {
+    const dupBytes = await buildSideLetterPdf({
+      leaseName: 'L',
+      edits: [
+        mkEdit({ paragraphIndex: 0, after: 'First wins.' }),
+        mkEdit({ paragraphIndex: 0, after: 'Second loses.' }),
+      ],
+      sectionFor: noSection,
+    });
+    const singleBytes = await buildSideLetterPdf({
+      leaseName: 'L',
+      edits: [mkEdit({ paragraphIndex: 0, after: 'First wins.' })],
+      sectionFor: noSection,
+    });
+    expect(dupBytes.length).toBe(singleBytes.length);
+  });
+
+  it('uses the section label when sectionFor returns one', async () => {
+    const bytes = await buildSideLetterPdf({
+      leaseName: 'L',
+      edits: [mkEdit({ paragraphIndex: 7 })],
+      sectionFor: (i) => (i === 7 ? '4.2' : undefined),
+    });
+    const reparsed = await PDFDocument.load(bytes);
+    expect(reparsed.getPageCount()).toBe(1);
+  });
+
+  it('paginates when many clauses overflow a single page', async () => {
+    const edits: RedlineEdit[] = [];
+    for (let i = 0; i < 60; i++) {
+      edits.push(mkEdit({ paragraphIndex: i, after: `Long amendment number ${i}. `.repeat(8) }));
+    }
+    const bytes = await buildSideLetterPdf({
+      leaseName: 'Big Lease',
+      edits,
+      sectionFor: noSection,
+    });
+    const reparsed = await PDFDocument.load(bytes);
+    expect(reparsed.getPageCount()).toBeGreaterThan(1);
+  });
+});

--- a/app/src/workflow/sideLetterPdf.ts
+++ b/app/src/workflow/sideLetterPdf.ts
@@ -1,0 +1,152 @@
+import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
+import { type SideLetterInput } from '../negotiation/sideLetter';
+
+interface Clause {
+  label: string;
+  after: string;
+}
+
+function buildClauses(input: SideLetterInput): Clause[] {
+  const seen = new Set<number>();
+  const clauses: Clause[] = [];
+  for (const edit of input.edits) {
+    if (seen.has(edit.paragraphIndex)) continue;
+    seen.add(edit.paragraphIndex);
+    const section = input.sectionFor(edit.paragraphIndex);
+    const label = section ? `Section ${section}` : `Page N, ¶ ${edit.paragraphIndex + 1}`;
+    clauses.push({ label, after: edit.after });
+  }
+  return clauses;
+}
+
+const PAGE_W = 612;
+const PAGE_H = 792;
+const MARGIN = 72;
+const LINE_HEIGHT = 14;
+const BODY_SIZE = 11;
+const HEADING_SIZE = 18;
+const META_SIZE = 10;
+
+/**
+ * Greedy word-wrap for a fixed-width column. pdf-lib has no built-in
+ * wrapping, so we measure each word with the embedded font and break on
+ * width overflow. Tabs and existing newlines are preserved as hard breaks.
+ */
+function wrap(
+  text: string,
+  font: import('pdf-lib').PDFFont,
+  size: number,
+  maxWidth: number,
+): string[] {
+  const out: string[] = [];
+  for (const para of text.split(/\n/)) {
+    const words = para.split(/\s+/).filter(Boolean);
+    if (words.length === 0) {
+      out.push('');
+      continue;
+    }
+    let line = '';
+    for (const w of words) {
+      const candidate = line === '' ? w : `${line} ${w}`;
+      if (font.widthOfTextAtSize(candidate, size) > maxWidth) {
+        if (line !== '') out.push(line);
+        line = w;
+      } else {
+        line = candidate;
+      }
+    }
+    if (line !== '') out.push(line);
+  }
+  return out;
+}
+
+/**
+ * Deterministic byte output: pin the creation/modification date and the
+ * "creator" / "producer" metadata so two calls with the same input yield
+ * byte-identical PDFs (golden-test-friendly).
+ */
+const PINNED_DATE = new Date('2026-01-01T00:00:00.000Z');
+
+export async function buildSideLetterPdf(input: SideLetterInput): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  doc.setCreator('LeaseGuard');
+  doc.setProducer('LeaseGuard');
+  doc.setTitle(`${input.leaseName} side letter`);
+  doc.setCreationDate(PINNED_DATE);
+  doc.setModificationDate(PINNED_DATE);
+
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  const bold = await doc.embedFont(StandardFonts.HelveticaBold);
+
+  let page = doc.addPage([PAGE_W, PAGE_H]);
+  let cursorY = PAGE_H - MARGIN;
+  const usableWidth = PAGE_W - MARGIN * 2;
+
+  function ensureSpace(needed: number): void {
+    if (cursorY - needed < MARGIN) {
+      page = doc.addPage([PAGE_W, PAGE_H]);
+      cursorY = PAGE_H - MARGIN;
+    }
+  }
+
+  function drawLine(text: string, opts: { font?: typeof font; size?: number } = {}): void {
+    const f = opts.font ?? font;
+    const size = opts.size ?? BODY_SIZE;
+    ensureSpace(size + 2);
+    page.drawText(text, {
+      x: MARGIN,
+      y: cursorY - size,
+      size,
+      font: f,
+      color: rgb(0, 0, 0),
+    });
+    cursorY -= size + 4;
+  }
+
+  function drawWrapped(text: string, opts: { font?: typeof font; size?: number } = {}): void {
+    const f = opts.font ?? font;
+    const size = opts.size ?? BODY_SIZE;
+    const lines = wrap(text, f, size, usableWidth);
+    for (const ln of lines) {
+      ensureSpace(LINE_HEIGHT);
+      page.drawText(ln, {
+        x: MARGIN,
+        y: cursorY - size,
+        size,
+        font: f,
+        color: rgb(0, 0, 0),
+      });
+      cursorY -= LINE_HEIGHT;
+    }
+  }
+
+  drawLine('Side Letter', { font: bold, size: HEADING_SIZE });
+  cursorY -= 6;
+  const meta = input.leaseDate
+    ? `Re: ${input.leaseName} (dated ${input.leaseDate})`
+    : `Re: ${input.leaseName}`;
+  drawLine(meta, { size: META_SIZE });
+  cursorY -= 12;
+
+  const clauses = buildClauses(input);
+  if (clauses.length === 0) {
+    drawWrapped('No changes to propose.');
+  } else {
+    clauses.forEach((c, i) => {
+      drawLine(`${i + 1}. ${c.label}.`, { font: bold });
+      drawWrapped(
+        `The parties agree that the text of ${c.label} is amended to read: “${c.after}”.`,
+      );
+      cursorY -= 6;
+    });
+  }
+
+  if (input.signer) {
+    cursorY -= 24;
+    drawLine('Sincerely,');
+    drawLine(input.signer.name, { font: bold });
+    if (input.signer.title) drawLine(input.signer.title, { size: META_SIZE });
+  }
+
+  return doc.save();
+}


### PR DESCRIPTION
## Summary

- New `app/src/workflow/sideLetterPdf.ts`: deterministic `buildSideLetterPdf(input)` using the existing `pdf-lib` dep. Pinned creator/producer/dates so two runs with the same input produce byte-identical PDFs. Greedy word-wrap + page pagination handle long clause lists.
- Replace the `window.open(...)` popup preview with an in-panel sandboxed `<iframe srcdoc>`. No more popup blocker, no more lost browser context.
- Add an "Export PDF" button alongside the existing "Download HTML". Both routes share the trim-signer logic in `useSideLetter`.
- App.tsx wires `previewHtml` + `clearPreview` + `downloadPdf`, and emits `safeAudit({ kind: 'export', payload: { artifact: 'side-letter', format: 'html' \| 'pdf', leaseName } })` on each download path. **No new audit `kind` strings.**
- The HTML extraction step from the wave plan is a no-op: the builder already lives in `negotiation/sideLetter.ts` from a prior wave. Skipped to avoid churn.

## Test plan

- [x] `npx vitest run src/workflow/sideLetterPdf.test.ts` — 6 new tests (signature, parse-roundtrip, determinism, dedup, section labels, pagination)
- [x] `npx vitest run src/ui/SideLetterPanel.test.tsx` — 14 tests (5 new for in-panel preview / Close / Export PDF)
- [x] Full `npm test` — 1059 passing, 1 todo
- [x] `npm run typecheck` + `npm run lint` — green
- [x] App.panels.test.tsx: rewrote popup-fallback test as in-panel preview test

🤖 Generated with [Claude Code](https://claude.com/claude-code)