### PR TITLE
wave16-A: coverage push (branches 87 → 88; +30 tests; doc real ceiling)

### DIFF
--- a/app/src/App/appHelpers.test.ts
+++ b/app/src/App/appHelpers.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  friendlyError,
+  readFileBytes,
+  stripPdfExt,
+  leaseFactsToIcsDates,
+  buildIcsBytes,
+  exportEncryptedArchiveFlow,
+  importEncryptedArchiveFlow,
+  clearAllFlow,
+} from './appHelpers';
+import { PasswordProtectedPdfError } from '../parser/types';
+import type { LeaseDocument } from '../parser/types';
+import type { LeaseFacts } from '../facts/types';
+
+beforeEach(() => {
+  // jsdom doesn't implement URL.createObjectURL; assign instead of spying
+  // because the property is undefined on the URL constructor.
+  (URL as unknown as { createObjectURL: () => string }).createObjectURL = vi
+    .fn()
+    .mockReturnValue('blob:stub');
+  (URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL = vi.fn();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('friendlyError', () => {
+  it('returns the PasswordProtectedPdfError message verbatim', () => {
+    const err = new PasswordProtectedPdfError();
+    expect(friendlyError(err)).toMatch(/password-protected/i);
+  });
+
+  it('returns the Error message for plain Error', () => {
+    expect(friendlyError(new Error('boom'))).toBe('boom');
+  });
+
+  it('coerces non-Error throws to string', () => {
+    expect(friendlyError({ weird: true })).toBe('[object Object]');
+    expect(friendlyError(42)).toBe('42');
+    expect(friendlyError('plain string')).toBe('plain string');
+  });
+});
+
+describe('readFileBytes', () => {
+  it('uses File.arrayBuffer when present', async () => {
+    const file = new File([new Uint8Array([1, 2, 3])], 'x.pdf');
+    const bytes = await readFileBytes(file);
+    expect(bytes).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  it('falls back to FileReader when arrayBuffer is missing', async () => {
+    const fakeFile = {
+      // no arrayBuffer method
+    } as unknown as File;
+    // Stub FileReader to immediately resolve with a known buffer.
+    const buf = new Uint8Array([7, 8, 9]).buffer;
+    class FakeReader {
+      result: ArrayBuffer | null = null;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      readAsArrayBuffer(): void {
+        this.result = buf;
+        queueMicrotask(() => this.onload?.());
+      }
+      get error(): null {
+        return null;
+      }
+    }
+    vi.stubGlobal('FileReader', FakeReader as unknown);
+    const bytes = await readFileBytes(fakeFile);
+    expect(bytes).toEqual(new Uint8Array([7, 8, 9]));
+  });
+
+  it('rejects via FileReader.onerror when the read fails', async () => {
+    const fakeFile = {} as unknown as File;
+    class ErrReader {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      readAsArrayBuffer(): void {
+        queueMicrotask(() => this.onerror?.());
+      }
+      get error(): Error {
+        return new Error('disk on fire');
+      }
+    }
+    vi.stubGlobal('FileReader', ErrReader as unknown);
+    await expect(readFileBytes(fakeFile)).rejects.toThrow('disk on fire');
+  });
+});
+
+describe('stripPdfExt', () => {
+  it('strips a trailing .pdf', () => {
+    expect(stripPdfExt('Lease.pdf')).toBe('Lease');
+  });
+
+  it('is case-insensitive', () => {
+    expect(stripPdfExt('Lease.PDF')).toBe('Lease');
+  });
+
+  it('leaves names without a .pdf suffix unchanged', () => {
+    expect(stripPdfExt('Lease.txt')).toBe('Lease.txt');
+    expect(stripPdfExt('NoExtension')).toBe('NoExtension');
+  });
+});
+
+describe('leaseFactsToIcsDates', () => {
+  function facts(overrides: Partial<LeaseFacts> = {}): LeaseFacts {
+    return {
+      tenantName: null,
+      landlordName: null,
+      monthlyRent: null,
+      securityDeposit: null,
+      commencementDate: null,
+      expirationDate: null,
+      noticePeriodDays: null,
+      ...overrides,
+    } as LeaseFacts;
+  }
+
+  it('returns empty when no dates are extractable', () => {
+    expect(leaseFactsToIcsDates(facts())).toEqual([]);
+  });
+
+  it('emits a single commencement event when only that date is set', () => {
+    const out = leaseFactsToIcsDates(facts({ commencementDate: '2026-01-01' }));
+    expect(out).toEqual([{ summary: 'Lease commences', date: '2026-01-01' }]);
+  });
+
+  it('emits commencement + expiration when both are set, no notice', () => {
+    const out = leaseFactsToIcsDates(
+      facts({ commencementDate: '2026-01-01', expirationDate: '2027-01-01' }),
+    );
+    expect(out.map((e) => e.summary)).toEqual(['Lease commences', 'Lease expires']);
+  });
+
+  it('emits a notice-deadline event when expiration + noticePeriodDays are set', () => {
+    const out = leaseFactsToIcsDates(facts({ expirationDate: '2027-01-31', noticePeriodDays: 30 }));
+    expect(out).toHaveLength(2); // expiration + notice
+    const notice = out.find((e) => e.summary.includes('Notice deadline'));
+    expect(notice?.date).toBe('2027-01-01');
+  });
+
+  it('skips the notice event when noticePeriodDays is set but expiration is not', () => {
+    const out = leaseFactsToIcsDates(facts({ noticePeriodDays: 30 }));
+    expect(out).toEqual([]);
+  });
+
+  it('skips the notice event when subtractDaysIso receives a malformed date', () => {
+    // The internal subtractDaysIso requires YYYY-MM-DD; a malformed expiration
+    // date returns null and the notice entry is dropped.
+    const out = leaseFactsToIcsDates(
+      facts({ expirationDate: 'not-a-date' as string, noticePeriodDays: 30 }),
+    );
+    // Expiration entry still emitted; notice entry suppressed.
+    expect(out.map((e) => e.summary)).toEqual(['Lease expires']);
+  });
+});
+
+describe('buildIcsBytes', () => {
+  function leaseDoc(): LeaseDocument {
+    return { pages: [], paragraphs: [], sections: [], raw: '' };
+  }
+
+  it('returns null when no dates are extractable', () => {
+    const result = buildIcsBytes({ fileName: 'empty.pdf', doc: leaseDoc() });
+    expect(result).toBeNull();
+  });
+});
+
+describe('exportEncryptedArchiveFlow', () => {
+  it('is a no-op when the user cancels the passphrase prompt', async () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue(null);
+    await exportEncryptedArchiveFlow();
+    expect(promptSpy).toHaveBeenCalled();
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the user submits an empty passphrase', async () => {
+    vi.spyOn(window, 'prompt').mockReturnValue('');
+    await exportEncryptedArchiveFlow();
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+  });
+});
+
+describe('importEncryptedArchiveFlow', () => {
+  function fakeFile(): File {
+    return new File([new Uint8Array([0])], 'archive.lgarchive');
+  }
+
+  it('is a no-op when the user cancels the passphrase prompt', async () => {
+    vi.spyOn(window, 'prompt').mockReturnValue(null);
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    await importEncryptedArchiveFlow(fakeFile(), { onSuccess, onError });
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('routes a wrong-passphrase error to onError with the underlying message', async () => {
+    vi.spyOn(window, 'prompt').mockReturnValue('wrong');
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    // Garbage bytes → archive header check throws WrongPassphraseError or
+    // similar; either path lands in the catch block we want to cover.
+    await importEncryptedArchiveFlow(fakeFile(), { onSuccess, onError });
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toMatch(/passphrase|Import failed/i);
+  });
+});
+
+describe('clearAllFlow', () => {
+  it('returns false and skips clearing when the user cancels the confirm dialog', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const onCleared = vi.fn();
+    const result = await clearAllFlow({ onCleared });
+    expect(result).toBe(false);
+    expect(onCleared).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/App/useVersionHistory.test.ts
+++ b/app/src/App/useVersionHistory.test.ts
@@ -1,15 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { useVersionHistory } from './useVersionHistory';
-import {
-  _resetVersionsDbForTests,
-  openVersionsDb,
-} from '../negotiation/versionHistory';
-import {
-  _resetRedlineDbForTests,
-  openRedlineDb,
-  saveEdit,
-} from '../redline/redlineStorage';
+import { _resetVersionsDbForTests, openVersionsDb } from '../negotiation/versionHistory';
+import { _resetRedlineDbForTests, openRedlineDb, saveEdit } from '../redline/redlineStorage';
 import { at } from '../test/assert';
 
 beforeEach(async () => {
@@ -46,9 +39,7 @@ describe('useVersionHistory', () => {
       updatedAt: new Date().toISOString(),
     });
     const audit = vi.fn(async () => undefined);
-    const { result } = renderHook(() =>
-      useVersionHistory({ leaseId: 'lease-1', audit }),
-    );
+    const { result } = renderHook(() => useVersionHistory({ leaseId: 'lease-1', audit }));
     await waitFor(() => {
       expect(result.current.versions).toEqual([]);
     });
@@ -59,19 +50,124 @@ describe('useVersionHistory', () => {
     expect(saved).not.toBeNull();
     expect(result.current.versions).toHaveLength(1);
     expect(at(result.current.versions, 0).label).toBe('label-A');
-    expect(audit).toHaveBeenCalledWith(
-      expect.objectContaining({ kind: 'version-save' }),
-    );
+    expect(audit).toHaveBeenCalledWith(expect.objectContaining({ kind: 'version-save' }));
   });
 
   it('getVersionById returns null when versionId belongs to another lease', async () => {
-    const { result } = renderHook(() =>
-      useVersionHistory({ leaseId: 'lease-other' }),
-    );
+    const { result } = renderHook(() => useVersionHistory({ leaseId: 'lease-other' }));
     await waitFor(() => {
       expect(result.current.versions).toEqual([]);
     });
     const got = await result.current.getVersionById('does-not-exist');
     expect(got).toBeNull();
+  });
+
+  it('createVersion is a no-op and returns null when leaseId is null', async () => {
+    const audit = vi.fn(async () => undefined);
+    const { result } = renderHook(() => useVersionHistory({ leaseId: null, audit }));
+    let saved;
+    await act(async () => {
+      saved = await result.current.createVersion();
+    });
+    expect(saved).toBeNull();
+    expect(audit).not.toHaveBeenCalled();
+  });
+
+  it('createVersion works without an audit callback supplied', async () => {
+    const { result } = renderHook(() => useVersionHistory({ leaseId: 'lease-1' }));
+    await waitFor(() => {
+      expect(result.current.versions).toEqual([]);
+    });
+    let saved;
+    await act(async () => {
+      saved = await result.current.createVersion();
+    });
+    expect(saved).not.toBeNull();
+    expect(result.current.versions).toHaveLength(1);
+  });
+
+  it('removeVersion is a no-op when leaseId is null', async () => {
+    const audit = vi.fn(async () => undefined);
+    const { result } = renderHook(() => useVersionHistory({ leaseId: null, audit }));
+    await act(async () => {
+      await result.current.removeVersion('any');
+    });
+    expect(audit).not.toHaveBeenCalled();
+  });
+
+  it('removeVersion deletes + audits when version exists', async () => {
+    const audit = vi.fn(async () => undefined);
+    const { result } = renderHook(() => useVersionHistory({ leaseId: 'lease-1', audit }));
+    await waitFor(() => {
+      expect(result.current.versions).toEqual([]);
+    });
+    let id = '';
+    await act(async () => {
+      const saved = await result.current.createVersion('v1');
+      id = saved!.versionId;
+    });
+    audit.mockClear();
+    await act(async () => {
+      await result.current.removeVersion(id);
+    });
+    expect(audit).toHaveBeenCalledWith(expect.objectContaining({ kind: 'version-delete' }));
+    expect(result.current.versions).toHaveLength(0);
+  });
+
+  it('restoreVersion is a no-op when leaseId is null or version is missing', async () => {
+    const apply = vi.fn();
+    const audit = vi.fn(async () => undefined);
+    const nullHook = renderHook(() => useVersionHistory({ leaseId: null, audit }));
+    await act(async () => {
+      await nullHook.result.current.restoreVersion('any', apply);
+    });
+    expect(apply).not.toHaveBeenCalled();
+
+    const validHook = renderHook(() => useVersionHistory({ leaseId: 'lease-1', audit }));
+    await waitFor(() => {
+      expect(validHook.result.current.versions).toEqual([]);
+    });
+    await act(async () => {
+      await validHook.result.current.restoreVersion('does-not-exist', apply);
+    });
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it('restoreVersion applies edits + audits when version belongs to this lease', async () => {
+    await saveEdit({
+      leaseId: 'lease-1',
+      paragraphIndex: 0,
+      before: 'a',
+      after: 'b',
+      updatedAt: new Date().toISOString(),
+    });
+    const audit = vi.fn(async () => undefined);
+    const apply = vi.fn();
+    const { result } = renderHook(() => useVersionHistory({ leaseId: 'lease-1', audit }));
+    let id = '';
+    await act(async () => {
+      const saved = await result.current.createVersion('v1');
+      id = saved!.versionId;
+    });
+    audit.mockClear();
+    await act(async () => {
+      await result.current.restoreVersion(id, apply);
+    });
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(audit).toHaveBeenCalledWith(expect.objectContaining({ kind: 'version-restore' }));
+  });
+
+  it('exportVersion is a no-op when the version does not exist', async () => {
+    const { result } = renderHook(() => useVersionHistory({ leaseId: 'lease-1' }));
+    await waitFor(() => {
+      expect(result.current.versions).toEqual([]);
+    });
+    // Should not throw.
+    await act(async () => {
+      await result.current.exportVersion('does-not-exist', {
+        leaseName: 'L.pdf',
+        doc: { pages: [], paragraphs: [], sections: [], raw: '' },
+      });
+    });
   });
 });

--- a/app/src/portfolio/clauseClusters.test.ts
+++ b/app/src/portfolio/clauseClusters.test.ts
@@ -41,37 +41,23 @@ describe('clusterParagraphs', () => {
   });
 
   it('clusters identical paragraphs across two leases', () => {
-    const leases = [
-      makeLease('L1', [STD_AUTO_RENEW]),
-      makeLease('L2', [STD_AUTO_RENEW]),
-    ];
+    const leases = [makeLease('L1', [STD_AUTO_RENEW]), makeLease('L2', [STD_AUTO_RENEW])];
     const out: ClauseCluster[] = clusterParagraphs(leases);
-    const auto = out.find((c) =>
-      c.paragraphs.some((p) => p.leaseId === 'L1'),
-    );
+    const auto = out.find((c) => c.paragraphs.some((p) => p.leaseId === 'L1'));
     expect(auto).toBeDefined();
     expect(auto?.paragraphs.map((p) => p.leaseId).sort()).toEqual(['L1', 'L2']);
   });
 
   it('clusters near-duplicates whose Jaccard >= 0.8', () => {
-    const leases = [
-      makeLease('L1', [STD_AUTO_RENEW]),
-      makeLease('L2', [NEAR_DUP_AUTO_RENEW]),
-    ];
+    const leases = [makeLease('L1', [STD_AUTO_RENEW]), makeLease('L2', [NEAR_DUP_AUTO_RENEW])];
     const out = clusterParagraphs(leases, { threshold: 0.8 });
     const merged = out.find((c) => c.paragraphs.length >= 2);
     expect(merged).toBeDefined();
-    expect(merged?.paragraphs.map((p) => p.leaseId).sort()).toEqual([
-      'L1',
-      'L2',
-    ]);
+    expect(merged?.paragraphs.map((p) => p.leaseId).sort()).toEqual(['L1', 'L2']);
   });
 
   it('does not cluster unrelated paragraphs', () => {
-    const leases = [
-      makeLease('L1', [STD_AUTO_RENEW]),
-      makeLease('L2', [UNRELATED]),
-    ];
+    const leases = [makeLease('L1', [STD_AUTO_RENEW]), makeLease('L2', [UNRELATED])];
     const out = clusterParagraphs(leases, { threshold: 0.8 });
     // No cluster has both leases.
     const cross = out.find(
@@ -90,6 +76,45 @@ describe('clusterParagraphs', () => {
     const a = clusterParagraphs(leases, { threshold: 0.8 });
     const b = clusterParagraphs(leases, { threshold: 0.8 });
     expect(a.map((c) => c.clusterId)).toEqual(b.map((c) => c.clusterId));
+  });
+
+  it('co-clusters two paragraphs short enough to have no shingles when their text is exactly equal', () => {
+    // A paragraph shorter than `k` chars produces zero shingles. The default
+    // `paragraphShingles` k is small but two single-word paragraphs land in
+    // the empty-shingle path; the co-cluster rule then requires exact text.
+    const leases = [makeLease('L1', ['ok']), makeLease('L2', ['ok'])];
+    const out = clusterParagraphs(leases, { threshold: 0.8, k: 50 });
+    const merged = out.find((c) => c.paragraphs.length >= 2);
+    expect(merged).toBeDefined();
+    expect(merged?.paragraphs.map((p) => p.leaseId).sort()).toEqual(['L1', 'L2']);
+  });
+
+  it('does not co-cluster two zero-shingle paragraphs whose text differs', () => {
+    const leases = [makeLease('L1', ['ok']), makeLease('L2', ['no'])];
+    const out = clusterParagraphs(leases, { threshold: 0.8, k: 50 });
+    // Each paragraph is its own cluster.
+    expect(out).toHaveLength(2);
+  });
+
+  it('handles leases whose doc.paragraphs is missing entirely', () => {
+    const lease: LeaseRecord = {
+      id: 'L1',
+      name: 'L1.pdf',
+      createdAt: 1000,
+      updatedAt: 1000,
+      rulePackVersion: '1.0.0',
+      pageCount: 1,
+      findingCount: 0,
+      // doc.paragraphs deliberately undefined → defaults to [] via `??`.
+      doc: {
+        pages: [{ pageNumber: 1, width: 612, height: 792, items: [] }],
+        paragraphs: undefined as unknown as [],
+        sections: [],
+        raw: '',
+      },
+      findings: [],
+    };
+    expect(clusterParagraphs([lease])).toEqual([]);
   });
 
   it('records leaseId + paragraphIndex for every clustered paragraph', () => {

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -62,12 +62,16 @@ export default defineConfig({
         'src/worker/leaseWorker.ts',
       ],
       thresholds: {
-        // Raised 2026-04-18 after wave 5 consolidation. Current actuals
-        // sit at 97.03 / 88.08 / 93.21 / 97.03; floors leave ~2 points of
-        // headroom on stmt/func/line and ~1 on branch so a single honest
-        // regression doesn't break CI.
+        // Raised 2026-04-25 after Wave 16 Part A test additions
+        // (appHelpers, useVersionHistory, clauseClusters edge cases).
+        // Actuals sit at 96.63 / 88.31 / 93.03 / 96.63; the +1 branch
+        // bump (87 → 88) is the honest ceiling without (a) decomposing
+        // App.tsx (38 missed branches; tracked as a Wave 17 candidate)
+        // and (b) reducing v8's defensive-guard noise from
+        // `noUncheckedIndexedAccess` (`?? 0` / `?? ''` paths it counts
+        // as branches but that runtime cannot reach).
         statements: 95,
-        branches: 87,
+        branches: 88,
         functions: 91,
         lines: 95,
       },

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -89,11 +89,22 @@ which is also directly covered.
 ## Coverage thresholds
 
 Defined in `app/vite.config.ts` under `test.coverage.thresholds`.
-Current floors: **stmt 95 / branch 87 / func 91 / line 95**. Actuals
-as of 2026-04-18: 97.03 / 88.08 / 93.21 / 97.03. Floors leave ~2 points
-of headroom on stmt/func/line and ~1 on branch so a single honest
-regression doesn't break CI. Raise floors in lock-step with actuals;
-never set a floor you don't already have headroom on.
+Current floors: **stmt 95 / branch 88 / func 91 / line 95**. Actuals
+as of 2026-04-25: 96.63 / 88.31 / 93.03 / 96.63. Floors leave ~1.5
+points of headroom on stmt/line and func, ~0.3 on branch — branch is
+the tight one because the two structural ceilings on the codebase
+keep it sticky:
+
+- `App.tsx` is 1007 lines with 38 missed branches; raising branch
+  coverage past ~89 means decomposing it (tracked as a Wave 17
+  candidate, not a Wave 16 task).
+- `noUncheckedIndexedAccess` produces `?? 0` / `?? ''` defensive
+  guards that v8 counts as branches but that runtime cannot reach.
+  These show up across the parser / matchers / diff code as
+  permanently uncovered branches.
+
+Raise floors in lock-step with actuals; never set a floor you don't
+already have headroom on.
 
 Excludes: test/bench/stories files, barrels (`index.ts`), `main.tsx`,
 `parser/env.d.ts`, `parser/testFixtures.ts`, and


### PR DESCRIPTION
## Summary
- New \`app/src/App/appHelpers.test.ts\` (21 tests) covering download / archive / clearAll flows that had zero direct unit coverage.
- 7 new tests in \`useVersionHistory.test.ts\` for null-leaseId no-ops, audit-callback-absent path, removeVersion / restoreVersion / exportVersion edges.
- 3 new tests in \`clauseClusters.test.ts\` for zero-shingle co-cluster path + missing \`doc.paragraphs\`.
- \`vite.config.ts\` branches floor 87 → 88. Actual: 88.31% (0.31 buffer).

## Why not 90?
The plan target was 90; landing at 88 with rationale captured in the threshold comment + \`docs/TESTING.md\`. Two structural ceilings:

1. **App.tsx (1007 lines, 38 missed branches)** — Wave 17 decomposition target. Pushing past ~89 means decomposing it.
2. **\`noUncheckedIndexedAccess\` defensive guards** — \`?? 0\` / \`?? ''\` paths v8 counts as branches but runtime cannot reach.

## Cap discipline
- 1 new test file + 2 extensions = 3 files. Cap was 15. ✓
- 30 new test cases. ✓
- **Zero production-source edits.** ✓
- Net branches +0.48% (87.83 → 88.31).

## Wave 17 candidate (file via Part C)
"Branch-coverage past 89% requires App.tsx decomposition (1007 → ≤600 lines per BACKLOG row line 504) and a sweep of \`?? 0\` / \`?? ''\` defensive guards that v8 flags as branches but runtime cannot reach."

## Test plan
- [x] \`npm run typecheck && npm run lint && npm run test:coverage\` green.
- [x] 144 test files, 1117 passing tests.
- [x] Threshold floor at 88 with 0.31% headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)