### PR TITLE
wave17-B: remove obsolete Lighthouse audit assertions

### DIFF
--- a/app/lighthouserc.json
+++ b/app/lighthouserc.json
@@ -11,9 +11,7 @@
     "assert": {
       "assertions": {
         "categories:accessibility": ["error", { "minScore": 0.95 }],
-        "categories:best-practices": ["error", { "minScore": 0.9 }],
-        "installable-manifest": ["error", { "minScore": 1 }],
-        "apple-touch-icon": ["error", { "minScore": 1 }]
+        "categories:best-practices": ["error", { "minScore": 0.9 }]
       }
     },
     "upload": {


### PR DESCRIPTION
## Summary
- Lighthouse CI has been red since Wave 13 with \`"apple-touch-icon" is not a known audit\` / \`"installable-manifest" is not a known audit\`. Both audits were **removed upstream in Lighthouse v12+** when the PWA category was de-emphasized in Chrome.
- Drop the two obsolete assertions from \`app/lighthouserc.json\`. \`categories:accessibility >= 0.95\` + \`categories:best-practices >= 0.9\` remain.

The PWA itself is unchanged: still ships a valid \`manifest.webmanifest\` (generated by vite-plugin-pwa) and an SVG icon. No regression in installability — just stops asserting on audits that haven't existed for two Lighthouse versions.

## Cap discipline
- 1 of ≤3 file edits used.
- 0 of 1 icon (not needed — the underlying issue was the assertion list, not the manifest).

## Plan deviation note
Plan Part B's premise was "the audits are failing because the manifest is missing fields." Reality: the audits don't exist anymore. Right fix is removing the obsolete assertions, not adding fields.

## Test plan
- [ ] CI Lighthouse run goes green (verifying after push).
- [x] No JS source edits.
- [x] \`docs/SECURITY.md\` and other CI workflows unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)