### PR TITLE
wave18-A: extract useDerivedAppState + <AppRedlinePane>

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { ChangeEvent } from 'react';
 import { usePipeline } from './App/usePipeline';
 import { usePackManager } from './App/usePackManager';
@@ -7,12 +7,12 @@ import { useRedlineState } from './App/useRedlineState';
 import { useVersionHistory } from './App/useVersionHistory';
 import { useSideLetter } from './App/useSideLetter';
 import { useCounterOffers } from './App/useCounterOffers';
+import { useDerivedAppState } from './App/useDerivedAppState';
 import { useSigningKey } from './App/useSigningKey';
 import { useReanalyzeOnRulesChange } from './App/useReanalyzeOnRulesChange';
 import {
   buildIcsBytes,
   clearAllFlow,
-  downloadBlob,
   downloadBlobBytes,
   downloadHandoffZip,
   exportEncryptedArchiveFlow,
@@ -21,7 +21,6 @@ import {
   friendlyError,
   importEncryptedArchiveFlow,
   readFileBytes,
-  stripPdfExt,
 } from './App/appHelpers';
 import { FindingsPanel } from './ui/FindingsPanel';
 import { loadGlossary, type GlossaryEntry } from './glossary/loadGlossary';
@@ -61,13 +60,10 @@ import { buildAuditLogJson, downloadAuditLogBlob } from './audit/auditExport';
 import { SigningKeyPanel } from './ui/SigningKeyPanel';
 import { AnnotationsPanel } from './ui/AnnotationsPanel';
 import { CounterOfferPanel } from './ui/CounterOfferPanel';
-import type { CounterOffer } from './negotiation/counterOffers';
 import { PortfolioPanel } from './ui/PortfolioPanel';
 import { paragraphShingles } from './portfolio/shingles';
 import { CustomRuleBuilderPanel } from './ui/CustomRuleBuilderPanel';
-import { RedlinePanel } from './ui/RedlinePanel';
-import { VersionHistoryPanel } from './ui/VersionHistoryPanel';
-import { SideLetterPanel } from './ui/SideLetterPanel';
+import { AppRedlinePane } from './ui/AppRedlinePane';
 import { needsOcr } from './compare/needsOcr';
 import { discoverOcrLanguages, type OcrLanguage } from './ocr/availableLanguages';
 import { OcrLanguagePickerPanel } from './ui/OcrLanguagePickerPanel';
@@ -251,29 +247,16 @@ function AppContent(): JSX.Element {
     severityOverrides: packs.severityOverrides,
   });
 
-  const plainEnglishByRuleId = useMemo<Record<string, string>>(() => {
-    const out: Record<string, string> = {};
-    for (const r of packs.activeRules) if (r.plainEnglish) out[r.id] = r.plainEnglish;
-    return out;
-  }, [packs.activeRules]);
-
-  const suggestedEditByRuleId = useMemo<Record<string, string>>(() => {
-    const out: Record<string, string> = {};
-    for (const r of packs.activeRules) if (r.suggestedEdit) out[r.id] = r.suggestedEdit;
-    return out;
-  }, [packs.activeRules]);
-
-  // User counter-offers override the rule's `suggestedEdit`. Most recent wins per rule.
-  const suggestedTextByRuleId = useMemo<Record<string, string>>(() => {
-    const out: Record<string, string> = { ...suggestedEditByRuleId };
-    const latestByRule = new Map<string, CounterOffer>();
-    for (const co of counters.counterOffers) {
-      const cur = latestByRule.get(co.ruleId);
-      if (!cur || co.updatedAt > cur.updatedAt) latestByRule.set(co.ruleId, co);
-    }
-    for (const [ruleId, co] of latestByRule) out[ruleId] = co.text;
-    return out;
-  }, [suggestedEditByRuleId, counters.counterOffers]);
+  const {
+    plainEnglishByRuleId,
+    suggestedEditByRuleId,
+    suggestedTextByRuleId,
+    sectionForParagraph,
+  } = useDerivedAppState({
+    activeRules: packs.activeRules,
+    counterOffers: counters.counterOffers,
+    doc: status.kind === 'analyzed' ? status.result.doc : null,
+  });
 
   useEffect(() => {
     void refreshLibrary();
@@ -417,22 +400,6 @@ function AppContent(): JSX.Element {
     downloadBlobBytes(ics.bytes, 'text/calendar', ics.filename);
   }
 
-  // Map a paragraph index to a section label, for side-letter clause headings.
-  const sectionForParagraph = useCallback(
-    (paragraphIndex: number): string | undefined => {
-      if (status.kind !== 'analyzed') return undefined;
-      const paragraph = status.result.doc.paragraphs[paragraphIndex];
-      if (!paragraph) return undefined;
-      for (const section of status.result.doc.sections) {
-        if (section.paragraphs.includes(paragraph)) {
-          return section.number ?? section.heading;
-        }
-      }
-      return undefined;
-    },
-    [status],
-  );
-
   return (
     <main>
       {onboardingDismissedAt !== undefined && (
@@ -487,96 +454,15 @@ function AppContent(): JSX.Element {
       )}
 
       {view === 'redline' && status.kind === 'analyzed' && (
-        <>
-          <RedlinePanel
-            doc={status.result.doc}
-            edits={redline.redlineEdits}
-            onEditParagraph={(pIdx, after) => {
-              const before =
-                status.kind === 'analyzed' ? (status.result.doc.paragraphs[pIdx]?.text ?? '') : '';
-              void redline.editParagraph({ paragraphIndex: pIdx, before, after });
-            }}
-            onDeleteEdit={(pIdx) => void redline.deleteParagraphEdit(pIdx)}
-            onExportHtml={() => {
-              if (status.kind !== 'analyzed') return;
-              downloadBlob(
-                redline.buildHtml({ leaseName: status.fileName, doc: status.result.doc }),
-                'text/html',
-                `${stripPdfExt(status.fileName)}-redline.html`,
-              );
-            }}
-          />
-          <details>
-            <summary>Version history</summary>
-            <VersionHistoryPanel
-              versions={versionHistory.versions}
-              currentEditCount={redline.redlineEdits.length}
-              onCreateVersion={(label, note) => void versionHistory.createVersion(label, note)}
-              onRestoreVersion={(vId) =>
-                void versionHistory.restoreVersion(vId, redline.replaceAll)
-              }
-              onDeleteVersion={(vId) => void versionHistory.removeVersion(vId)}
-              onExportVersion={(vId) => {
-                if (status.kind !== 'analyzed') return;
-                void versionHistory.exportVersion(vId, {
-                  leaseName: status.fileName,
-                  doc: status.result.doc,
-                });
-              }}
-            />
-          </details>
-          <SideLetterPanel
-            leaseName={status.fileName}
-            edits={redline.redlineEdits}
-            signerDraft={sideLetter.signerDraft}
-            previewHtml={sideLetter.previewHtml}
-            onSignerChange={(s) => sideLetter.setSignerDraft(s)}
-            onPreview={() => {
-              if (status.kind !== 'analyzed') return;
-              sideLetter.preview({
-                leaseName: status.fileName,
-                edits: redline.redlineEdits,
-                sectionFor: sectionForParagraph,
-              });
-            }}
-            onClosePreview={() => sideLetter.clearPreview()}
-            onDownload={() => {
-              if (status.kind !== 'analyzed') return;
-              sideLetter.download({
-                leaseName: status.fileName,
-                edits: redline.redlineEdits,
-                sectionFor: sectionForParagraph,
-              });
-              void safeAudit({
-                kind: 'export',
-                payload: {
-                  artifact: 'side-letter',
-                  format: 'html',
-                  leaseName: status.fileName,
-                },
-              });
-            }}
-            onDownloadPdf={() => {
-              if (status.kind !== 'analyzed') return;
-              void sideLetter
-                .downloadPdf({
-                  leaseName: status.fileName,
-                  edits: redline.redlineEdits,
-                  sectionFor: sectionForParagraph,
-                })
-                .then(() =>
-                  safeAudit({
-                    kind: 'export',
-                    payload: {
-                      artifact: 'side-letter',
-                      format: 'pdf',
-                      leaseName: status.fileName,
-                    },
-                  }),
-                );
-            }}
-          />
-        </>
+        <AppRedlinePane
+          doc={status.result.doc}
+          leaseName={status.fileName}
+          redline={redline}
+          versionHistory={versionHistory}
+          sideLetter={sideLetter}
+          sectionForParagraph={sectionForParagraph}
+          safeAudit={safeAudit}
+        />
       )}
 
       {view === 'current' && status.kind === 'analyzed' && (

--- a/app/src/App/useDerivedAppState.test.ts
+++ b/app/src/App/useDerivedAppState.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useDerivedAppState } from './useDerivedAppState';
+import type { Rule } from '../rules/types';
+import type { CounterOffer } from '../negotiation/counterOffers';
+import type { LeaseDocument } from '../parser/types';
+
+function rule(id: string, partial: Partial<Rule> = {}): Rule {
+  return {
+    id,
+    title: id,
+    severity: 'medium',
+    category: 'compliance',
+    matcher: { kind: 'regex', pattern: 'x' },
+    plainEnglish: undefined,
+    suggestedEdit: undefined,
+    ...partial,
+  } as Rule;
+}
+
+function offer(ruleId: string, text: string, updatedAt: number): CounterOffer {
+  return {
+    id: `${ruleId}-${updatedAt}`,
+    ruleId,
+    name: 'Counter',
+    text,
+    createdAt: updatedAt,
+    updatedAt,
+  };
+}
+
+describe('useDerivedAppState', () => {
+  it('builds plainEnglishByRuleId from rules that have plainEnglish set', () => {
+    const { result } = renderHook(() =>
+      useDerivedAppState({
+        activeRules: [
+          rule('a', { plainEnglish: 'A in plain words' }),
+          rule('b'), // no plainEnglish
+          rule('c', { plainEnglish: 'C in plain words' }),
+        ],
+        counterOffers: [],
+        doc: null,
+      }),
+    );
+    expect(result.current.plainEnglishByRuleId).toEqual({
+      a: 'A in plain words',
+      c: 'C in plain words',
+    });
+  });
+
+  it('suggestedTextByRuleId starts from rule.suggestedEdit and is overridden by latest counter-offer per rule', () => {
+    const { result } = renderHook(() =>
+      useDerivedAppState({
+        activeRules: [
+          rule('a', { suggestedEdit: 'pack edit for a' }),
+          rule('b', { suggestedEdit: 'pack edit for b' }),
+        ],
+        counterOffers: [
+          offer('a', 'older user edit', 1000),
+          offer('a', 'newer user edit', 2000),
+          // b has no counter-offer; falls back to pack
+        ],
+        doc: null,
+      }),
+    );
+    expect(result.current.suggestedTextByRuleId).toEqual({
+      a: 'newer user edit',
+      b: 'pack edit for b',
+    });
+  });
+
+  it('sectionForParagraph returns undefined when doc is null', () => {
+    const { result } = renderHook(() =>
+      useDerivedAppState({ activeRules: [], counterOffers: [], doc: null }),
+    );
+    expect(result.current.sectionForParagraph(0)).toBeUndefined();
+  });
+
+  it('sectionForParagraph returns the section number/heading for a paragraph in a section', () => {
+    const para0 = { text: 'Article body 1', page: 1 };
+    const para1 = { text: 'Article body 2', page: 1 };
+    const para2 = { text: 'Lone paragraph', page: 1 };
+    const doc: LeaseDocument = {
+      pages: [{ pageNumber: 1, width: 612, height: 792, items: [] }],
+      paragraphs: [para0, para1, para2],
+      sections: [{ number: '1', heading: 'Rent', startPage: 1, paragraphs: [para0, para1] }],
+      raw: '',
+    };
+    const { result } = renderHook(() =>
+      useDerivedAppState({ activeRules: [], counterOffers: [], doc }),
+    );
+    expect(result.current.sectionForParagraph(0)).toBe('1');
+    expect(result.current.sectionForParagraph(1)).toBe('1');
+    // Paragraph 2 is not in any section.
+    expect(result.current.sectionForParagraph(2)).toBeUndefined();
+    // Out-of-range index also returns undefined.
+    expect(result.current.sectionForParagraph(99)).toBeUndefined();
+  });
+
+  it('sectionForParagraph falls back to heading when section.number is missing', () => {
+    const para = { text: 'Body', page: 1 };
+    const doc: LeaseDocument = {
+      pages: [{ pageNumber: 1, width: 612, height: 792, items: [] }],
+      paragraphs: [para],
+      sections: [{ heading: 'Preamble', startPage: 1, paragraphs: [para] } as never],
+      raw: '',
+    };
+    const { result } = renderHook(() =>
+      useDerivedAppState({ activeRules: [], counterOffers: [], doc }),
+    );
+    expect(result.current.sectionForParagraph(0)).toBe('Preamble');
+  });
+});

--- a/app/src/App/useDerivedAppState.ts
+++ b/app/src/App/useDerivedAppState.ts
@@ -1,0 +1,83 @@
+import { useCallback, useMemo } from 'react';
+import type { Rule } from '../rules/types';
+import type { CounterOffer } from '../negotiation/counterOffers';
+import type { LeaseDocument } from '../parser/types';
+
+interface UseDerivedAppStateInputs {
+  activeRules: Rule[];
+  counterOffers: CounterOffer[];
+  /**
+   * The currently-loaded document, or null when no lease is analyzed.
+   * `sectionForParagraph` returns undefined for any paragraph index when
+   * this is null — matches App's pre-extraction behavior of returning
+   * undefined when `status.kind !== 'analyzed'`.
+   */
+  doc: LeaseDocument | null;
+}
+
+interface UseDerivedAppStateOutputs {
+  plainEnglishByRuleId: Record<string, string>;
+  suggestedEditByRuleId: Record<string, string>;
+  /**
+   * Suggested-text resolver: pack rule's `suggestedEdit` is the base,
+   * overridden by the user's most-recent counter-offer per rule.
+   */
+  suggestedTextByRuleId: Record<string, string>;
+  /**
+   * Map a paragraph index to its section label (number → heading
+   * fallback). Used for side-letter clause headings; returns undefined
+   * when no doc is loaded or the paragraph isn't in any section.
+   */
+  sectionForParagraph: (paragraphIndex: number) => string | undefined;
+}
+
+export function useDerivedAppState({
+  activeRules,
+  counterOffers,
+  doc,
+}: UseDerivedAppStateInputs): UseDerivedAppStateOutputs {
+  const plainEnglishByRuleId = useMemo<Record<string, string>>(() => {
+    const out: Record<string, string> = {};
+    for (const r of activeRules) if (r.plainEnglish) out[r.id] = r.plainEnglish;
+    return out;
+  }, [activeRules]);
+
+  const suggestedEditByRuleId = useMemo<Record<string, string>>(() => {
+    const out: Record<string, string> = {};
+    for (const r of activeRules) if (r.suggestedEdit) out[r.id] = r.suggestedEdit;
+    return out;
+  }, [activeRules]);
+
+  const suggestedTextByRuleId = useMemo<Record<string, string>>(() => {
+    const out: Record<string, string> = { ...suggestedEditByRuleId };
+    const latestByRule = new Map<string, CounterOffer>();
+    for (const co of counterOffers) {
+      const cur = latestByRule.get(co.ruleId);
+      if (!cur || co.updatedAt > cur.updatedAt) latestByRule.set(co.ruleId, co);
+    }
+    for (const [ruleId, co] of latestByRule) out[ruleId] = co.text;
+    return out;
+  }, [suggestedEditByRuleId, counterOffers]);
+
+  const sectionForParagraph = useCallback(
+    (paragraphIndex: number): string | undefined => {
+      if (!doc) return undefined;
+      const paragraph = doc.paragraphs[paragraphIndex];
+      if (!paragraph) return undefined;
+      for (const section of doc.sections) {
+        if (section.paragraphs.includes(paragraph)) {
+          return section.number ?? section.heading;
+        }
+      }
+      return undefined;
+    },
+    [doc],
+  );
+
+  return {
+    plainEnglishByRuleId,
+    suggestedEditByRuleId,
+    suggestedTextByRuleId,
+    sectionForParagraph,
+  };
+}

--- a/app/src/ui/AppRedlinePane.test.tsx
+++ b/app/src/ui/AppRedlinePane.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AppRedlinePane } from './AppRedlinePane';
+import type { LeaseDocument } from '../parser/types';
+import type { UseRedlineStateApi } from '../App/useRedlineState';
+import type { UseVersionHistoryApi } from '../App/useVersionHistory';
+import type { UseSideLetterApi } from '../App/useSideLetter';
+
+function makeDoc(): LeaseDocument {
+  return {
+    pages: [{ pageNumber: 1, width: 612, height: 792, items: [] }],
+    paragraphs: [{ text: 'Tenant shall pay rent.', page: 1 }],
+    sections: [],
+    raw: 'Tenant shall pay rent.',
+  };
+}
+
+function makeRedline(): UseRedlineStateApi {
+  return {
+    redlineEdits: [],
+    editParagraph: vi.fn(),
+    deleteParagraphEdit: vi.fn(),
+    buildHtml: vi.fn(() => '<html></html>'),
+    replaceAll: vi.fn(),
+    applySuggestion: vi.fn(),
+  } as unknown as UseRedlineStateApi;
+}
+
+function makeVersionHistory(): UseVersionHistoryApi {
+  return {
+    versions: [],
+    createVersion: vi.fn(),
+    restoreVersion: vi.fn(),
+    removeVersion: vi.fn(),
+    refresh: vi.fn(),
+    exportVersion: vi.fn(),
+    getVersionById: vi.fn(),
+  } as unknown as UseVersionHistoryApi;
+}
+
+function makeSideLetter(): UseSideLetterApi {
+  return {
+    signerDraft: { name: '', title: '' },
+    previewHtml: null,
+    setSignerDraft: vi.fn(),
+    preview: vi.fn(),
+    clearPreview: vi.fn(),
+    download: vi.fn(),
+    downloadPdf: vi.fn(() => Promise.resolve()),
+  } as unknown as UseSideLetterApi;
+}
+
+describe('AppRedlinePane', () => {
+  it('mounts the redline + version-history + side-letter panels', () => {
+    render(
+      <AppRedlinePane
+        doc={makeDoc()}
+        leaseName="lease.pdf"
+        redline={makeRedline()}
+        versionHistory={makeVersionHistory()}
+        sideLetter={makeSideLetter()}
+        sectionForParagraph={() => undefined}
+        safeAudit={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    expect(screen.getByRole('region', { name: /redline/i })).toBeInTheDocument();
+    expect(screen.getAllByText(/version history/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole('region', { name: /side letter/i })).toBeInTheDocument();
+  });
+
+  it('audits a side-letter HTML download with kind=export, format=html', async () => {
+    const safeAudit = vi.fn(() => Promise.resolve());
+    const sideLetter = makeSideLetter();
+    render(
+      <AppRedlinePane
+        doc={makeDoc()}
+        leaseName="lease.pdf"
+        redline={makeRedline()}
+        versionHistory={makeVersionHistory()}
+        sideLetter={sideLetter}
+        sectionForParagraph={() => undefined}
+        safeAudit={safeAudit}
+      />,
+    );
+    const downloadBtn = screen.getByRole('button', { name: /^download side letter html$/i });
+    await userEvent.click(downloadBtn);
+    expect(sideLetter.download).toHaveBeenCalledTimes(1);
+    expect(safeAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'export',
+        payload: expect.objectContaining({ artifact: 'side-letter', format: 'html' }),
+      }),
+    );
+  });
+});

--- a/app/src/ui/AppRedlinePane.tsx
+++ b/app/src/ui/AppRedlinePane.tsx
@@ -1,0 +1,102 @@
+import { RedlinePanel } from './RedlinePanel';
+import { VersionHistoryPanel } from './VersionHistoryPanel';
+import { SideLetterPanel } from './SideLetterPanel';
+import type { LeaseDocument } from '../parser/types';
+import type { UseRedlineStateApi } from '../App/useRedlineState';
+import type { UseVersionHistoryApi } from '../App/useVersionHistory';
+import type { UseSideLetterApi } from '../App/useSideLetter';
+import { downloadBlob, stripPdfExt } from '../App/appHelpers';
+
+interface AppRedlinePaneProps {
+  doc: LeaseDocument;
+  leaseName: string;
+  redline: UseRedlineStateApi;
+  versionHistory: UseVersionHistoryApi;
+  sideLetter: UseSideLetterApi;
+  sectionForParagraph: (paragraphIndex: number) => string | undefined;
+  safeAudit: (input: { kind: string; payload: Record<string, unknown> }) => Promise<void>;
+}
+
+export function AppRedlinePane({
+  doc,
+  leaseName,
+  redline,
+  versionHistory,
+  sideLetter,
+  sectionForParagraph,
+  safeAudit,
+}: AppRedlinePaneProps): JSX.Element {
+  return (
+    <>
+      <RedlinePanel
+        doc={doc}
+        edits={redline.redlineEdits}
+        onEditParagraph={(pIdx, after) => {
+          const before = doc.paragraphs[pIdx]?.text ?? '';
+          void redline.editParagraph({ paragraphIndex: pIdx, before, after });
+        }}
+        onDeleteEdit={(pIdx) => void redline.deleteParagraphEdit(pIdx)}
+        onExportHtml={() => {
+          downloadBlob(
+            redline.buildHtml({ leaseName, doc }),
+            'text/html',
+            `${stripPdfExt(leaseName)}-redline.html`,
+          );
+        }}
+      />
+      <details>
+        <summary>Version history</summary>
+        <VersionHistoryPanel
+          versions={versionHistory.versions}
+          currentEditCount={redline.redlineEdits.length}
+          onCreateVersion={(label, note) => void versionHistory.createVersion(label, note)}
+          onRestoreVersion={(vId) => void versionHistory.restoreVersion(vId, redline.replaceAll)}
+          onDeleteVersion={(vId) => void versionHistory.removeVersion(vId)}
+          onExportVersion={(vId) => {
+            void versionHistory.exportVersion(vId, { leaseName, doc });
+          }}
+        />
+      </details>
+      <SideLetterPanel
+        leaseName={leaseName}
+        edits={redline.redlineEdits}
+        signerDraft={sideLetter.signerDraft}
+        previewHtml={sideLetter.previewHtml}
+        onSignerChange={(s) => sideLetter.setSignerDraft(s)}
+        onPreview={() => {
+          sideLetter.preview({
+            leaseName,
+            edits: redline.redlineEdits,
+            sectionFor: sectionForParagraph,
+          });
+        }}
+        onClosePreview={() => sideLetter.clearPreview()}
+        onDownload={() => {
+          sideLetter.download({
+            leaseName,
+            edits: redline.redlineEdits,
+            sectionFor: sectionForParagraph,
+          });
+          void safeAudit({
+            kind: 'export',
+            payload: { artifact: 'side-letter', format: 'html', leaseName },
+          });
+        }}
+        onDownloadPdf={() => {
+          void sideLetter
+            .downloadPdf({
+              leaseName,
+              edits: redline.redlineEdits,
+              sectionFor: sectionForParagraph,
+            })
+            .then(() =>
+              safeAudit({
+                kind: 'export',
+                payload: { artifact: 'side-letter', format: 'pdf', leaseName },
+              }),
+            );
+        }}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
Two extractions from \`App.tsx\`:
1. **\`useDerivedAppState\`** (\`app/src/App/useDerivedAppState.ts\`) — pulls 4 derivations (\`plainEnglishByRuleId\`, \`suggestedEditByRuleId\`, \`suggestedTextByRuleId\`, \`sectionForParagraph\`) out of App's render body. **−29 lines**.
2. **\`<AppRedlinePane>\`** (\`app/src/ui/AppRedlinePane.tsx\`) — wraps the redline view's RedlinePanel + VersionHistoryPanel + SideLetterPanel triple. 7 props (the derived-state hook made the prop count manageable). **−83 lines**.

App.tsx: **958 → 844 lines (−114)**.

## Cap-miss honesty (cap was ≤820)
Miss by 24 lines. Adding a third file (e.g. \`<AppFooterControls>\`) would breach the **≤2 new files** cap that's also part of the contract. The remaining drop rolls to Wave 19 with the next sub-component (likely \`<AppFooterControls>\` + the long imperative callbacks lifted into a hook).

## Cap discipline
- 2 of ≤2 new files used ✓
- App.tsx 844 vs 820 cap → **miss documented; rolls to Wave 19**
- Coverage thresholds held (S 96.83 / B 88.66 / F 93.35 / L 96.83). NOT bumped per plan.
- Zero behavior changes; \`App.test.tsx\` + \`App.panels.test.tsx\` pass unchanged.

## Test plan
- [x] \`npm run typecheck\` green.
- [x] \`npm run lint\` green.
- [x] \`npm run test:coverage\` — 147 test files / 1130 tests passing; thresholds intact.
- [x] 5 new tests in \`useDerivedAppState.test.ts\`.
- [x] 2 new tests in \`AppRedlinePane.test.tsx\`.

## Note for Part C
Branches actual is **88.66%** post-A. Cap C requires ≥89.5% for the 88→89 floor bump (0.5% buffer rule). **Part C will SKIP** per the contingent contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)