### PR TITLE
wave18-B: multi-model Phase 18 measurement + recommendation

### DIFF
--- a/app/scripts/measure-llm-budget.mjs
+++ b/app/scripts/measure-llm-budget.mjs
@@ -6,28 +6,38 @@
  * small classification head can be bundled into the precache without
  * blowing the offline-correctness contract. The current Workbox
  * precache baseline is 17 entries / 11901 KiB (Tesseract eng.traineddata
- * dominates that). This script measures the marginal cost of dropping a
- * classification-capable transformers.js model alongside it.
+ * dominates that). This script measures the marginal cost of dropping
+ * each of N candidate transformers.js models alongside it.
  *
- * Why DistilBERT (Xenova/distilbert-base-uncased)?
- *  - transformers.js-compatible (ONNX quantized weights on the
- *    huggingface.co/Xenova org).
- *  - Encoder-only, classification-friendly. We do not need generative
- *    text from this layer, only paragraph-level risk classification.
- *  - The smallest "real BERT" baseline; if even this is too large the
- *    "on-device LLM" branch is a non-starter and Phase 18 should pivot
- *    to a hand-distilled head (fastText / linear-on-MiniLM-embeds).
+ * Wave 17-D measured DistilBERT (Xenova/distilbert-base-uncased) at
+ * 65 MiB — 5.6× the entire current precache. Wave 18-B extends the
+ * script to compare DistilBERT against two smaller candidates so the
+ * BACKLOG row can pick a default with real numbers, not vibes.
+ *
+ * Candidate justification:
+ *  - Xenova/distilbert-base-uncased (baseline) — Wave 17-D's
+ *    measurement; included for apples-to-apples comparison.
+ *  - Xenova/all-MiniLM-L6-v2 — sentence-embedding model used widely
+ *    for paragraph-level classification on top. ~22 MiB int8 expected.
+ *    Phase 18 would train a thin linear head on top of these embeds.
+ *  - Xenova/paraphrase-MiniLM-L3-v2 — 3-layer MiniLM (vs 6-layer L6).
+ *    ~16 MiB int8 expected. The "can we ship this with the lightest
+ *    precache hit" candidate. (bge-micro-v2 was the original third
+ *    candidate but the Xenova port returns 401; subbed in L3.)
  *
  * Usage:
- *   node app/scripts/measure-llm-budget.mjs
+ *   node app/scripts/measure-llm-budget.mjs                 # all candidates
+ *   node app/scripts/measure-llm-budget.mjs --only minilm   # one model
+ *   node app/scripts/measure-llm-budget.mjs --verbose       # print URLs
  *
- * Output: a summary table suitable for pasting into the BACKLOG row.
+ * Output: a per-model summary plus a comparison table at the end,
+ * suitable for pasting into the Phase 18 BACKLOG row.
  *
  * Non-goals:
- *  - This script does NOT add the model to app/public/, package.json,
+ *  - This script does NOT add any model to app/public/, package.json,
  *    or the build. It writes only to a temp directory and prints
- *    numbers. Ship the model in a follow-up wave once the budget gate
- *    is wired.
+ *    numbers. Ship the chosen model in a follow-up wave once the
+ *    budget gate is wired.
  */
 
 import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
@@ -35,19 +45,38 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { argv, exit } from 'node:process';
 
-const MODEL_REPO = 'Xenova/distilbert-base-uncased';
-const HF_BASE = `https://huggingface.co/${MODEL_REPO}/resolve/main`;
-
-// transformers.js convention: quantized model + tokenizer + configs.
-// These are the files transformers.js fetches at runtime when you
-// `await pipeline('feature-extraction', 'Xenova/distilbert-base-uncased')`.
-const FILES = [
+// transformers.js fetches these files at runtime when you load a
+// pipeline. The exact set varies per model; each candidate lists its
+// own. Files that 404 on a given repo are silently skipped (some models
+// don't ship a vocab.txt, some skip special_tokens_map.json, etc.).
+const COMMON_FILES = [
   { rel: 'onnx/model_quantized.onnx', kind: 'weights (int8 quantized)' },
   { rel: 'tokenizer.json', kind: 'tokenizer' },
   { rel: 'tokenizer_config.json', kind: 'tokenizer-config' },
   { rel: 'config.json', kind: 'model-config' },
   { rel: 'vocab.txt', kind: 'vocab' },
   { rel: 'special_tokens_map.json', kind: 'tokens-map' },
+];
+
+const CANDIDATES = [
+  {
+    id: 'distilbert',
+    repo: 'Xenova/distilbert-base-uncased',
+    note: 'Wave 17-D baseline; smallest "real BERT" encoder.',
+    files: COMMON_FILES,
+  },
+  {
+    id: 'minilm',
+    repo: 'Xenova/all-MiniLM-L6-v2',
+    note: 'Sentence-embedding; train a thin classification head on top.',
+    files: COMMON_FILES,
+  },
+  {
+    id: 'minilm-l3',
+    repo: 'Xenova/paraphrase-MiniLM-L3-v2',
+    note: '3-layer MiniLM; smallest viable English embedder on Xenova.',
+    files: COMMON_FILES,
+  },
 ];
 
 // Existing precache baseline reported by the Workbox manifest at the
@@ -64,10 +93,13 @@ function fmtBytes(n) {
   return `${n} B`;
 }
 
-async function downloadOne(tmp, file) {
-  const url = `${HF_BASE}/${file.rel}`;
+async function downloadOne(tmp, repoBase, file) {
+  const url = `${repoBase}/${file.rel}`;
   const dest = join(tmp, file.rel.replace(/\//g, '__'));
   const res = await fetch(url, { redirect: 'follow' });
+  if (res.status === 404) {
+    return { ...file, url, size: 0, missing: true };
+  }
   if (!res.ok) {
     throw new Error(`HTTP ${res.status} for ${url}`);
   }
@@ -77,25 +109,29 @@ async function downloadOne(tmp, file) {
   return { ...file, url, size };
 }
 
-async function main() {
-  const verbose = argv.includes('--verbose');
-  console.log(`[measure-llm-budget] target model: ${MODEL_REPO}`);
-  console.log(`[measure-llm-budget] base url:     ${HF_BASE}`);
-
-  const tmp = mkdtempSync(join(tmpdir(), 'leaseguard-llm-measure-'));
-  console.log(`[measure-llm-budget] tmp dir:      ${tmp}`);
+async function measureCandidate(candidate, opts) {
+  const repoBase = `https://huggingface.co/${candidate.repo}/resolve/main`;
+  const tmp = mkdtempSync(join(tmpdir(), `leaseguard-llm-measure-${candidate.id}-`));
+  console.log(`\n[${candidate.id}] ${candidate.repo}`);
+  console.log(`[${candidate.id}] ${candidate.note}`);
 
   const results = [];
   let totalBytes = 0;
   let failed = 0;
+  let countedFiles = 0;
 
-  for (const file of FILES) {
+  for (const file of candidate.files) {
     process.stdout.write(`  fetching ${file.rel} ... `);
     try {
-      const r = await downloadOne(tmp, file);
+      const r = await downloadOne(tmp, repoBase, file);
       results.push(r);
-      totalBytes += r.size;
-      console.log(fmtBytes(r.size));
+      if (r.missing) {
+        console.log('MISSING (404, skipped)');
+      } else {
+        totalBytes += r.size;
+        countedFiles += 1;
+        console.log(fmtBytes(r.size));
+      }
     } catch (err) {
       failed += 1;
       console.log(`FAILED (${err instanceof Error ? err.message : String(err)})`);
@@ -103,46 +139,85 @@ async function main() {
     }
   }
 
-  // Cleanup tmp dir — measurement only.
   try {
     rmSync(tmp, { recursive: true, force: true });
   } catch {
     /* best-effort */
   }
 
-  const totalKiB = totalBytes / KB;
-  const totalMiB = totalBytes / MB;
-  const newPrecacheKiB = BASELINE_PRECACHE_KIB + totalKiB;
-  const newEntries = BASELINE_PRECACHE_ENTRIES + FILES.length;
-  const deltaPct = (totalKiB / BASELINE_PRECACHE_KIB) * 100;
-
-  console.log('');
-  console.log('──────────────────────────────────────────────────────────────');
-  console.log(' Phase 18 — on-device LLM precache measurement');
-  console.log('──────────────────────────────────────────────────────────────');
-  console.log(` Model:                ${MODEL_REPO}`);
-  console.log(` Files measured:       ${FILES.length}`);
-  console.log(` Files downloaded:     ${FILES.length - failed}`);
-  console.log('');
-  console.log(' Per-file breakdown:');
-  for (const r of results) {
-    const pad = r.kind.padEnd(28, ' ');
-    const size = r.error ? `ERROR (${r.error})` : fmtBytes(r.size);
-    console.log(`   ${pad} ${size}`);
-    if (verbose && r.url) console.log(`     ${r.url}`);
+  if (opts.verbose) {
+    for (const r of results) {
+      if (r.url) console.log(`     ${r.url}`);
+    }
   }
-  console.log('');
-  console.log(` Total model bytes:    ${fmtBytes(totalBytes)}  (${totalKiB.toFixed(1)} KiB / ${totalMiB.toFixed(2)} MiB)`);
-  console.log('');
-  console.log(' Precache impact:');
-  console.log(`   Baseline (today):   ${BASELINE_PRECACHE_ENTRIES} entries / ${BASELINE_PRECACHE_KIB} KiB`);
-  console.log(`   Would-add delta:    +${FILES.length} entries / +${totalKiB.toFixed(1)} KiB`);
-  console.log(`   New total:          ${newEntries} entries / ${newPrecacheKiB.toFixed(1)} KiB`);
-  console.log(`   Delta as % of base: +${deltaPct.toFixed(1)}%`);
-  console.log('──────────────────────────────────────────────────────────────');
 
-  if (failed > 0) {
-    console.error(`\n[measure-llm-budget] ${failed} file(s) failed to download.`);
+  return {
+    id: candidate.id,
+    repo: candidate.repo,
+    note: candidate.note,
+    countedFiles,
+    failed,
+    totalBytes,
+    results,
+  };
+}
+
+function printComparison(measurements) {
+  console.log('');
+  console.log('═══════════════════════════════════════════════════════════════════');
+  console.log(' Phase 18 — on-device classifier candidate comparison');
+  console.log('═══════════════════════════════════════════════════════════════════');
+  console.log(
+    `   Baseline precache: ${BASELINE_PRECACHE_ENTRIES} entries / ${BASELINE_PRECACHE_KIB} KiB`,
+  );
+  console.log('');
+  // Header.
+  const header = ` ${'candidate'.padEnd(12)}  ${'files'.padEnd(6)}  ${'size'.padEnd(12)}  ${'+ delta %'.padEnd(11)}  repo`;
+  console.log(header);
+  console.log(' ' + '─'.repeat(header.length - 1));
+  for (const m of measurements) {
+    const totalKiB = m.totalBytes / KB;
+    const totalMiB = m.totalBytes / MB;
+    const deltaPct = (totalKiB / BASELINE_PRECACHE_KIB) * 100;
+    const idCol = m.id.padEnd(12);
+    const filesCol = `${m.countedFiles}`.padEnd(6);
+    const sizeCol = (totalBytes => {
+      if (totalBytes >= MB) return `${totalMiB.toFixed(2)} MiB`;
+      return `${totalKiB.toFixed(1)} KiB`;
+    })(m.totalBytes).padEnd(12);
+    const deltaCol = `+${deltaPct.toFixed(1)}%`.padEnd(11);
+    const fail = m.failed > 0 ? ` (${m.failed} fetches failed)` : '';
+    console.log(` ${idCol}  ${filesCol}  ${sizeCol}  ${deltaCol}  ${m.repo}${fail}`);
+  }
+  console.log('═══════════════════════════════════════════════════════════════════');
+}
+
+async function main() {
+  const verbose = argv.includes('--verbose');
+  const onlyIdx = argv.indexOf('--only');
+  const onlyId = onlyIdx >= 0 ? argv[onlyIdx + 1] : null;
+
+  const candidates = onlyId
+    ? CANDIDATES.filter((c) => c.id === onlyId)
+    : CANDIDATES;
+
+  if (candidates.length === 0) {
+    console.error(`No candidate matched --only=${onlyId}. Known ids: ${CANDIDATES.map((c) => c.id).join(', ')}`);
+    exit(2);
+  }
+
+  console.log(`[measure-llm-budget] candidates: ${candidates.map((c) => c.id).join(', ')}`);
+
+  const measurements = [];
+  for (const c of candidates) {
+    measurements.push(await measureCandidate(c, { verbose }));
+  }
+
+  printComparison(measurements);
+
+  const anyFailed = measurements.some((m) => m.failed > 0);
+  if (anyFailed) {
+    console.error('\n[measure-llm-budget] one or more candidates had fetch failures.');
     exit(2);
   }
 }

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -523,12 +523,28 @@ and the precache-cost tradeoff need empirical measurement first. See
       configs ~1 KiB combined; total +6 precache entries / +67045 KiB
       (~65.47 MiB). Against the existing 17-entry / 11901 KiB
       baseline that is a +563% precache delta — DistilBERT-quantized
-      alone is ~5.6x the entire current shell+OCR precache. Implication
-      for the budget gate: a ceiling like "OCR + classifier ≤ 80 MiB
-      precache" is achievable with this model, but anything tighter
-      (≤ 25 MiB combined) requires a smaller candidate (MiniLM-L6 ≈
-      22 MiB int8, fastText, or a hand-distilled head). Re-run the
-      script before locking the budget.
+      alone is ~5.6x the entire current shell+OCR precache.
+
+      **Compared 2026-04-25** (Wave 18-B, `--all` candidates):
+      | candidate                        | total size | + precache delta |
+      |----------------------------------|------------|------------------|
+      | Xenova/distilbert-base-uncased   | 65.47 MiB  | +563%            |
+      | Xenova/all-MiniLM-L6-v2          | 22.81 MiB  | +196%            |
+      | Xenova/paraphrase-MiniLM-L3-v2   | 17.54 MiB  | +151%            |
+
+      **Recommendation: `Xenova/paraphrase-MiniLM-L3-v2`** as the
+      Phase 18 default. ~17.5 MiB int8 is the smallest viable real
+      semantic embedder on the Xenova org (smaller HF candidates
+      `Xenova/bge-micro-v2` and `Xenova/gte-tiny` both return 401 —
+      not redistributed under the Xenova umbrella). The +151%
+      precache delta sets the next budget contract: "OCR + classifier
+      ≤ 30 MiB combined precache (1.5× current Tesseract baseline)."
+      Phase 18's hybrid `analyze()` path trains a thin linear
+      classification head on top of these embeddings, so the model
+      stays a pure embedder and the head ships as ~50 KiB of weights
+      bundled with the rules engine. Re-run the script before
+      locking the budget; HuggingFace file sizes drift across
+      releases.
 - [ ] **Hybrid `analyze()` path: regex/proximity first, LLM as
       tie-breaker** — extend `app/src/rules/analyze.ts` so paragraphs
       whose strongest matcher hit is below a confidence threshold


### PR DESCRIPTION
## Summary
Extends \`app/scripts/measure-llm-budget.mjs\` from single-model to a 3-candidate comparison with a summary table.

## Comparison (2026-04-25)
| candidate     | total size | + precache delta |
|---------------|------------|------------------|
| distilbert    | 65.47 MiB  | +563%            |
| minilm-l6     | 22.81 MiB  | +196%            |
| **minilm-l3** | **17.54 MiB** | **+151%**     |

(bge-micro-v2 was the plan's original third candidate; the Xenova port returns 401. Substituted with \`Xenova/paraphrase-MiniLM-L3-v2\` — same "smallest viable English embedder" role.)

## Recommendation
**\`Xenova/paraphrase-MiniLM-L3-v2\`** as the Phase 18 default. The +151% precache delta sets the next wave's integration budget: "OCR + classifier ≤ 30 MiB combined precache." The classification head ships as ~50 KiB of weights bundled with the rules engine; the model stays a pure embedder.

## Cap discipline
- 3 of ≤3 candidate models measured ✓
- 0 production-source edits ✓
- 1 BACKLOG row trailer added ✓
- No new npm dep; no model committed to \`app/public/\` ✓

## Test plan
- [x] \`node app/scripts/measure-llm-budget.mjs\` runs all 3 candidates to completion; exits 0.
- [x] \`npm run typecheck\` and \`npm run lint\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)