### PR TITLE
wave17-A: extract <AppHeader> from App.tsx

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -93,7 +93,7 @@ import {
 import { OnboardingTour } from './ui/OnboardingTour';
 import { I18nProvider } from './i18n/I18nProvider';
 import { useI18n } from './i18n/I18nContext';
-import { LocalePickerPanel } from './ui/LocalePickerPanel';
+import { AppHeader } from './ui/AppHeader';
 import { StandardSuitePanel } from './ui/StandardSuitePanel';
 import {
   deleteStandard,
@@ -444,64 +444,15 @@ function AppContent(): JSX.Element {
           }}
         />
       )}
-      <header>
-        <h1>{t('app.title')}</h1>
-        <p>{t('app.tagline')}</p>
-        <LocalePickerPanel />
-        <details className="privacy">
-          <summary>{t('header.privacy.summary')}</summary>
-          <ul>
-            <li>The PDF is parsed entirely in your browser via pdf.js.</li>
-            <li>All storage is in IndexedDB on this device. No account, no sync.</li>
-            <li>
-              A strict Content-Security-Policy (<code>default-src &apos;self&apos;</code>) blocks
-              this page from loading scripts, fonts, or data from any other origin.
-            </li>
-            <li>LeaseGuard is not legal advice. Findings are heuristic pattern matches.</li>
-          </ul>
-        </details>
-        <label>
-          <span className="visually-hidden">Upload lease</span>
-          <input
-            type="file"
-            accept="application/pdf"
-            aria-label="upload lease"
-            onChange={async (e) => {
-              const file = e.target.files?.[0];
-              if (!file) return;
-              await handleBytes(await readFileBytes(file), file.name);
-            }}
-          />
-        </label>
-        <button type="button" onClick={() => void onTrySample()}>
-          {t('header.trySample')}
-        </button>
-        <div role="group" aria-label="view mode" className="view-toggle">
-          <button
-            type="button"
-            aria-pressed={view === 'current'}
-            onClick={() => setView('current')}
-          >
-            {t('header.view.current')}
-          </button>
-          <button
-            type="button"
-            aria-pressed={view === 'portfolio'}
-            onClick={() => setView('portfolio')}
-          >
-            {t('header.view.portfolio')}
-          </button>
-          {status.kind === 'analyzed' && (
-            <button
-              type="button"
-              aria-pressed={view === 'redline'}
-              onClick={() => setView('redline')}
-            >
-              {t('header.view.redline')}
-            </button>
-          )}
-        </div>
-      </header>
+      <AppHeader
+        view={view}
+        showRedlineToggle={status.kind === 'analyzed'}
+        onUpload={async (file) => {
+          await handleBytes(await readFileBytes(file), file.name);
+        }}
+        onTrySample={() => void onTrySample()}
+        onViewChange={(next) => setView(next)}
+      />
 
       {view === 'current' && status.kind === 'loading' && (
         <p role="status" aria-live="polite">

--- a/app/src/ui/AppHeader.test.tsx
+++ b/app/src/ui/AppHeader.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AppHeader } from './AppHeader';
+import { I18nProvider } from '../i18n/I18nProvider';
+
+function renderHeader(props: Partial<React.ComponentProps<typeof AppHeader>> = {}) {
+  const defaults: React.ComponentProps<typeof AppHeader> = {
+    view: 'current',
+    showRedlineToggle: false,
+    onUpload: vi.fn(),
+    onTrySample: vi.fn(),
+    onViewChange: vi.fn(),
+  };
+  return render(
+    <I18nProvider>
+      <AppHeader {...defaults} {...props} />
+    </I18nProvider>,
+  );
+}
+
+describe('AppHeader', () => {
+  it('renders title, upload control, sample-lease button, and view-mode toggle', () => {
+    renderHeader();
+    expect(screen.getByRole('heading', { name: /leaseguard/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/upload lease/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try a sample lease/i })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: /view mode/i })).toBeInTheDocument();
+  });
+
+  it('marks the active view-mode button with aria-pressed=true', () => {
+    renderHeader({ view: 'portfolio' });
+    expect(screen.getByRole('button', { name: /portfolio/i })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: /current lease/i })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+  });
+
+  it('hides the redline view-mode button until showRedlineToggle is true', () => {
+    const { rerender } = renderHeader({ showRedlineToggle: false });
+    expect(screen.queryByRole('button', { name: /redline/i })).toBeNull();
+    rerender(
+      <I18nProvider>
+        <AppHeader
+          view="current"
+          showRedlineToggle={true}
+          onUpload={vi.fn()}
+          onTrySample={vi.fn()}
+          onViewChange={vi.fn()}
+        />
+      </I18nProvider>,
+    );
+    expect(screen.getByRole('button', { name: /redline/i })).toBeInTheDocument();
+  });
+
+  it('fires onViewChange when a view-mode button is clicked', async () => {
+    const onViewChange = vi.fn();
+    renderHeader({ showRedlineToggle: true, onViewChange });
+    await userEvent.click(screen.getByRole('button', { name: /portfolio/i }));
+    expect(onViewChange).toHaveBeenCalledWith('portfolio');
+  });
+
+  it('fires onTrySample when the sample-lease button is clicked', async () => {
+    const onTrySample = vi.fn();
+    renderHeader({ onTrySample });
+    await userEvent.click(screen.getByRole('button', { name: /try a sample lease/i }));
+    expect(onTrySample).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onUpload with the selected file when a PDF is chosen', async () => {
+    const onUpload = vi.fn();
+    renderHeader({ onUpload });
+    const input = screen.getByLabelText(/upload lease/i) as HTMLInputElement;
+    const file = new File([new Uint8Array([1, 2, 3])], 'test.pdf', { type: 'application/pdf' });
+    await userEvent.upload(input, file);
+    expect(onUpload).toHaveBeenCalledTimes(1);
+    expect(onUpload.mock.calls[0]?.[0]).toBeInstanceOf(File);
+  });
+});

--- a/app/src/ui/AppHeader.tsx
+++ b/app/src/ui/AppHeader.tsx
@@ -1,0 +1,82 @@
+import { LocalePickerPanel } from './LocalePickerPanel';
+import { useI18n } from '../i18n/I18nContext';
+
+export type AppViewMode = 'current' | 'portfolio' | 'redline';
+
+interface AppHeaderProps {
+  view: AppViewMode;
+  showRedlineToggle: boolean;
+  onUpload: (file: File) => void | Promise<void>;
+  onTrySample: () => void;
+  onViewChange: (next: AppViewMode) => void;
+}
+
+export function AppHeader({
+  view,
+  showRedlineToggle,
+  onUpload,
+  onTrySample,
+  onViewChange,
+}: AppHeaderProps): JSX.Element {
+  const { t } = useI18n();
+  return (
+    <header>
+      <h1>{t('app.title')}</h1>
+      <p>{t('app.tagline')}</p>
+      <LocalePickerPanel />
+      <details className="privacy">
+        <summary>{t('header.privacy.summary')}</summary>
+        <ul>
+          <li>The PDF is parsed entirely in your browser via pdf.js.</li>
+          <li>All storage is in IndexedDB on this device. No account, no sync.</li>
+          <li>
+            A strict Content-Security-Policy (<code>default-src &apos;self&apos;</code>) blocks this
+            page from loading scripts, fonts, or data from any other origin.
+          </li>
+          <li>LeaseGuard is not legal advice. Findings are heuristic pattern matches.</li>
+        </ul>
+      </details>
+      <label>
+        <span className="visually-hidden">Upload lease</span>
+        <input
+          type="file"
+          accept="application/pdf"
+          aria-label="upload lease"
+          onChange={async (e) => {
+            const file = e.target.files?.[0];
+            if (!file) return;
+            await onUpload(file);
+          }}
+        />
+      </label>
+      <button type="button" onClick={onTrySample}>
+        {t('header.trySample')}
+      </button>
+      <div role="group" aria-label="view mode" className="view-toggle">
+        <button
+          type="button"
+          aria-pressed={view === 'current'}
+          onClick={() => onViewChange('current')}
+        >
+          {t('header.view.current')}
+        </button>
+        <button
+          type="button"
+          aria-pressed={view === 'portfolio'}
+          onClick={() => onViewChange('portfolio')}
+        >
+          {t('header.view.portfolio')}
+        </button>
+        {showRedlineToggle && (
+          <button
+            type="button"
+            aria-pressed={view === 'redline'}
+            onClick={() => onViewChange('redline')}
+          >
+            {t('header.view.redline')}
+          </button>
+        )}
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
Extracts the title / privacy-disclosure / upload / sample-lease / view-mode toggle block out of \`App.tsx\` into \`app/src/ui/AppHeader.tsx\`.

App.tsx: **1007 → 958 lines (−49)**.

## Cap-miss honesty (the plan said ≤850)
Second-extraction candidates evaluated:
- **Panel stack** (lines 746-925): would need a ~30-prop wrapper; violates "presentational, plain data + callbacks" contract.
- **Results block** (lines 582-744): tightly coupled to App state via 8+ closures; would need pre-extraction of derived-state hooks first.

Neither shaves enough lines for the cost-to-readability ratio. The remaining ~110-line drop rolls to **Wave 18** with a refined approach (derived-state hooks first, then JSX).

## Cap discipline
- 1 of ≤2 new sub-component files used.
- App.tsx 958 vs 850 cap → **miss documented; rolls to Wave 18.**
- Coverage thresholds held (S 96.77 / B 88.35 / F 93.33 / L 96.77, all above floors). NOT bumped per plan.
- Zero behavior changes.

## Test plan
- [x] \`npm run typecheck\` green.
- [x] \`npm run lint\` green.
- [x] \`npm run test:coverage\` — 145 test files / 1123 tests passing; thresholds intact.
- [x] 6 new tests in \`AppHeader.test.tsx\` pinning the prop contract.
- [x] \`App.test.tsx\` and \`App.panels.test.tsx\` pass unchanged (public selectors stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)