### PR TITLE
wave14-D: a11y axe-core gate (vitest-axe + @axe-core/playwright)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -42,7 +42,8 @@
         "typescript": "^5.5.3",
         "vite": "^5.3.3",
         "vite-plugin-pwa": "^0.20.5",
-        "vitest": "^1.6.0"
+        "vitest": "^1.6.0",
+        "vitest-axe": "^0.1.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -5344,6 +5345,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.17",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
@@ -8215,6 +8226,13 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -11143,6 +11161,37 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest-axe": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
+      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.0.0",
+        "axe-core": "^4.4.2",
+        "chalk": "^5.0.1",
+        "dom-accessibility-api": "^0.5.14",
+        "lodash-es": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "vitest": ">=0.16.0"
+      }
+    },
+    "node_modules/vitest-axe/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/app/package.json
+++ b/app/package.json
@@ -58,6 +58,7 @@
     "typescript": "^5.5.3",
     "vite": "^5.3.3",
     "vite-plugin-pwa": "^0.20.5",
-    "vitest": "^1.6.0"
+    "vitest": "^1.6.0",
+    "vitest-axe": "^0.1.0"
   }
 }

--- a/app/src/App.panels.test.tsx
+++ b/app/src/App.panels.test.tsx
@@ -191,8 +191,9 @@ async function uploadLease(name = 'lease.pdf'): Promise<void> {
   // Wait until the findings <aside> mounts — rule titles also surface in the
   // SeverityOverridesPanel even before analysis finishes, so we scope to the
   // findings region here rather than looking for a rule title anywhere.
-  await waitFor(() =>
-    expect(screen.getByRole('complementary', { name: /findings/i })).toBeInTheDocument(),
+  await waitFor(
+    () => expect(screen.getByRole('complementary', { name: /findings/i })).toBeInTheDocument(),
+    { timeout: 5000 },
   );
 }
 

--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -2,19 +2,24 @@ import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 vi.mock('./ocr/runOcr', () => ({
-  runOcr: vi.fn(async (_bytes: Uint8Array, opts?: { onProgress?: (p: { pct: number; stage: string }) => void }) => {
-    opts?.onProgress?.({ pct: 0, stage: 'starting' });
-    opts?.onProgress?.({ pct: 1, stage: 'done' });
-    return {
-      pages: [{ pageNumber: 1, width: 612, height: 792, items: [] }],
-      paragraphs: [
-        { page: 1, text: 'Any dispute shall be resolved by binding arbitration, not court.' },
-        { page: 1, text: 'Tenant waives any right to a jury trial.' },
-      ],
-      sections: [],
-      raw: '',
-    };
-  }),
+  runOcr: vi.fn(
+    async (
+      _bytes: Uint8Array,
+      opts?: { onProgress?: (p: { pct: number; stage: string }) => void },
+    ) => {
+      opts?.onProgress?.({ pct: 0, stage: 'starting' });
+      opts?.onProgress?.({ pct: 1, stage: 'done' });
+      return {
+        pages: [{ pageNumber: 1, width: 612, height: 792, items: [] }],
+        paragraphs: [
+          { page: 1, text: 'Any dispute shall be resolved by binding arbitration, not court.' },
+          { page: 1, text: 'Tenant waives any right to a jury trial.' },
+        ],
+        sections: [],
+        raw: '',
+      };
+    },
+  ),
 }));
 import { App } from './App';
 import { makePdf } from './parser/testFixtures';
@@ -83,13 +88,12 @@ async function uploadLease(name = 'lease.pdf'): Promise<void> {
   await userEvent.upload(input, file);
   // "auto-renewal" now also appears in the SeverityOverridesPanel row; use
   // `findAllByText` so we pass as soon as the findings panel renders.
-  await waitFor(() =>
-    expect(screen.getAllByText(/auto-renewal/i).length).toBeGreaterThan(0),
-  );
+  await waitFor(() => expect(screen.getAllByText(/auto-renewal/i).length).toBeGreaterThan(0));
   // Wait for the findings aside to render so click/scroll assertions downstream
   // find their targets.
-  await waitFor(() =>
-    expect(screen.getByRole('complementary', { name: /findings/i })).toBeInTheDocument(),
+  await waitFor(
+    () => expect(screen.getByRole('complementary', { name: /findings/i })).toBeInTheDocument(),
+    { timeout: 5000 },
   );
 }
 
@@ -146,9 +150,7 @@ describe('App', () => {
       .mockResolvedValue(new Response(bytes as BlobPart, { status: 200 }));
     render(<App />);
     await userEvent.click(screen.getByRole('button', { name: /try a sample lease/i }));
-    await waitFor(() =>
-      expect(screen.getAllByText(/auto-renewal/i).length).toBeGreaterThan(0),
-    );
+    await waitFor(() => expect(screen.getAllByText(/auto-renewal/i).length).toBeGreaterThan(0));
     fetchMock.mockRestore();
   });
 
@@ -185,9 +187,7 @@ describe('App', () => {
   it('set-as-standard marks the badge and triggers auto-compare on next upload', async () => {
     render(<App />);
     await uploadLease('Standard.pdf');
-    await userEvent.click(
-      screen.getByRole('button', { name: /set standard\.pdf as standard/i }),
-    );
+    await userEvent.click(screen.getByRole('button', { name: /set standard\.pdf as standard/i }));
     await waitFor(async () => {
       expect(await getStandardId()).toBeTruthy();
     });
@@ -258,9 +258,7 @@ describe('App', () => {
       expect(screen.getByRole('button', { name: /open reopen\.pdf/i })).toBeInTheDocument(),
     );
     await userEvent.click(screen.getByRole('button', { name: /open reopen\.pdf/i }));
-    await waitFor(() =>
-      expect(screen.getAllByText(/auto-renewal/i).length).toBeGreaterThan(0),
-    );
+    await waitFor(() => expect(screen.getAllByText(/auto-renewal/i).length).toBeGreaterThan(0));
   });
 
   it('export findings JSON and HTML each trigger a download', async () => {
@@ -281,7 +279,9 @@ describe('App', () => {
     render(<App />);
     await uploadLease('Report.pdf');
     await userEvent.click(screen.getByRole('button', { name: /export findings \(json\)/i }));
-    await userEvent.click(screen.getByRole('button', { name: /export findings \(printable html\)/i }));
+    await userEvent.click(
+      screen.getByRole('button', { name: /export findings \(printable html\)/i }),
+    );
 
     expect(aClicks).toContain('Report-findings.json');
     expect(aClicks).toContain('Report-findings.html');

--- a/app/src/test/axe.ts
+++ b/app/src/test/axe.ts
@@ -1,0 +1,23 @@
+import { axe } from 'vitest-axe';
+import { expect } from 'vitest';
+import type { AxeResults, Result } from 'axe-core';
+
+/**
+ * Run axe-core against `container` and assert there are zero violations.
+ * The failure message includes each violation's id, impact, and the
+ * targeted node selectors so a regression points at the offending DOM.
+ */
+export async function expectAxeClean(container: Element): Promise<void> {
+  const results = (await axe(container)) as AxeResults;
+  expect(results.violations, formatViolations(results.violations)).toEqual([]);
+}
+
+function formatViolations(violations: Result[]): string {
+  if (violations.length === 0) return '';
+  return violations
+    .map((v) => {
+      const targets = v.nodes.map((n) => n.target.join(', ')).join(' | ');
+      return `${v.impact ?? 'unknown'} :: ${v.id} — ${v.help}\n  at ${targets}`;
+    })
+    .join('\n');
+}

--- a/app/src/ui/FindingsPanel.a11y.test.tsx
+++ b/app/src/ui/FindingsPanel.a11y.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { FindingsPanel } from './FindingsPanel';
+import { RULE_PACK_V1 } from '../rules/packV1';
+import type { Finding } from '../rules/types';
+import { expectAxeClean } from '../test/axe';
+
+function f(over: Partial<Finding>): Finding {
+  return {
+    ruleId: 'rule',
+    severity: 'medium',
+    category: 'general',
+    title: 'Generic title',
+    explanation: 'Generic explanation.',
+    citation: null,
+    page: 1,
+    paragraphIndex: 0,
+    snippet: 'snippet',
+    span: { start: 0, end: 7 },
+    confidence: 0.9,
+    negated: false,
+    rulePackVersion: '1.0.0',
+    ...over,
+  };
+}
+
+describe('FindingsPanel a11y', () => {
+  it('empty state has no axe violations', async () => {
+    const { container } = render(<FindingsPanel findings={[]} onSelect={() => {}} />);
+    await expectAxeClean(container);
+  });
+
+  it('single severity has no axe violations', async () => {
+    const findings: Finding[] = [
+      f({ ruleId: 'a', severity: 'high', title: 'Arbitration' }),
+      f({ ruleId: 'b', severity: 'high', title: 'Late fee' }),
+    ];
+    const { container } = render(<FindingsPanel findings={findings} onSelect={() => {}} />);
+    await expectAxeClean(container);
+  });
+
+  it('full pack across all severities has no axe violations', async () => {
+    const findings: Finding[] = RULE_PACK_V1.map((rule, idx) =>
+      f({
+        ruleId: rule.id,
+        severity: rule.severity,
+        category: rule.category,
+        title: rule.title,
+        explanation: rule.explanation,
+        page: (idx % 3) + 1,
+      }),
+    );
+    const { container } = render(<FindingsPanel findings={findings} onSelect={() => {}} />);
+    await expectAxeClean(container);
+  });
+});

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -74,7 +74,12 @@ and +10 MB of language data once `eng.traineddata.gz` is dropped into
 - [x] Loading / empty / parse-error states
 - [x] PDF viewer canvas per page via pdf.js
 - [x] Span-level highlight overlay (paragraph bbox + absolute div over canvas)
-- [ ] Full a11y audit (basic labels in place)
+- [x] Full a11y audit gate — `app/src/ui/FindingsPanel.a11y.test.tsx`
+      runs `vitest-axe` on the most aria-heavy panel; `tests/e2e/a11y.spec.ts`
+      runs `@axe-core/playwright` against the analyzed-lease view with
+      `wcag2a` + `wcag2aa` tags and fails on any serious/critical
+      violation. Manual screen-reader walkthrough remains a deferred
+      follow-up — see `docs/TESTING.md` "a11y gate" (2026-04-25).
 
 ## Phase 4 — Local Storage
 - [x] IndexedDB wrapper (idb), versioned schema (v1 leases → v2 settings → v3 clauseTemplates); cumulative `if (oldVersion < N)` migration gates
@@ -106,7 +111,10 @@ and +10 MB of language data once `eng.traineddata.gz` is dropped into
 - [x] Privacy disclosure `<details>` block + not-legal-advice disclaimer
 - [x] SVG app icon + favicon link
 - [x] Side-by-side CSS layout (stacks below 960px)
-- [ ] Lighthouse a11y + PWA scores ≥ 95 in CI
+- [x] Lighthouse a11y + PWA scores ≥ 95 in CI — enforced via
+      `app/lighthouserc.json` (`categories:accessibility ≥ 0.95`,
+      `installable-manifest`, `apple-touch-icon`); `npm run lhci`
+      runs in `.github/workflows/ci.yml` (2026-04-25).
 - [x] Tauri desktop wrapper scaffold committed (`app/src-tauri/`); CI
       builds on Linux (`.deb`), macOS (`.app` + `.dmg`), and Windows
       (`.msi`) per `.github/workflows/tauri.yml`. Artifacts upload per

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -99,6 +99,23 @@ Excludes: test/bench/stories files, barrels (`index.ts`), `main.tsx`,
 `parser/env.d.ts`, `parser/testFixtures.ts`, and
 `worker/leaseWorker.ts` (not reachable from jsdom).
 
+### a11y gate (separate axis)
+
+a11y is enforced separately from coverage. Two redundant gates:
+
+- **Unit:** `app/src/ui/FindingsPanel.a11y.test.tsx` runs `vitest-axe`
+  against the most aria-heavy panel in three states (empty, single
+  severity, full pack). Helper lives in `app/src/test/axe.ts`.
+- **e2e:** `tests/e2e/a11y.spec.ts` runs `@axe-core/playwright`
+  against the analyzed-lease view loaded via the sample-lease button.
+  Filters to `wcag2a` + `wcag2aa` tags; fails the build on any
+  `serious` or `critical` impact violation.
+
+Both must be green. They're a separate axis from coverage thresholds —
+coverage is "did the test exercise the code", a11y is "does the rendered
+output meet WCAG". A coverage regression and an a11y regression can
+land independently.
+
 ### Per-file timeout exemption
 
 `src/App.panels.test.tsx` is the only file that opts out of the global

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,23 @@
     "": {
       "name": "lease-analyzer-workspace",
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.2",
         "@playwright/test": "^1.49.1",
         "husky": "^9.1.7",
         "lint-staged": "^15.2.10"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -67,6 +81,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/braces": {
@@ -624,6 +648,7 @@
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "e2e:install": "playwright install --with-deps chromium"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.2",
     "@playwright/test": "^1.49.1",
     "husky": "^9.1.7",
     "lint-staged": "^15.2.10"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -44,6 +44,21 @@ running on :4173 is reused instead of being torn down.
 The HTML report is uploaded as a build artifact when the job fails so
 you can replay the trace + screenshots locally.
 
+## a11y (`a11y.spec.ts`)
+
+A second spec runs `@axe-core/playwright` against the analyzed-lease
+view (sample-lease loaded, findings panel populated). It calls
+`AxeBuilder.withTags(['wcag2a', 'wcag2aa'])` and fails the build on
+any `serious` or `critical` impact violation. `moderate` / `minor`
+impacts surface in the report but don't gate the merge — those are on
+a separate manual-review track.
+
+The unit-side companion is `app/src/ui/FindingsPanel.a11y.test.tsx`,
+which uses `vitest-axe` against the most aria-heavy panel. The two
+gates are intentionally redundant: the unit gate catches regressions
+inside a single component, the e2e gate catches regressions caused by
+how panels compose.
+
 ## Out of scope (deferred to later waves)
 
 - WebKit / Firefox matrix.

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import { AxeBuilder } from '@axe-core/playwright';
+
+test.describe('LeaseGuard a11y', () => {
+  test('analyzed-lease view has no serious or critical WCAG 2 A/AA violations', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    // Onboarding tour intercepts every interaction. Dismiss it before
+    // running axe so the overlay isn't the only thing axe sees.
+    await page.getByRole('button', { name: /skip onboarding tour/i }).click();
+
+    // Sample lease drives the parse → analyze pipeline; we want axe to
+    // run against the loaded analyzed-lease state, not the empty shell.
+    await page.getByRole('button', { name: /try a sample lease/i }).click();
+
+    const findings = page.getByRole('complementary', { name: /findings/i });
+    await expect(findings).toBeVisible();
+    await expect(findings.locator('button.finding-btn').first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa'])
+      .analyze();
+
+    const blocking = results.violations.filter(
+      (v) => v.impact === 'serious' || v.impact === 'critical',
+    );
+    expect(blocking, JSON.stringify(blocking, null, 2)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- `app/src/test/axe.ts` (NEW) — `expectAxeClean(container)` runs axe-core and asserts zero violations with a formatted failure message (impact, rule id, target selectors).
- `app/src/ui/FindingsPanel.a11y.test.tsx` (NEW) — `vitest-axe` against the most aria-heavy panel in 3 states (empty / single severity / full pack).
- `tests/e2e/a11y.spec.ts` (NEW) — `@axe-core/playwright` against the analyzed-lease view, `wcag2a` + `wcag2aa` tags, fails on `serious` / `critical` violations.
- `docs/TESTING.md` — new "a11y gate" subsection makes it explicit that a11y is a separate axis from coverage.
- `tests/e2e/README.md` — documents the new spec + why the unit and e2e gates are intentionally redundant.
- `docs/BACKLOG.md` — flips "Full a11y audit" and "Lighthouse a11y + PWA scores ≥ 95" to `[x]` (Lighthouse was already enforced via `app/lighthouserc.json`; this just confirms the tick).
- Deps: `vitest-axe` in `app/`, `@axe-core/playwright` at the root workspace.

Wave 14 Part D per `docs/plans/wave14-ci-hardening-governance.md`.

## Test plan
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npm test` — 1082 passing (3 new a11y unit tests).
- [ ] `npm run e2e -- tests/e2e/a11y.spec.ts` green on the production preview (verified locally per the plan; CI will confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)