### PR TITLE
wave13-C: marketplace UI wire-up

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -36,6 +36,10 @@ import { extractLeaseFacts } from './facts/extractFacts';
 import { WorkflowPanel } from './ui/WorkflowPanel';
 import { buildSummary, copyToClipboard } from './workflow/copySummary';
 import { PackManagerPanel } from './ui/PackManagerPanel';
+import { loadCuratedManifest, type CuratedPackEntry } from './rules/curatedPacks';
+import { validatePackFile } from './rules/packSchema';
+import { diffPack } from './rules/packDiff';
+import { verifySignedPack } from './rules/packSigning';
 import { JURISDICTION_OPTIONS } from './rules/jurisdictions';
 import { JurisdictionPickerPanel } from './ui/JurisdictionPickerPanel';
 import { SeverityOverridesPanel } from './ui/SeverityOverridesPanel';
@@ -814,6 +818,68 @@ function AppContent(): JSX.Element {
         onToggle={(id, enabled) => void packs.togglePack(id, enabled)}
         onDelete={(id) => void packs.deletePack(id)}
         signatureStatusByPackId={packs.packSignatureStatus}
+        marketplace={{
+          loadManifest: loadCuratedManifest,
+          onInstall: async (entry: CuratedPackEntry) => {
+            // Same-origin fetch of the curated pack JSON. The pack is
+            // re-verified inside `importPackFile` (signed envelopes go
+            // through `verifySignedPack`); we additionally peek at the
+            // bytes here so the marketplace can surface a verified vs.
+            // invalid badge without round-tripping through IDB state.
+            const res = await fetch(entry.path);
+            if (!res.ok) {
+              throw new Error(`Failed to load curated pack: HTTP ${res.status}`);
+            }
+            const text = await res.text();
+            const parsed: unknown = JSON.parse(text);
+            let signature: 'verified' | 'invalid' = 'verified';
+            if (
+              parsed !== null &&
+              typeof parsed === 'object' &&
+              'algorithm' in parsed &&
+              'payload' in parsed &&
+              'signature' in parsed
+            ) {
+              const v = await verifySignedPack(parsed);
+              signature = v.ok ? 'verified' : 'invalid';
+            }
+            const file = new File([text], `${entry.id}.lgpack.json`, {
+              type: 'application/json',
+            });
+            await packs.importPackFile(file);
+            return { ok: true, signature };
+          },
+          onPreviewDiff: async (entry: CuratedPackEntry) => {
+            const res = await fetch(entry.path);
+            if (!res.ok) {
+              throw new Error(`Failed to load curated pack: HTTP ${res.status}`);
+            }
+            const parsed: unknown = await res.json();
+            // Signed-envelope packs need to be unwrapped before diffing.
+            let candidate: unknown = parsed;
+            if (
+              parsed !== null &&
+              typeof parsed === 'object' &&
+              'algorithm' in parsed &&
+              'payload' in parsed &&
+              'signature' in parsed
+            ) {
+              const v = await verifySignedPack(parsed);
+              if (v.ok && v.pack) candidate = v.pack;
+              else throw new Error(`Invalid signed pack: ${v.reason ?? 'unknown'}`);
+            }
+            const result = validatePackFile(candidate);
+            if (!result.ok) {
+              throw new Error(`Invalid pack: ${result.errors.join('; ')}`);
+            }
+            const d = diffPack(packs.activeRules, result.pack);
+            return {
+              added: d.added.map((r) => r.id),
+              removed: d.removed.map((r) => r.id),
+              changed: d.changed.map((c) => c.ruleId),
+            };
+          },
+        }}
       />
 
       <details>

--- a/app/src/storage/packStorage.test.ts
+++ b/app/src/storage/packStorage.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { listCuratedPackUrls } from './packStorage';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function mockFetch(payload: unknown, ok = true): typeof fetch {
+  return vi.fn(async () => {
+    return {
+      ok,
+      status: ok ? 200 : 500,
+      json: async () => payload,
+    } as Response;
+  }) as unknown as typeof fetch;
+}
+
+describe('listCuratedPackUrls', () => {
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  it('returns the curated paths from a valid manifest', async () => {
+    globalThis.fetch = mockFetch([
+      {
+        id: 'us-ca-residential',
+        name: 'CA',
+        description: 'd',
+        jurisdictions: ['US-CA'],
+        author: 'LeaseGuard core',
+        fingerprint: 'a'.repeat(64),
+        path: '/packs/curated/us-ca-residential.lgpack.json',
+      },
+      {
+        id: 'us-ny-commercial',
+        name: 'NY',
+        description: 'd',
+        jurisdictions: ['US-NY'],
+        author: 'LeaseGuard core',
+        fingerprint: 'b'.repeat(64),
+        path: '/packs/curated/us-ny-commercial.lgpack.json',
+      },
+    ]);
+    const urls = await listCuratedPackUrls();
+    expect(urls).toEqual([
+      '/packs/curated/us-ca-residential.lgpack.json',
+      '/packs/curated/us-ny-commercial.lgpack.json',
+    ]);
+  });
+
+  it('returns an empty array when the manifest fetch fails', async () => {
+    globalThis.fetch = mockFetch(null, false);
+    const urls = await listCuratedPackUrls();
+    expect(urls).toEqual([]);
+  });
+
+  it('returns an empty array when the manifest is malformed', async () => {
+    globalThis.fetch = mockFetch({ not: 'an array' });
+    const urls = await listCuratedPackUrls();
+    expect(urls).toEqual([]);
+  });
+});

--- a/app/src/storage/packStorage.ts
+++ b/app/src/storage/packStorage.ts
@@ -1,0 +1,35 @@
+/**
+ * Wave 13 Part C — curated marketplace helpers.
+ *
+ * Read-only helpers for the curated-pack marketplace UI. The canonical
+ * IndexedDB-backed pack store lives at `src/rules/packStorage.ts`; this
+ * module is intentionally separate so the marketplace wire-up never
+ * mutates persisted state and so the helper sits next to other UI-facing
+ * storage adapters in `src/storage/`.
+ *
+ * `listCuratedPackUrls()` returns the set of same-origin paths the
+ * marketplace can fetch. The list is currently derived from the curated
+ * manifest at `/packs/curated/manifest.json` — keeping the logic here
+ * means callers can stub the manifest loader for tests without hitting
+ * `fetch` in the rest of the panel.
+ */
+
+import { loadCuratedManifest, type CuratedPackEntry } from '../rules/curatedPacks';
+
+/**
+ * Resolve the same-origin URLs for every curated pack advertised in the
+ * shipped manifest. Returns `[]` on any load / parse failure so callers
+ * can surface an empty marketplace state instead of throwing.
+ *
+ * Network policy: this helper only reads `/packs/curated/manifest.json`
+ * (a same-origin static asset bundled into the PWA). It performs no
+ * cross-origin requests and never writes to IndexedDB.
+ */
+export async function listCuratedPackUrls(): Promise<string[]> {
+  try {
+    const entries = await loadCuratedManifest();
+    return entries.map((e: CuratedPackEntry) => e.path);
+  } catch {
+    return [];
+  }
+}

--- a/app/src/ui/MarketplacePanel.test.tsx
+++ b/app/src/ui/MarketplacePanel.test.tsx
@@ -72,10 +72,12 @@ describe('MarketplacePanel', () => {
   });
 
   it('install success surfaces a status message and does not show an error', async () => {
-    const onInstall = vi.fn(async (): Promise<InstallResult> => ({
-      ok: true,
-      signature: 'verified',
-    }));
+    const onInstall = vi.fn(
+      async (): Promise<InstallResult> => ({
+        ok: true,
+        signature: 'verified',
+      }),
+    );
     render(
       <MarketplacePanel
         loadManifest={async () => [ENTRY_A]}
@@ -138,10 +140,12 @@ describe('MarketplacePanel', () => {
   });
 
   it('shows a signature-invalid badge when install reports an invalid signature', async () => {
-    const onInstall = vi.fn(async (): Promise<InstallResult> => ({
-      ok: false,
-      signature: 'invalid',
-    }));
+    const onInstall = vi.fn(
+      async (): Promise<InstallResult> => ({
+        ok: false,
+        signature: 'invalid',
+      }),
+    );
     render(
       <MarketplacePanel
         loadManifest={async () => [ENTRY_A]}
@@ -153,9 +157,35 @@ describe('MarketplacePanel', () => {
       name: /install california residential/i,
     });
     await userEvent.click(installBtn);
+    expect(await screen.findByLabelText(/signature status: invalid/i)).toBeInTheDocument();
+  });
+});
+
+describe('MarketplacePanel — empty state', () => {
+  it('renders an empty-state message when no curated packs are available', async () => {
+    render(
+      <MarketplacePanel
+        loadManifest={async () => []}
+        onInstall={async () => ({ ok: true, signature: 'verified' })}
+        onPreviewDiff={async () => ({ added: [], removed: [], changed: [] })}
+      />,
+    );
     expect(
-      await screen.findByLabelText(/signature status: invalid/i),
+      await screen.findByText(/no curated packs are currently available/i),
     ).toBeInTheDocument();
+  });
+
+  it('does not render install or diff controls in the empty state', async () => {
+    render(
+      <MarketplacePanel
+        loadManifest={async () => []}
+        onInstall={async () => ({ ok: true, signature: 'verified' })}
+        onPreviewDiff={async () => ({ added: [], removed: [], changed: [] })}
+      />,
+    );
+    await screen.findByText(/no curated packs/i);
+    expect(screen.queryByRole('button', { name: /install/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /view diff/i })).toBeNull();
   });
 });
 
@@ -166,7 +196,5 @@ describe('build-curated-packs.mjs', () => {
   // import attempt still serves as a failing-on-purpose marker until the
   // implementer ships the script and a test-side runner.
   beforeEach(() => {});
-  it.todo(
-    'produces byte-identical output across two runs (script + manifest hash)',
-  );
+  it.todo('produces byte-identical output across two runs (script + manifest hash)');
 });

--- a/app/src/ui/MarketplacePanel.tsx
+++ b/app/src/ui/MarketplacePanel.tsx
@@ -105,6 +105,15 @@ export function MarketplacePanel({
     );
   }
 
+  if (entries.length === 0) {
+    return (
+      <section aria-label="curated rule packs">
+        <h2>Curated rule packs</h2>
+        <p role="status">No curated packs are currently available.</p>
+      </section>
+    );
+  }
+
   return (
     <section aria-label="curated rule packs">
       <h2>Curated rule packs</h2>
@@ -112,16 +121,11 @@ export function MarketplacePanel({
         {entries.map((entry) => {
           const state = perEntry[entry.id] ?? emptyState();
           const sig: 'verified' | 'invalid' =
-            state.install.kind === 'success'
-              ? state.install.signature
-              : 'verified';
+            state.install.kind === 'success' ? state.install.signature : 'verified';
           return (
             <li key={entry.id}>
               <strong>{entry.name}</strong>{' '}
-              <span
-                aria-label={`Signature status: ${sig}`}
-                data-signature-status={sig}
-              >
+              <span aria-label={`Signature status: ${sig}`} data-signature-status={sig}>
                 [{sig === 'verified' ? 'Verified' : 'Invalid signature'}]
               </span>
               <p>{entry.description}</p>


### PR DESCRIPTION
## Summary

- Mount `<MarketplacePanel>` inside the existing pack-manager view (it already had a fully-built `marketplace` prop slot from Wave 8-A — App-side caller was the missing piece).
- New `app/src/storage/packStorage.ts` exposing `listCuratedPackUrls()` for the panel to enumerate `app/public/packs/curated/`. Read-only, no IDB.
- Add the panel's empty-state branch (existing tests already covered loaded / verified-badge / install-success/failure / diff-preview / invalid-signature; only empty-state was missing).
- Installs continue to route through the existing `import-pack` audit `kind` (and `pack-signature-verified` / `pack-signature-invalid`). **No new audit kinds.**
- Verified-badge resolution matches `packBaseline.ts`'s existing signature check.

## Test plan

- [x] `npm run typecheck` + `npm run lint` — green
- [x] `npm test` — 1059 → 1064 (+5 tests across `MarketplacePanel.test.tsx` empty-state and new `packStorage.test.ts`)

## Notes
- `app/src/storage/packStorage.ts` is new and co-exists with the pre-existing IDB-backed `app/src/rules/packStorage.ts` (different module, doc comment explains).
- `usePackManager.importPackFile` only accepts `File`, so the App-level `onInstall` fetches the curated pack same-origin and wraps the bytes in a `new File([...])` to reuse it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)