### PR TITLE
wave14-B: WebKit + Firefox e2e matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,10 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -27,21 +31,21 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: ms-playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: ms-playwright-${{ runner.os }}-
-      - name: Install Chromium + system deps
-        run: npx playwright install --with-deps chromium
+          key: ms-playwright-${{ runner.os }}-${{ matrix.browser }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: ms-playwright-${{ runner.os }}-${{ matrix.browser }}-
+      - name: Install ${{ matrix.browser }} + system deps
+        run: npx playwright install --with-deps ${{ matrix.browser }}
       - name: Build app
         working-directory: app
         run: npm run build
-      - name: Run e2e smoke
+      - name: Run e2e smoke (${{ matrix.browser }})
         env:
           CI: 'true'
-        run: npm run e2e
+        run: npx playwright test --project=${{ matrix.browser }}
       - name: Upload Playwright HTML report on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.browser }}
           path: playwright-report/
           retention-days: 7

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -38,7 +38,10 @@ and +10 MB of language data once `eng.traineddata.gz` is dropped into
 - [x] ESLint + Prettier
 - [x] Vitest wired; `npm run test:coverage` with thresholds in CI
 - [ ] Pre-commit hook (`lint-staged`) — opt-in; CI is authoritative
-- [ ] Playwright smoke test (browser sanity is currently manual via Chrome DevTools MCP)
+- [x] Playwright smoke test. Landed chromium-only in Wave 12 Part B
+      (`tests/e2e/golden.spec.ts`); extended to a 3-way `chromium` /
+      `firefox` / `webkit` matrix in Wave 14 Part B
+      (`playwright.config.ts` + `.github/workflows/e2e.yml`).
 - [x] CSP `default-src 'self'` + local pdf.worker + no-CDN contract
 - [x] GitHub Actions: typecheck + lint + coverage on PR
 - [x] Bundled synthetic fixtures (residential + commercial leases via pdf-lib)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prepare": "husky",
     "e2e": "playwright test",
-    "e2e:install": "playwright install --with-deps chromium"
+    "e2e:install": "playwright install --with-deps chromium firefox webkit"
   },
   "devDependencies": {
     "@playwright/test": "^1.49.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,5 +28,13 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
   ],
 });

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,7 +1,8 @@
 # Playwright e2e smoke
 
 A single happy-path browser test that exercises the user-facing pipeline
-end-to-end against a real Chromium build:
+end-to-end. The same spec runs against Chromium, Firefox, and WebKit on
+every PR via a 3-way matrix in `.github/workflows/e2e.yml`:
 
 1. Load the production preview build.
 2. Dismiss the first-run onboarding tour.
@@ -20,13 +21,22 @@ service-worker install, and the preview build's bundle wiring.
 From the repo root:
 
 ```bash
-# One-time: install Chromium + system deps.
+# One-time: install Chromium + system deps. To run the full matrix
+# locally, also install Firefox + WebKit:
+#   npx playwright install --with-deps firefox webkit
 npm run e2e:install
 
 # Build the app and run the smoke. Playwright auto-starts `vite preview`
 # on http://127.0.0.1:4173 via the webServer config in playwright.config.ts.
 cd app && npm run build && cd ..
+
+# All three browsers (matches CI):
 npm run e2e
+
+# Single browser:
+npx playwright test --project=chromium
+npx playwright test --project=firefox
+npx playwright test --project=webkit
 ```
 
 `reuseExistingServer` is on outside CI, so an `npm run preview` already
@@ -46,7 +56,6 @@ you can replay the trace + screenshots locally.
 
 ## Out of scope (deferred to later waves)
 
-- WebKit / Firefox matrix.
 - Visual regression snapshots.
 - e2e for review-link / counter-sign / delta-packet flows (those need
   filesystem fixtures).


### PR DESCRIPTION
## Summary
- Extend the chromium-only Playwright smoke (Wave 12-B) to a 3-way browser matrix: \`chromium\`, \`firefox\`, \`webkit\`.
- Each matrix entry installs only its own browser and caches independently (cache key includes the browser name); \`fail-fast: false\` so one browser's flake doesn't mask sibling status.
- \`playwright.config.ts\` adds \`firefox\` + \`webkit\` projects alongside \`chromium\`. \`webServer\` stays shared.
- Repo-root \`e2e:install\` now installs all three browsers for local matrix parity.
- \`tests/e2e/README.md\` documents per-project local invocation; \`docs/BACKLOG.md\` row 41 flipped \`[ ]\` → \`[x]\`.

## Test plan
- [ ] CI matrix: all three browser jobs pass on this PR.
- [ ] Total e2e wall time stays under 10 minutes (matrix runs in parallel).
- [ ] Per-browser HTML report uploaded on failure (artifact name includes browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)