### PR TITLE
wave16-F: security pass — fix 4 HIGH npm-audit vulns + add audit CI

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,34 @@
+name: security
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly Mon 09:00 UTC — catches new advisories on deps that haven't
+    # otherwise changed.
+    - cron: '0 9 * * 1'
+
+jobs:
+  npm-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            app/package-lock.json
+      - name: Install root deps
+        run: npm ci
+      - name: Audit root (high+ only)
+        run: npm audit --audit-level=high
+      - name: Install app deps
+        working-directory: app
+        run: npm ci
+      - name: Audit app (high+ only)
+        working-directory: app
+        run: npm audit --audit-level=high

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9156,16 +9156,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -9585,27 +9575,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -9684,13 +9653,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-function-length": {

--- a/app/package.json
+++ b/app/package.json
@@ -61,5 +61,8 @@
     "vite-plugin-pwa": "^0.20.5",
     "vitest": "^1.6.0",
     "vitest-axe": "^0.1.0"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
   }
 }

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -12,6 +12,33 @@ items closed out in Wave 11 (see `docs/BACKLOG.md` → "Known unknowns &
 risk register"). When a related design changes, update the matching
 section here in the same PR.
 
+**Last review:** 2026-04-25 (Wave 16-F).
+
+Findings from the 2026-04-25 pass:
+
+- `npm audit --audit-level=high` was reporting 4 HIGH findings via
+  `vite-plugin-pwa → workbox-build → @rollup/plugin-terser →
+  serialize-javascript@<=7.0.4` (RCE via `RegExp.flags` /
+  `Date.prototype.toISOString`, plus a CPU-DoS). Pinned via the new
+  `overrides.serialize-javascript: ^7.0.5` block in `app/package.json`.
+  All four HIGHs cleared; 9 MODERATEs remain in the Storybook /
+  vite-plugin-pwa transitive tree (build-time only, not shipped to
+  end users — track for routine maintenance, not blocking).
+- A03 Injection: zero `dangerouslySetInnerHTML` callers in `app/src`.
+- A05 Misconfiguration: `npm run check:csp` clean; CSP in
+  `app/index.html` is `default-src 'self'` with `style-src 'self'
+  'unsafe-inline'` (React inline styles), `connect-src 'self' blob:`
+  (worker postMessage), `worker-src 'self' blob:`, and `object-src
+  'none'`. No external origins.
+- A02 Crypto: encrypted-archive AES-GCM uses a fresh `randomBytes`
+  IV per encryption (`app/src/storage/archive.ts:28`); Ed25519 keys
+  go through `crypto.subtle.generateKey` and the private key never
+  leaves IDB unencrypted (Wave 8-D's `signingKeys.ts`). No regressions
+  vs. the Wave 8-D baseline.
+- A08 Integrity: SHA-256 via `crypto.subtle` is the single content
+  fingerprinting source (`app/src/security/inputHash.ts`); no parallel
+  hashing implementations.
+
 ---
 
 ## 1. Encrypted archive threat model


### PR DESCRIPTION
## Summary
- **\`serialize-javascript\` <=7.0.4** transitive (via \`vite-plugin-pwa → workbox-build → @rollup/plugin-terser\`) was vulnerable to RCE (GHSA-5c6j-r48x-rmvq) and CPU-DoS (GHSA-qj8w-gfj5-8c6v). Pinned via \`overrides.serialize-javascript: ^7.0.5\` in \`app/package.json\`. **All 4 HIGH advisories cleared.**
- 9 MODERATEs remain in the Storybook / vite-plugin-pwa transitive tree — build-time only, not shipped to end users; tracked for routine maintenance.
- New \`.github/workflows/security.yml\` runs \`npm audit --audit-level=high\` on every PR + weekly. Catches new HIGHs without flagging existing tolerated MODERATEs.

## OWASP-top-10 spot-check (clean)
- **A03 Injection:** zero \`dangerouslySetInnerHTML\` callers.
- **A05 Misconfiguration:** \`npm run check:csp\` clean; CSP unchanged from Wave 12-A baseline.
- **A02 Crypto:** AES-GCM IV is fresh \`randomBytes\` per encryption; Ed25519 flow unchanged from Wave 8-D.
- **A08 Integrity:** SHA-256 via \`crypto.subtle\` is the single content-fingerprinting source.

## Cap discipline
- 0 source-file edits ✓
- 1 dep-pin bump (the override) ✓
- 1 new workflow file ✓

## Test plan
- [x] \`npm audit --audit-level=high\` reports 0 findings (was 4).
- [x] \`npm run typecheck && npm run lint && npm run test:coverage\` green (1117 tests).
- [x] \`npm run build\` succeeds; \`npm run check:csp\` clean.
- [x] \`docs/SECURITY.md\` "Last review" updated to 2026-04-25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)