### PR TITLE
wave16-E: delete dead `buildResolverMapForLease` export

### DIFF
--- a/app/src/rules/portfolioOverrides.ts
+++ b/app/src/rules/portfolioOverrides.ts
@@ -63,24 +63,3 @@ export const migrateLegacyOverrides = (
   }
   return out;
 };
-
-/**
- * Build a `Record<ruleId, Severity>` resolver map for a single lease, suitable
- * for handing to `applySeverityOverrides`. Lease-scope wins over portfolio-
- * scope; rules with no entry are omitted (caller falls back to pack default).
- */
-export const buildResolverMapForLease = (
-  entries: readonly ScopedOverrideEntry[],
-  leaseId: string,
-): Record<string, Severity> => {
-  const portfolio: Record<string, Severity> = {};
-  const lease: Record<string, Severity> = {};
-  for (const e of entries) {
-    if (e.scope === 'portfolio') {
-      portfolio[e.ruleId] = e.severity;
-    } else if (e.scope === 'lease' && e.leaseId === leaseId) {
-      lease[e.ruleId] = e.severity;
-    }
-  }
-  return { ...portfolio, ...lease };
-};


### PR DESCRIPTION
## Summary
Triage results from the Wave 16 Part E pass:

### Deleted
- \`buildResolverMapForLease\` in \`src/rules/portfolioOverrides.ts\` — exported but had **zero consumers** anywhere in \`app/src\` (verified with grep across test + non-test files). −20 lines.

### Audited and kept
- Two \`eslint-disable no-console\` in App.tsx (\`:194\`, \`:298\`) — both wrap \`console.warn\` in catch blocks for non-fatal failures (audit append, shingle persistence). Load-bearing.
- All other \`eslint-disable\` in stories files are demo \`console.log\` handlers (convention-allowed).
- Other knip-flagged exports (\`DEFAULT_KEY_ID\`, \`STANDARDS_DB_NAME\`, \`EXPORT_SCHEMA\`, etc.) are referenced **internally within their own modules** — not actually dead. Removing the \`export\` keyword would change the API; risky for negligible gain.
- \`ts-unused-exports\`: **0 modules with unused exports.**

### BACKLOG candidates filed for Part C to absorb
1. Line 530 "App.tsx ~1540 lines" is stale — actual is 1007 post-Wave 7-D decomposition.
2. Line 536 panels-test timeout note: re-check after Wave 16-A's \`uploadLease\` timeout bump; may now be obsolete.

## Cap discipline
- 1 src file modified (cap ≤5)
- 0 new files
- Net **−20 lines** (deletion-only contract preserved)
- Zero behavior changes

## Test plan
- [x] \`npm run typecheck\` green.
- [x] \`npm run lint\` green.
- [x] \`npm run test:coverage\` — 144 test files / 1117 tests passing; thresholds intact (S 96.63 / B 88.31 / F 93.03 / L 96.63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)