### PR TITLE
wave19-A: extract <AppFooterControls> + useAppCallbacks

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useState } from 'react';
-import type { ChangeEvent } from 'react';
 import { usePipeline } from './App/usePipeline';
 import { usePackManager } from './App/usePackManager';
 import { useAnnotations } from './App/useAnnotations';
@@ -18,8 +17,6 @@ import {
   exportEncryptedArchiveFlow,
   exportFindingsAsHtml,
   exportFindingsAsJson,
-  friendlyError,
-  importEncryptedArchiveFlow,
   readFileBytes,
 } from './App/appHelpers';
 import { FindingsPanel } from './ui/FindingsPanel';
@@ -72,9 +69,6 @@ import type { ClauseTemplate } from './templates/types';
 import { matchTemplates } from './templates/matchTemplates';
 import { saveTemplate, listTemplates, updateTemplate, deleteTemplate } from './storage/templates';
 import {
-  clearStandardId,
-  deleteLease,
-  getLease,
   getOnboardingDismissedAt,
   getStandardId,
   listAllLeaseRecords,
@@ -90,6 +84,8 @@ import { OnboardingTour } from './ui/OnboardingTour';
 import { I18nProvider } from './i18n/I18nProvider';
 import { useI18n } from './i18n/I18nContext';
 import { AppHeader } from './ui/AppHeader';
+import { AppFooterControls } from './ui/AppFooterControls';
+import { useAppCallbacks } from './App/useAppCallbacks';
 import { StandardSuitePanel } from './ui/StandardSuitePanel';
 import {
   deleteStandard,
@@ -306,76 +302,23 @@ function AppContent(): JSX.Element {
     return () => window.removeEventListener('keydown', onKeyDown);
   }, []);
 
-  async function handleBytes(bytes: Uint8Array, fileName: string): Promise<void> {
-    setSelected(null);
-    await safeAudit({ kind: 'analyze', payload: { fileName, phase: 'start' } });
-    await pipeline.upload(bytes, fileName);
-    await safeAudit({ kind: 'analyze', payload: { fileName, phase: 'complete' } });
-    void refreshAuditLog();
-  }
-
-  async function onTrySample(): Promise<void> {
-    try {
-      const res = await fetch('/sample.pdf');
-      if (!res.ok) throw new Error(`Could not load sample (${res.status})`);
-      const buf = await res.arrayBuffer();
-      await handleBytes(new Uint8Array(buf), 'Sample lease.pdf');
-    } catch (err) {
-      pipeline.setError(friendlyError(err));
-    }
-  }
-
-  async function onOpenLibrary(id: string): Promise<void> {
-    const record = await getLease(id);
-    if (!record) return;
-    setSelected(null);
-    pipeline.open(record);
-  }
-
-  async function onDeleteLibrary(id: string): Promise<void> {
-    await deleteLease(id);
-    if (standardId === id) await clearStandardId();
-    await safeAudit({ kind: 'delete-lease', payload: { leaseId: id } });
-    await refreshLibrary();
-    void refreshAuditLog();
-  }
-
-  async function onCompare(aId: string, bId: string): Promise<void> {
-    const [a, b] = await Promise.all([getLease(aId), getLease(bId)]);
-    if (!a || !b) return;
-    pipeline.setComparison({ a, b });
-  }
-
-  async function onImportArchiveFile(e: ChangeEvent<HTMLInputElement>): Promise<void> {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    e.target.value = '';
-    await importEncryptedArchiveFlow(file, {
-      onSuccess: async () => {
-        await refreshLibrary();
-        pipeline.reset();
-        setSelected(null);
-      },
-      onError: (msg) => pipeline.setError(msg),
-    });
-  }
-
-  async function onExportSignedJson(): Promise<void> {
-    if (status.kind !== 'analyzed') return;
-    const passphrase = window.prompt('Passphrase to unlock the signing key:');
-    if (!passphrase) return;
-    try {
-      await signingKey.signAndDownloadFindings({
-        fileName: status.fileName,
-        doc: status.result.doc,
-        findings: status.result.findings,
-        bytes: status.bytes,
-        passphrase,
-      });
-    } catch (err) {
-      pipeline.setError(`Signing failed: ${friendlyError(err)}`);
-    }
-  }
+  const {
+    handleBytes,
+    onTrySample,
+    onOpenLibrary,
+    onDeleteLibrary,
+    onCompare,
+    onImportArchiveFile,
+    onExportSignedJson,
+  } = useAppCallbacks({
+    pipeline,
+    signingKey,
+    safeAudit,
+    refreshAuditLog,
+    refreshLibrary,
+    setSelected,
+    standardId,
+  });
 
   function onExportJson(): void {
     if (status.kind !== 'analyzed') return;
@@ -809,36 +752,20 @@ function AppContent(): JSX.Element {
         />
       )}
 
-      <footer>
-        <button type="button" onClick={() => void exportEncryptedArchiveFlow()}>
-          {t('footer.archive.export')}
-        </button>
-        <label>
-          <span className="visually-hidden">Import encrypted archive</span>
-          Import encrypted archive:
-          <input
-            type="file"
-            accept=".lgarchive,application/octet-stream"
-            aria-label="import encrypted archive"
-            onChange={(e) => void onImportArchiveFile(e)}
-          />
-        </label>
-        <button
-          type="button"
-          onClick={() => {
-            void clearAllFlow({
-              onCleared: async () => {
-                await refreshLibrary();
-                await refreshTemplates();
-                pipeline.reset();
-                setSelected(null);
-              },
-            });
-          }}
-        >
-          {t('footer.clearAll')}
-        </button>
-      </footer>
+      <AppFooterControls
+        onExportArchive={() => void exportEncryptedArchiveFlow()}
+        onImportArchive={(e) => void onImportArchiveFile(e)}
+        onClearAll={() => {
+          void clearAllFlow({
+            onCleared: async () => {
+              await refreshLibrary();
+              await refreshTemplates();
+              pipeline.reset();
+              setSelected(null);
+            },
+          });
+        }}
+      />
     </main>
   );
 }

--- a/app/src/App/useAppCallbacks.test.ts
+++ b/app/src/App/useAppCallbacks.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useAppCallbacks } from './useAppCallbacks';
+import {
+  _resetDbForTests,
+  openLeaseDb,
+  saveLease,
+  setStandardId,
+  type LeaseRecord,
+} from '../storage/storage';
+
+function fakePipeline(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    status: { kind: 'idle' },
+    upload: vi.fn(async () => undefined),
+    open: vi.fn(),
+    setError: vi.fn(),
+    setComparison: vi.fn(),
+    reset: vi.fn(),
+    reanalyze: vi.fn(),
+    ocr: vi.fn(),
+    ocrState: { kind: 'idle' },
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+function fakeSigningKey(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    publicKey: null,
+    createKey: vi.fn(),
+    exportKeyToClipboard: vi.fn(),
+    signAndDownloadFindings: vi.fn(async () => undefined),
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+function makeDeps(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    pipeline: fakePipeline(),
+    signingKey: fakeSigningKey(),
+    safeAudit: vi.fn(async () => undefined),
+    refreshAuditLog: vi.fn(async () => undefined),
+    refreshLibrary: vi.fn(async () => undefined),
+    setSelected: vi.fn(),
+    standardId: null,
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+beforeEach(async () => {
+  try {
+    (await openLeaseDb()).close();
+  } catch {
+    /* ignore */
+  }
+  _resetDbForTests();
+  await new Promise<void>((r) => setTimeout(r, 0));
+  await new Promise<void>((resolve) => {
+    const req = indexedDB.deleteDatabase('leaseguard');
+    req.onsuccess = () => resolve();
+    req.onerror = () => resolve();
+    req.onblocked = () => resolve();
+  });
+});
+
+describe('useAppCallbacks', () => {
+  it('handleBytes bookends pipeline.upload with start/complete audit entries', async () => {
+    const deps = makeDeps();
+    const { result } = renderHook(() => useAppCallbacks(deps));
+    await act(async () => {
+      await result.current.handleBytes(new Uint8Array([1, 2]), 'lease.pdf');
+    });
+    expect(deps.setSelected).toHaveBeenCalledWith(null);
+    expect(deps.pipeline.upload).toHaveBeenCalledTimes(1);
+    expect(deps.safeAudit).toHaveBeenCalledTimes(2);
+    expect(deps.safeAudit.mock.calls[0]?.[0]).toEqual({
+      kind: 'analyze',
+      payload: { fileName: 'lease.pdf', phase: 'start' },
+    });
+    expect(deps.safeAudit.mock.calls[1]?.[0]).toEqual({
+      kind: 'analyze',
+      payload: { fileName: 'lease.pdf', phase: 'complete' },
+    });
+  });
+
+  it('onDeleteLibrary clears the standard pointer when the deleted lease was the standard', async () => {
+    const id = await saveLease({
+      name: 'Std.pdf',
+      doc: { pages: [], paragraphs: [], sections: [], raw: '' },
+      findings: [],
+    });
+    await setStandardId(id);
+
+    const deps = makeDeps({ standardId: id });
+    const { result } = renderHook(() => useAppCallbacks(deps));
+    await act(async () => {
+      await result.current.onDeleteLibrary(id);
+    });
+    expect(deps.safeAudit).toHaveBeenCalledWith(expect.objectContaining({ kind: 'delete-lease' }));
+    expect(deps.refreshLibrary).toHaveBeenCalledTimes(1);
+  });
+
+  it('onCompare no-ops when one of the lease ids does not exist', async () => {
+    const id = await saveLease({
+      name: 'Real.pdf',
+      doc: { pages: [], paragraphs: [], sections: [], raw: '' },
+      findings: [],
+    });
+
+    const deps = makeDeps();
+    const { result } = renderHook(() => useAppCallbacks(deps));
+    await act(async () => {
+      await result.current.onCompare(id, 'does-not-exist');
+    });
+    expect(deps.pipeline.setComparison).not.toHaveBeenCalled();
+  });
+
+  it('onCompare hands a {a, b} pair to pipeline.setComparison when both exist', async () => {
+    const a = await saveLease({
+      name: 'A.pdf',
+      doc: { pages: [], paragraphs: [], sections: [], raw: '' },
+      findings: [],
+    });
+    const b = await saveLease({
+      name: 'B.pdf',
+      doc: { pages: [], paragraphs: [], sections: [], raw: '' },
+      findings: [],
+    });
+
+    const deps = makeDeps();
+    const { result } = renderHook(() => useAppCallbacks(deps));
+    await act(async () => {
+      await result.current.onCompare(a, b);
+    });
+    expect(deps.pipeline.setComparison).toHaveBeenCalledTimes(1);
+    const call = deps.pipeline.setComparison.mock.calls[0]?.[0] as
+      | { a: LeaseRecord; b: LeaseRecord }
+      | undefined;
+    expect(call?.a.name).toBe('A.pdf');
+    expect(call?.b.name).toBe('B.pdf');
+  });
+
+  it('onTrySample surfaces fetch failures via pipeline.setError', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('nope', { status: 404 }));
+    const deps = makeDeps();
+    const { result } = renderHook(() => useAppCallbacks(deps));
+    await act(async () => {
+      await result.current.onTrySample();
+    });
+    expect(deps.pipeline.setError).toHaveBeenCalledWith(
+      expect.stringMatching(/Could not load sample/),
+    );
+    fetchSpy.mockRestore();
+  });
+
+  it('onExportSignedJson is a no-op when status.kind is not analyzed', async () => {
+    const deps = makeDeps();
+    const { result } = renderHook(() => useAppCallbacks(deps));
+    await act(async () => {
+      await result.current.onExportSignedJson();
+    });
+    expect(deps.signingKey.signAndDownloadFindings).not.toHaveBeenCalled();
+  });
+
+  it('onExportSignedJson is a no-op when the user cancels the passphrase prompt', async () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue(null);
+    const deps = makeDeps({
+      pipeline: fakePipeline({
+        status: {
+          kind: 'analyzed',
+          fileName: 'L.pdf',
+          result: {
+            doc: { pages: [], paragraphs: [], sections: [], raw: '' },
+            findings: [],
+          },
+          bytes: null,
+        },
+      }),
+    });
+    const { result } = renderHook(() => useAppCallbacks(deps));
+    await act(async () => {
+      await result.current.onExportSignedJson();
+    });
+    expect(deps.signingKey.signAndDownloadFindings).not.toHaveBeenCalled();
+    promptSpy.mockRestore();
+  });
+});

--- a/app/src/App/useAppCallbacks.ts
+++ b/app/src/App/useAppCallbacks.ts
@@ -1,0 +1,142 @@
+import { useCallback } from 'react';
+import type { ChangeEvent } from 'react';
+import type { PipelineApi } from './usePipeline';
+import type { UseSigningKeyApi } from './useSigningKey';
+import { clearStandardId, deleteLease, getLease, type LeaseRecord } from '../storage/storage';
+import { friendlyError, importEncryptedArchiveFlow } from './appHelpers';
+
+interface AuditEntry {
+  kind: string;
+  payload: Record<string, unknown>;
+}
+
+interface UseAppCallbacksDeps {
+  pipeline: PipelineApi;
+  signingKey: UseSigningKeyApi;
+  safeAudit: (entry: AuditEntry) => Promise<void>;
+  refreshAuditLog: () => Promise<void> | void;
+  refreshLibrary: () => Promise<void>;
+  setSelected: (selected: null) => void;
+  /** The currently-saved standard lease id, if any. Used by `onDelete` to
+   *  clear the pointer when the standard itself is being deleted. */
+  standardId: string | null;
+}
+
+export interface UseAppCallbacksApi {
+  handleBytes: (bytes: Uint8Array, fileName: string) => Promise<void>;
+  onTrySample: () => Promise<void>;
+  onOpenLibrary: (id: string) => Promise<void>;
+  onDeleteLibrary: (id: string) => Promise<void>;
+  onCompare: (aId: string, bId: string) => Promise<void>;
+  onImportArchiveFile: (e: ChangeEvent<HTMLInputElement>) => Promise<void>;
+  onExportSignedJson: () => Promise<void>;
+}
+
+export function useAppCallbacks(deps: UseAppCallbacksDeps): UseAppCallbacksApi {
+  const {
+    pipeline,
+    signingKey,
+    safeAudit,
+    refreshAuditLog,
+    refreshLibrary,
+    setSelected,
+    standardId,
+  } = deps;
+
+  const handleBytes = useCallback(
+    async (bytes: Uint8Array, fileName: string): Promise<void> => {
+      setSelected(null);
+      await safeAudit({ kind: 'analyze', payload: { fileName, phase: 'start' } });
+      await pipeline.upload(bytes, fileName);
+      await safeAudit({ kind: 'analyze', payload: { fileName, phase: 'complete' } });
+      void refreshAuditLog();
+    },
+    [pipeline, safeAudit, refreshAuditLog, setSelected],
+  );
+
+  const onTrySample = useCallback(async (): Promise<void> => {
+    try {
+      const res = await fetch('/sample.pdf');
+      if (!res.ok) throw new Error(`Could not load sample (${res.status})`);
+      const buf = await res.arrayBuffer();
+      await handleBytes(new Uint8Array(buf), 'Sample lease.pdf');
+    } catch (err) {
+      pipeline.setError(friendlyError(err));
+    }
+  }, [handleBytes, pipeline]);
+
+  const onOpenLibrary = useCallback(
+    async (id: string): Promise<void> => {
+      const record: LeaseRecord | undefined = await getLease(id);
+      if (!record) return;
+      setSelected(null);
+      pipeline.open(record);
+    },
+    [pipeline, setSelected],
+  );
+
+  const onDeleteLibrary = useCallback(
+    async (id: string): Promise<void> => {
+      await deleteLease(id);
+      if (standardId === id) await clearStandardId();
+      await safeAudit({ kind: 'delete-lease', payload: { leaseId: id } });
+      await refreshLibrary();
+      void refreshAuditLog();
+    },
+    [standardId, safeAudit, refreshLibrary, refreshAuditLog],
+  );
+
+  const onCompare = useCallback(
+    async (aId: string, bId: string): Promise<void> => {
+      const [a, b] = await Promise.all([getLease(aId), getLease(bId)]);
+      if (!a || !b) return;
+      pipeline.setComparison({ a, b });
+    },
+    [pipeline],
+  );
+
+  const onImportArchiveFile = useCallback(
+    async (e: ChangeEvent<HTMLInputElement>): Promise<void> => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      e.target.value = '';
+      await importEncryptedArchiveFlow(file, {
+        onSuccess: async () => {
+          await refreshLibrary();
+          pipeline.reset();
+          setSelected(null);
+        },
+        onError: (msg) => pipeline.setError(msg),
+      });
+    },
+    [pipeline, refreshLibrary, setSelected],
+  );
+
+  const onExportSignedJson = useCallback(async (): Promise<void> => {
+    const status = pipeline.status;
+    if (status.kind !== 'analyzed') return;
+    const passphrase = window.prompt('Passphrase to unlock the signing key:');
+    if (!passphrase) return;
+    try {
+      await signingKey.signAndDownloadFindings({
+        fileName: status.fileName,
+        doc: status.result.doc,
+        findings: status.result.findings,
+        bytes: status.bytes,
+        passphrase,
+      });
+    } catch (err) {
+      pipeline.setError(`Signing failed: ${friendlyError(err)}`);
+    }
+  }, [pipeline, signingKey]);
+
+  return {
+    handleBytes,
+    onTrySample,
+    onOpenLibrary,
+    onDeleteLibrary,
+    onCompare,
+    onImportArchiveFile,
+    onExportSignedJson,
+  };
+}

--- a/app/src/ui/AppFooterControls.test.tsx
+++ b/app/src/ui/AppFooterControls.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AppFooterControls } from './AppFooterControls';
+import { I18nProvider } from '../i18n/I18nProvider';
+
+function renderFooter(props: Partial<React.ComponentProps<typeof AppFooterControls>> = {}) {
+  const defaults: React.ComponentProps<typeof AppFooterControls> = {
+    onExportArchive: vi.fn(),
+    onImportArchive: vi.fn(),
+    onClearAll: vi.fn(),
+  };
+  return render(
+    <I18nProvider>
+      <AppFooterControls {...defaults} {...props} />
+    </I18nProvider>,
+  );
+}
+
+describe('AppFooterControls', () => {
+  it('renders the three controls (export, import file input, clear)', () => {
+    renderFooter();
+    expect(screen.getByLabelText(/import encrypted archive/i)).toBeInTheDocument();
+    // Two buttons: export archive + clear all. Their labels come from i18n.
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+  });
+
+  it('fires onExportArchive when the export button is clicked', async () => {
+    const onExportArchive = vi.fn();
+    renderFooter({ onExportArchive });
+    const buttons = screen.getAllByRole('button');
+    await userEvent.click(buttons[0]!);
+    expect(onExportArchive).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onClearAll when the clear button is clicked', async () => {
+    const onClearAll = vi.fn();
+    renderFooter({ onClearAll });
+    const buttons = screen.getAllByRole('button');
+    // Second button is clear-all per render order.
+    await userEvent.click(buttons[1]!);
+    expect(onClearAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onImportArchive with the selected file', async () => {
+    const onImportArchive = vi.fn();
+    renderFooter({ onImportArchive });
+    const input = screen.getByLabelText(/import encrypted archive/i) as HTMLInputElement;
+    const file = new File([new Uint8Array([0])], 'a.lgarchive', {
+      type: 'application/octet-stream',
+    });
+    await userEvent.upload(input, file);
+    expect(onImportArchive).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/ui/AppFooterControls.tsx
+++ b/app/src/ui/AppFooterControls.tsx
@@ -1,0 +1,36 @@
+import type { ChangeEvent } from 'react';
+import { useI18n } from '../i18n/I18nContext';
+
+interface AppFooterControlsProps {
+  onExportArchive: () => void | Promise<void>;
+  onImportArchive: (e: ChangeEvent<HTMLInputElement>) => void | Promise<void>;
+  onClearAll: () => void;
+}
+
+export function AppFooterControls({
+  onExportArchive,
+  onImportArchive,
+  onClearAll,
+}: AppFooterControlsProps): JSX.Element {
+  const { t } = useI18n();
+  return (
+    <footer>
+      <button type="button" onClick={() => void onExportArchive()}>
+        {t('footer.archive.export')}
+      </button>
+      <label>
+        <span className="visually-hidden">Import encrypted archive</span>
+        Import encrypted archive:
+        <input
+          type="file"
+          accept=".lgarchive,application/octet-stream"
+          aria-label="import encrypted archive"
+          onChange={(e) => void onImportArchive(e)}
+        />
+      </label>
+      <button type="button" onClick={onClearAll}>
+        {t('footer.clearAll')}
+      </button>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
Two more extractions from \`App.tsx\`:
1. **\`<AppFooterControls>\`** (\`app/src/ui/AppFooterControls.tsx\`) — wraps the encrypted-archive export/import + clear-all \`<footer>\` block. 3 callback props. **−15 lines**.
2. **\`useAppCallbacks\`** (\`app/src/App/useAppCallbacks.ts\`) — lifts seven imperative callbacks (\`handleBytes\`, \`onTrySample\`, \`onOpenLibrary\`, \`onDeleteLibrary\`, \`onCompare\`, \`onImportArchiveFile\`, \`onExportSignedJson\`) out of App's render body. **−58 more lines**.

App.tsx: **844 → 771 lines (−73)**.

## Cap miss
Cap was ≤740. Miss by 31 lines. Both file slots (≤2) used. The remaining drop rolls to Wave 20 (\`<AppCurrentPane>\` is the obvious next target but needs more state lifting first).

## Note for Part B
Branches actual: **88.62%** post-A, slightly DOWN from 88.66% pre-A. New code added defensive branches faster than tests covered them. Part B requires ≥89.5% buffer — **Part B will SKIP** per the contingent contract; the bump rolls to Wave 20+.

## Cap discipline
- 2 of ≤2 new files used ✓
- Coverage thresholds held (S 96.81 / B 88.62 / F 93.32 / L 96.81) ✓
- Zero behavior changes; existing tests pass unchanged ✓

## Test plan
- [x] \`npm run typecheck\` green.
- [x] \`npm run lint\` green.
- [x] \`npm run test:coverage\` — 149 test files / 1141 tests passing; thresholds intact.
- [x] 4 new tests in \`AppFooterControls.test.tsx\`; 7 new tests in \`useAppCallbacks.test.ts\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)