### PR TITLE
fix(bundle): code-split sideLetterPdf so pdf-lib stays out of app shell

### DIFF
--- a/app/src/App/useSideLetter.ts
+++ b/app/src/App/useSideLetter.ts
@@ -1,6 +1,9 @@
 import { useCallback, useState } from 'react';
 import { buildSideLetterHtml, type SideLetterSigner } from '../negotiation/sideLetter';
-import { buildSideLetterPdf } from '../workflow/sideLetterPdf';
+// `buildSideLetterPdf` is dynamic-imported inside `downloadPdf` so the
+// pdf-lib runtime (~500 KiB) stays out of the app shell. The PDF path is
+// only reached after a user click, so the chunk-fetch latency is masked
+// by the click-to-download motion.
 import type { RedlineEdit } from '../redline/redline';
 import { downloadBlob, downloadBlobBytes, stripPdfExt } from './appHelpers';
 
@@ -82,6 +85,7 @@ export function useSideLetter(): UseSideLetterApi {
   const downloadPdf = useCallback<UseSideLetterApi['downloadPdf']>(
     async (input) => {
       const signer = trimmedSigner(signerDraft);
+      const { buildSideLetterPdf } = await import('../workflow/sideLetterPdf');
       const bytes = await buildSideLetterPdf({
         leaseName: input.leaseName,
         edits: input.edits,


### PR DESCRIPTION
## Summary
- Wave 13-B side-letter PDF export landed \`buildSideLetterPdf\` with a top-level \`pdf-lib\` import, pulling ~430 KiB of pdf-lib into the main app chunk. App shell was **747 KiB raw vs the 342 KiB budget** — main has been red on \`check:budget\` since PR #52.
- Move \`buildSideLetterPdf\` behind a dynamic \`import()\` inside the \`downloadPdf\` callback so pdf-lib only loads when the user actually clicks the PDF export button.
- App shell drops to **309 KiB**; new \`sideLetterPdf-*.js\` chunk holds the 430 KiB lazy payload.

## Test plan
- [x] \`npm run build\` — app shell now 309 KiB.
- [x] \`npm run check:budget\` — green.
- [x] \`npm run typecheck\` — green.
- [x] \`npm run lint\` — green.
- [x] \`npm test\` — 1079/1080 passing (1 pre-existing todo); side-letter tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)