### PR TITLE
wave14-C: release & versioning policy

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -538,12 +538,15 @@ Things worth a deliberate decision before they surprise us.
       code-signing cert; deferred until real distribution channels
       exist. Re-open when we're ready to ship installers outside the
       PWA (2026-04-25).
-- [ ] **Release & versioning policy** — no version bumps yet; decide
-      when rule-pack changes bump `RULE_PACK_VERSION` vs the package
-      version. Tie to the signed-export format.
-      Decision: open — Wave 11 is content + risk-register only;
-      release-policy decision belongs in a future trust-infra wave
-      (2026-04-25).
+- [x] **Release & versioning policy** — `RULE_PACK_VERSION`,
+      `app/package.json` version, release tags, and the signed-export
+      envelope (`leaseguard.findings.vN`) are now four independent
+      axes with explicit bump rules in
+      [`RELEASING.md`](./RELEASING.md). Signed-format compatibility
+      contract (v1 payload shape + triggers for v2) lives in
+      [`SECURITY.md`](./SECURITY.md) §6. Decision: closed — the two
+      docs are the gate; any future PR that bumps a version cites
+      whichever section justifies the bump (2026-04-25).
 - [x] **Crash-log privacy review** —
       Decision: `diagnosticsReport` now emits a `summary: string[]`
       field enumerating every category included (`userAgent`,

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,176 @@
+# Releasing LeaseGuard
+
+Authoritative source of truth for when to bump versions, when to cut a
+release, and what compatibility guarantees we promise. Cross-references
+the implementation files so the rules don't drift.
+
+## Versions we track
+
+There are three independent version axes. Bumping one does not imply
+bumping the others.
+
+| Version | Lives in | Scheme | Bumps on |
+|---|---|---|---|
+| `RULE_PACK_VERSION` | `app/src/rules/analyze.ts` | semver | rule-pack content changes (see §1) |
+| `app/package.json` `version` | `app/package.json` | semver | UX / schema / signed-format changes (see §2) |
+| Tauri / PWA release tag | `git tag vX.Y.Z` | mirrors `app/package.json` | distribution events (see §3) |
+| Signed-export envelope | `EXPORT_SCHEMA` in `app/src/storage/exportReport.ts` | `vN` integer suffix | format-breaking changes (see §4 and `SECURITY.md` §6) |
+
+## 1. When to bump `RULE_PACK_VERSION`
+
+`RULE_PACK_VERSION` ships in every `Finding`'s `rulePackVersion` field
+and in the signed-export envelope. Older signed exports must remain
+verifiable forever, so the version is meaningful, not cosmetic.
+
+Bump `RULE_PACK_VERSION` when **any** of the following changes in
+`app/src/rules/packV1.ts` (or any module the pack imports at compile
+time):
+
+- A matcher's regex, keyword set, or proximity threshold.
+- A rule's `severity`, `category`, `plainEnglish`, or `suggestedEdit`.
+- A rule's `id` (only ever via deprecation — see "id retirement"
+  below; the bump is still required).
+- The `Matcher` union itself (a new matcher type counts even if no
+  existing rule uses it yet, because the compiled-rule cache shape
+  changes).
+
+Do **not** bump for:
+
+- Test-only edits (`*.test.ts`, fixtures, golden assertions).
+- Comment / docstring changes inside `packV1.ts`.
+- Refactors of `compileRules.ts` or `matchers.ts` that don't change
+  observable matcher output.
+
+Scheme: semver. **Major** for any change that would make a previously-
+matched finding stop matching (rule deletion, severity downgrade past
+the export consumer's threshold, matcher semantics rewrite). **Minor**
+for additive rule changes (new rule, expanded matcher coverage).
+**Patch** for plainEnglish / suggestedEdit text-only edits.
+
+### id retirement
+
+A retired rule **id** is reserved forever. Never re-use it for a new
+rule, even after a major bump. The signed-export envelope cites
+findings by `ruleId`, so re-using an id would silently change what an
+old export claims about a lease. Keep retired ids in a comment block
+at the bottom of `packV1.ts` with the version they were retired in.
+
+## 2. When to bump `app/package.json` version
+
+Bump when any of the following ship to `main`:
+
+- An additive UX change visible in a release-note bullet (new panel,
+  new flag, new export format option).
+- An IDB schema bump (any `_resetXDbForTests` test fixture also bumps
+  the underlying `version` argument to `openDB`).
+- The signed-export envelope schema changes — this also bumps
+  `EXPORT_SCHEMA` per §4.
+- The Tauri bundle config (`app/src-tauri/tauri.conf.json`) changes in
+  a way that affects installed binary identity (productName,
+  identifier, window title).
+
+Do **not** bump for:
+
+- Pure dev-dep additions (Storybook, eslint plugins).
+- CI workflow edits.
+- Doc-only PRs.
+- Internal refactors with no surface-level effect.
+
+Scheme: semver. **Major** for IDB schema breaks where existing
+on-device data can't be migrated (this is a hard line we want to
+avoid; prefer migrations). **Minor** for any new shipped surface.
+**Patch** for bug fixes that change observable behavior but not
+compatibility.
+
+## 3. When to cut a release tag
+
+A release tag (`vX.Y.Z` matching `app/package.json`) gates two
+distribution events:
+
+- A new `dist/` deploy of the PWA (auto-deploys today; the tag
+  documents the snapshot).
+- A new Tauri build of the `.deb` / `.app` / `.dmg` / `.msi` artifacts
+  intended for distribution outside CI.
+
+Tag when:
+
+- `app/package.json` minor or major bumps (see §2).
+- `RULE_PACK_VERSION` minor or major bumps that haven't shipped under
+  a previous app-version tag (a content release).
+- A security fix has landed (always tag, even on patch).
+
+Do **not** tag for:
+
+- CI / docs / test-infra-only PRs since the last tag.
+- Patch app-version bumps that batch with another upcoming bump
+  within the next merge window.
+
+Release-note format: bulleted list keyed off the `wave-N` commit
+messages already in `git log`. Pull from
+`git log --oneline <previous-tag>..HEAD --grep="wave"` and curate.
+Group bullets by category: **Rules**, **UX**, **Trust + privacy**,
+**Performance**, **Build / CI**.
+
+## 4. When to cut a new signed-export envelope (`v2`, `v3`, …)
+
+The signed-export envelope is `EXPORT_SCHEMA = 'leaseguard.findings.v1'`
+in `app/src/storage/exportReport.ts`. The signature covers the
+canonical 2-space-indented JSON serialization with the `signature`
+field stripped.
+
+Bump the envelope (`v1` → `v2`) when **any** of the following changes:
+
+- The set of fields covered by the signature (adding or removing a
+  top-level key in the payload — `lease`, `inputHash`,
+  `rulePackVersion`, `findings`, `deviations`, anything new).
+- The canonicalization rules themselves (indent width, key ordering,
+  number serialization, anything that affects the bytes the signature
+  is computed over).
+- The signature algorithm or key format (today: Ed25519 raw 32-byte
+  public key, base64).
+- The `SignatureBlock` shape (`publicKey`, `signature`, `signedAt`).
+
+Do **not** bump the envelope for:
+
+- Adding fields *inside* an existing array element (e.g., a new
+  per-finding field) — that already breaks the signature, so it
+  requires `v2`. (Said another way: there is no such thing as a
+  backward-compatible add to a signed payload. Any payload change is
+  a `v2`.)
+
+Wait — that's the same trigger. The point is: there's no "soft" change
+to a signed envelope. Either the bytes-under-signature are identical
+or they're not. If they're not, it's a new envelope version.
+
+Compatibility contract: `v1` exports must remain verifiable by the app
+forever. `verifySignedExport` must dispatch on `schema` and keep the
+v1 verifier code path indefinitely. Document the dispatch in
+`docs/SECURITY.md` §6 when `v2` is cut.
+
+## 5. Worked example
+
+Suppose the next merge train looks like:
+
+- Wave 16-A: adds three new rules to `packV1.ts`.
+- Wave 16-B: adjusts `FindingsPanel` empty-state copy.
+- Wave 16-C: bumps `tesseract.js` from 5.x to 6.x.
+
+Bumps:
+
+- `RULE_PACK_VERSION`: `1.0.0` → `1.1.0` (additive rules).
+- `app/package.json`: `0.0.0` → `0.1.0` (UX surface — new rules
+  are user-visible findings; minor bump).
+- Release tag: `v0.1.0`, with notes citing the three wave commits.
+- Signed-export envelope: unchanged (no envelope schema change).
+- `SECURITY.md`: tesseract major bump triggers the §5 re-review per
+  the existing trigger; that's a separate review, not a release-policy
+  decision.
+
+## 6. Cross-references
+
+- `app/src/rules/analyze.ts` — `RULE_PACK_VERSION` literal.
+- `app/src/storage/exportReport.ts` — `EXPORT_SCHEMA`,
+  `signExport`, `verifySignedExport`.
+- `docs/SECURITY.md` §6 — the signed-format compatibility section
+  this file is the operational counterpart to.
+- `docs/BACKLOG.md` — risk-register pointer to this doc.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -103,8 +103,10 @@ list.
 Tracked in [`BACKLOG.md`](./BACKLOG.md#known-unknowns--risk-register).
 Wave 11-D closed the encrypted-archive security review, crash-log
 privacy review, CSP regression tests, and rule-pack rot review (see
-[`SECURITY.md`](./SECURITY.md)). Open: tesseract licensing audit,
-release / versioning policy.
+[`SECURITY.md`](./SECURITY.md)). Wave 14-C closed the release /
+versioning policy — see [`RELEASING.md`](./RELEASING.md) for bump
+rules and `SECURITY.md` §6 for the signed-format compatibility
+contract.
 
 ---
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -255,3 +255,64 @@ the NOTICE already attributes. The unit test in
 `app/src/security/notice.test.ts` asserts that the NOTICE file is
 reachable at build time and contains the expected attribution
 strings; a refactor that drops or empties the file fails CI.
+
+## 6. Versioning + signed-format compatibility
+
+The signed-findings envelope is identified by
+`EXPORT_SCHEMA = 'leaseguard.findings.v1'` in
+`app/src/storage/exportReport.ts`. The signature covers the canonical
+2-space-indented `JSON.stringify` of the payload with the `signature`
+field stripped. The signing key is Ed25519; the public key is the raw
+32-byte key encoded as base64 inside `SignatureBlock.publicKey`.
+
+### v1 payload shape (pinned)
+
+The fields under the `v1` signature, exactly as `exportFindingsJson`
+emits them:
+
+- `schema: 'leaseguard.findings.v1'`
+- `lease: { name, pageCount, paragraphCount, sectionCount }`
+- `inputHash: string | null`
+- `rulePackVersion: string | null`
+- `findings: Array<{ ruleId, severity, category, title, explanation,
+  citation, page, snippet, span, confidence, negated }>` —
+  `confidence` is rounded to 2 decimal places before signing
+- `deviations: Array<{ id, baselineFingerprint, currentFingerprint,
+  deviates }>`
+
+The `signature` block (`{ publicKey, signature, signedAt }`) is
+appended **after** signing and is not itself covered by the signature.
+`verifySignedExport` re-canonicalizes by stripping `signature` and
+re-running `JSON.stringify(rest, null, 2)`.
+
+### Triggers for cutting `v2`
+
+Bump `EXPORT_SCHEMA` to `leaseguard.findings.v2` whenever **any** of
+the following change:
+
+1. The set of top-level keys in the payload (adding `tenant`,
+   removing `deviations`, renaming any of the above).
+2. The shape of any nested object or array element under the
+   signature — including additive fields on `findings[*]` or
+   `deviations[*]`. There is no backward-compatible change to a
+   signed payload; any change to the bytes-under-signature is a new
+   envelope version.
+3. The canonicalization rules: indent width, key ordering, number
+   serialization (e.g., changing `confidence` rounding precision),
+   line-ending convention.
+4. The signature algorithm (Ed25519 → anything else) or the public-key
+   encoding (raw 32-byte / base64 → SPKI / hex / etc.).
+5. The `SignatureBlock` shape.
+
+When `v2` ships, `verifySignedExport` must dispatch on the `schema`
+field and keep the `v1` verifier code path indefinitely. Existing
+`v1` exports on user devices must remain verifiable forever — old
+exports are evidence; rotating them out is not an option.
+
+### What this section pins
+
+This is the policy companion to the operational rules in
+[`RELEASING.md`](./RELEASING.md). `RELEASING.md` says **when** to
+bump versions; this section says **what compatibility guarantee** the
+signed-export bump implies. They must move together: a `v2` envelope
+PR must update both files in the same change.


### PR DESCRIPTION
## Summary
- New `docs/RELEASING.md` — authoritative bump rules for `RULE_PACK_VERSION`, `app/package.json` version, release tags, and the signed-export envelope (`leaseguard.findings.vN`). Includes a worked example and a retired-id-reservation policy.
- New `docs/SECURITY.md` §6 — pins the v1 signed-export payload shape, enumerates the triggers for cutting v2, and locks in the forever-verifiable contract for old `v1` exports.
- `docs/BACKLOG.md` risk-register row flipped to `[x]`; `docs/ROADMAP.md` updated to link `RELEASING.md` instead of listing the policy as open.

Wave 14 Part C per `docs/plans/wave14-ci-hardening-governance.md`. No production code touched.

## Test plan
- [ ] `RELEASING.md` is internally consistent — every "bump X when Y" rule cross-references the file the rule applies to.
- [ ] `SECURITY.md` §6 v1 envelope shape matches `app/src/storage/exportReport.ts` exactly (read-and-cite, no code change).
- [ ] No app source / test changes; existing CI remains green by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)