### PR TITLE
wave14-A: Tauri CI matrix (Linux + macOS + Windows)

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -5,9 +5,28 @@ on:
     branches: [main]
 
 jobs:
-  build-linux:
-    name: Tauri build (linux .deb)
-    runs-on: ubuntu-latest
+  build:
+    name: Tauri build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            bundles: deb
+            artifact-name: leaseguard-linux-deb
+            artifact-path: app/src-tauri/target/release/bundle/deb/*.deb
+          - os: macos-latest
+            bundles: app,dmg
+            artifact-name: leaseguard-macos
+            artifact-path: |
+              app/src-tauri/target/release/bundle/dmg/*.dmg
+              app/src-tauri/target/release/bundle/macos/*.app
+          - os: windows-latest
+            bundles: msi
+            artifact-name: leaseguard-windows-msi
+            artifact-path: app/src-tauri/target/release/bundle/msi/*.msi
+
     steps:
       - uses: actions/checkout@v4
 
@@ -18,6 +37,7 @@ jobs:
           cache-dependency-path: app/package-lock.json
 
       - name: Install Linux build dependencies
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -53,13 +73,13 @@ jobs:
         working-directory: app
         run: npm ci
 
-      - name: Build Tauri app (.deb only)
+      - name: Build Tauri app
         working-directory: app
-        run: cargo tauri build --bundles deb
+        run: cargo tauri build --bundles ${{ matrix.bundles }}
 
-      - name: Upload .deb artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: leaseguard-linux-deb
-          path: app/src-tauri/target/release/bundle/deb/*.deb
+          name: ${{ matrix.artifact-name }}
+          path: ${{ matrix.artifact-path }}
           if-no-files-found: error

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -107,7 +107,12 @@ and +10 MB of language data once `eng.traineddata.gz` is dropped into
 - [x] SVG app icon + favicon link
 - [x] Side-by-side CSS layout (stacks below 960px)
 - [ ] Lighthouse a11y + PWA scores ≥ 95 in CI
-- [~] Tauri desktop wrapper scaffold committed (`app/src-tauri/`); needs Rust toolchain locally to build. CI pending.
+- [x] Tauri desktop wrapper scaffold committed (`app/src-tauri/`); CI
+      builds on Linux (`.deb`), macOS (`.app` + `.dmg`), and Windows
+      (`.msi`) per `.github/workflows/tauri.yml`. Artifacts upload per
+      OS on every PR. Decision: closed — the CI matrix is the gate;
+      code-signing / notarization tracked separately in the risk
+      register (2026-04-25).
 - [ ] Onboarding tour (sample lease button exists; full walkthrough pending)
 
 ## Phase 7 — Observability & hygiene
@@ -527,6 +532,12 @@ Things worth a deliberate decision before they surprise us.
       for v1; defer Argon2id to a v2 archive format with explicit
       revisit on **2026-10-01**. Threat model + trigger conditions
       documented in `docs/SECURITY.md` §1 (2026-04-25).
+- [ ] **Tauri code-signing + notarization** — CI builds unsigned
+      `.app`/`.dmg`/`.msi` on every PR (Wave 14-A). Distribution-grade
+      signing needs an Apple Developer ID + a Microsoft EV
+      code-signing cert; deferred until real distribution channels
+      exist. Re-open when we're ready to ship installers outside the
+      PWA (2026-04-25).
 - [ ] **Release & versioning policy** — no version bumps yet; decide
       when rule-pack changes bump `RULE_PACK_VERSION` vs the package
       version. Tie to the signed-export format.

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -473,8 +473,22 @@ verify the patch / delta really came from the holder of that key.
 - `renderPdfPages` accepts an `AbortSignal` so stale renders cancel
   when the viewer unmounts or switches documents.
 
+## Desktop CI
+
+`.github/workflows/tauri.yml` runs a 3-OS matrix on every PR:
+`ubuntu-latest` → `.deb`, `macos-latest` → `.app` + `.dmg`,
+`windows-latest` → `.msi`. Each job shares the same Node + Rust setup
+and `cargo tauri build --bundles <platform-specific>`. The Cargo cache
+is keyed on `runner.os` so the three runners don't collide. Artifacts
+upload to the run summary via `actions/upload-artifact@v4`. Jobs run
+with `fail-fast: false` so a regression on one OS doesn't mask the
+status of the others. Code-signing / notarization is intentionally out
+of scope here — the matrix proves the build, not the distribution.
+
 ## Known non-goals (for now)
 
 Cloud sync, accounts, team collaboration, jurisdiction-specific legal
-reasoning, LLM-based summarization. Tauri desktop wrapper has a `src-
-tauri/` stub dir but no code.
+reasoning, LLM-based summarization. The Tauri desktop wrapper now
+builds in CI on Linux, macOS, and Windows (see "Desktop CI" above);
+code-signing / notarization is still pending real Apple Developer +
+Microsoft EV cert credentials.


### PR DESCRIPTION
## Summary
- Extend `.github/workflows/tauri.yml` from a Linux-only `.deb` job to a 3-OS matrix: `ubuntu-latest` (`.deb`), `macos-latest` (`.app` + `.dmg`), `windows-latest` (`.msi`).
- Cargo cache keyed on `runner.os` so the runners don't collide; `fail-fast: false` so a regression on one OS doesn't mask sibling status.
- Document the new "Desktop CI" subsection in `docs/SYSTEM_DESIGN.md`; flip the Tauri scaffold backlog row from `[~]` to `[x]`; add a deferred `[ ]` risk-register row for code-signing + notarization.

Wave 14 Part A per `docs/plans/wave14-ci-hardening-governance.md`.

## Test plan
- [ ] All 3 matrix jobs (`ubuntu-latest`, `macos-latest`, `windows-latest`) go green on this PR.
- [ ] Per-OS artifacts upload to the run summary.
- [ ] No production code touched (workflow + docs only); existing app `typecheck` / `lint` / `test` jobs remain unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)