### PR TITLE
wave15-C: clip highlight overlay to viewport + reduced-motion scroll

### DIFF
--- a/app/src/ui/PdfViewer.test.tsx
+++ b/app/src/ui/PdfViewer.test.tsx
@@ -43,6 +43,47 @@ describe('PdfViewer', () => {
     expect(overlay?.style.height).toBe('20px');
   });
 
+  it('clips a highlight overlay that extends past the page viewport', () => {
+    const pages = [{ pageNumber: 1, width: 612, height: 792, items: [] }];
+    render(
+      <PdfViewer
+        bytes={null}
+        pageCount={1}
+        selectedPage={null}
+        pages={pages}
+        // Right edge (700) and top (-50 → top 842) overflow the page.
+        highlight={{ page: 1, xLeft: 500, xRight: 700, yTop: 842, yBottom: 700 }}
+      />,
+    );
+    const overlay = document.querySelector('.pdf-highlight') as HTMLElement | null;
+    expect(overlay).not.toBeNull();
+    // left is unclamped (still inside the page), width is clipped to page.width - left.
+    expect(overlay?.style.left).toBe('500px');
+    expect(overlay?.style.width).toBe('112px'); // 612 - 500
+    // rawTop = 792 - 842 = -50 → clamped to 0; height shrinks accordingly.
+    expect(overlay?.style.top).toBe('0px');
+    expect(parseFloat(overlay?.style.height ?? '0')).toBeLessThanOrEqual(792);
+  });
+
+  it('uses behavior=auto for scrollIntoView when prefers-reduced-motion is set', () => {
+    const scrollSpy = vi.fn();
+    Element.prototype.scrollIntoView = scrollSpy;
+    const matchMediaSpy = vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    const { rerender } = render(<PdfViewer bytes={null} pageCount={2} selectedPage={null} />);
+    rerender(<PdfViewer bytes={null} pageCount={2} selectedPage={2} />);
+    expect(scrollSpy).toHaveBeenCalledWith({ behavior: 'auto', block: 'start' });
+    matchMediaSpy.mockRestore();
+  });
+
   it('does not render a highlight for a page that does not match', () => {
     const pages = [
       { pageNumber: 1, width: 612, height: 792, items: [] },

--- a/app/src/ui/PdfViewer.tsx
+++ b/app/src/ui/PdfViewer.tsx
@@ -53,7 +53,17 @@ export function PdfViewer({
     if (selectedPage == null) return;
     const el = document.getElementById(`pdf-page-${selectedPage}`);
     if (el && typeof el.scrollIntoView === 'function') {
-      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      // Honor `prefers-reduced-motion` so the scroll respects the OS-level
+      // motion preference (WCAG 2.3.3). Fall back to `smooth` when the
+      // media query is unavailable (jsdom) or the user hasn't opted in.
+      const reduceMotion =
+        typeof window !== 'undefined' &&
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      el.scrollIntoView({
+        behavior: reduceMotion ? 'auto' : 'smooth',
+        block: 'start',
+      });
     }
   }, [selectedPage]);
 
@@ -67,10 +77,17 @@ export function PdfViewer({
 
   function overlayStyle(bbox: BoundingBox, page: PageText): CSSProperties {
     // PDF coords: y increases upward. Canvas CSS coords: top-left origin.
-    const left = bbox.xLeft;
-    const width = Math.max(1, bbox.xRight - bbox.xLeft);
-    const top = page.height - bbox.yTop;
-    const height = Math.max(1, bbox.yTop - bbox.yBottom);
+    // Clamp the overlay to the page viewport so a finding whose bbox
+    // overshoots (landscape / oversized fonts) doesn't render past the
+    // canvas edges and bleed into adjacent layout.
+    const rawLeft = bbox.xLeft;
+    const rawWidth = Math.max(1, bbox.xRight - bbox.xLeft);
+    const rawTop = page.height - bbox.yTop;
+    const rawHeight = Math.max(1, bbox.yTop - bbox.yBottom);
+    const left = Math.max(0, rawLeft);
+    const top = Math.max(0, rawTop);
+    const width = Math.max(1, Math.min(rawLeft + rawWidth, page.width) - left);
+    const height = Math.max(1, Math.min(rawTop + rawHeight, page.height) - top);
     return {
       position: 'absolute',
       left: `${left}px`,

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -158,6 +158,18 @@ Local-only, CSP-compatible.
       `definitions` prop is supplied.
 - [ ] Golden tests: a commercial lease fixture exercising table +
       definitions + references simultaneously.
+- [ ] **Per-span bbox on `Finding`** so the PDF viewer can highlight the
+      exact matched substring instead of the whole paragraph. Today
+      `Finding.span` is `{start, end}` char offsets into
+      `paragraph.text`; mapping that back to a canvas bbox requires
+      walking the paragraph's `PageText.items[]` (each item has
+      x/y/width/height). Plan: extend `Finding` with a derived
+      `spanBbox: BoundingBox` populated by the rules engine when the
+      span maps cleanly to one or more text items, and consumed by
+      `PdfViewer.tsx` (multiple rects when the span straddles items).
+      Out of scope for Wave 15-C (shipped clipping + reduced-motion
+      only); track as a dedicated follow-up wave because it touches
+      parser → rules → ui in lockstep.
 
 ## Phase 9 — Negotiation support
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -170,8 +170,12 @@ New UI panels live in `src/ui/` and follow a four-file convention:
 
 ## Deferred / explicitly out of scope
 
-- Real scanned-PDF binary fixture (detection works; binary not committed).
-- Span-level highlight overlay refinements (basic overlay shipped).
+- Span-level highlight bbox computation. Wave 15-C shipped viewport
+  clipping + `prefers-reduced-motion` opt-out on the existing paragraph
+  bbox; per-span bbox highlighting is tracked as a planned follow-up
+  wave because `Finding.span` is `{start, end}` char offsets, not a
+  bbox — the parser needs to attach a per-span bounding box first.
+  See the BACKLOG row under Phase 8.
 - Full WCAG 2.1 AA audit.
 - Tauri desktop wrapper (stub dir exists; no code).
 - Cloud sync / accounts / telemetry.


### PR DESCRIPTION
## Summary
Two viewer-only refinements from the Wave 15-C plan:
- **Clip highlight overlay to page viewport** — \`overlayStyle\` clamps the rect to \`page.width\`/\`page.height\` so a finding whose bbox overflows (landscape or oversized fonts) no longer bleeds past the canvas edges.
- **Reduced-motion scroll** — page-scroll honors \`prefers-reduced-motion\` (WCAG 2.3.3): \`behavior: 'auto'\` when the OS preference is set, \`'smooth'\` otherwise. Falls back to \`'smooth'\` when \`matchMedia\` is absent (jsdom).

## Out of scope (filed as follow-up wave)
- **Per-span bbox highlighting.** The plan's third bullet asked to \"use the parser's per-span bbox when \`finding.spans[]\` is populated,\" but \`Finding.span\` is \`{start, end}\` char offsets — there's no per-span bbox in \`LeaseDocument\`. Mapping char offsets back to canvas coordinates requires walking \`PageText.items[]\`; that's parser/rules-engine work, not a viewer refinement. Filed as a Phase 8 BACKLOG row + a CLAUDE.md note pointing at it.

## Test plan
- [x] \`npx vitest run src/ui/PdfViewer.test.tsx\` — 7/7 passing (5 existing + 2 new: clip math, reduced-motion).
- [x] \`npm run typecheck\` green.
- [x] \`npm run lint\` green.
- [x] \`npx vitest run\` — 1083/1084 passing (1 pre-existing todo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)