### PR TITLE
wave20-B: extract <AppCurrentPane> from App.tsx

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -13,24 +13,15 @@ import {
   buildIcsBytes,
   clearAllFlow,
   downloadBlobBytes,
-  downloadHandoffZip,
   exportEncryptedArchiveFlow,
-  exportFindingsAsHtml,
   exportFindingsAsJson,
   readFileBytes,
 } from './App/appHelpers';
-import { FindingsPanel } from './ui/FindingsPanel';
 import { loadGlossary, type GlossaryEntry } from './glossary/loadGlossary';
 import { LibraryPanel } from './ui/LibraryPanel';
-import { PdfViewer } from './ui/PdfViewer';
 import { ComparePanel } from './ui/ComparePanel';
 import { LibraryCompareForm } from './ui/LibraryCompareForm';
 import { TemplatesPanel } from './ui/TemplatesPanel';
-import { TemplateMatchesPanel } from './ui/TemplateMatchesPanel';
-import { LeaseFactsPanel } from './ui/LeaseFactsPanel';
-import { extractLeaseFacts } from './facts/extractFacts';
-import { WorkflowPanel } from './ui/WorkflowPanel';
-import { buildSummary, copyToClipboard } from './workflow/copySummary';
 import { PackManagerPanel } from './ui/PackManagerPanel';
 import { loadCuratedManifest, type CuratedPackEntry } from './rules/curatedPacks';
 import { validatePackFile } from './rules/packSchema';
@@ -55,18 +46,13 @@ import {
 } from './audit/auditLog';
 import { buildAuditLogJson, downloadAuditLogBlob } from './audit/auditExport';
 import { SigningKeyPanel } from './ui/SigningKeyPanel';
-import { AnnotationsPanel } from './ui/AnnotationsPanel';
-import { CounterOfferPanel } from './ui/CounterOfferPanel';
 import { PortfolioPanel } from './ui/PortfolioPanel';
 import { paragraphShingles } from './portfolio/shingles';
 import { CustomRuleBuilderPanel } from './ui/CustomRuleBuilderPanel';
 import { AppRedlinePane } from './ui/AppRedlinePane';
-import { needsOcr } from './compare/needsOcr';
 import { discoverOcrLanguages, type OcrLanguage } from './ocr/availableLanguages';
-import { OcrLanguagePickerPanel } from './ui/OcrLanguagePickerPanel';
 import type { Finding } from './rules/types';
 import type { ClauseTemplate } from './templates/types';
-import { matchTemplates } from './templates/matchTemplates';
 import { saveTemplate, listTemplates, updateTemplate, deleteTemplate } from './storage/templates';
 import {
   getOnboardingDismissedAt,
@@ -82,9 +68,9 @@ import {
 } from './storage/storage';
 import { OnboardingTour } from './ui/OnboardingTour';
 import { I18nProvider } from './i18n/I18nProvider';
-import { useI18n } from './i18n/I18nContext';
 import { AppHeader } from './ui/AppHeader';
 import { AppFooterControls } from './ui/AppFooterControls';
+import { AppCurrentPane } from './ui/AppCurrentPane';
 import { useAppCallbacks } from './App/useAppCallbacks';
 import { StandardSuitePanel } from './ui/StandardSuitePanel';
 import {
@@ -122,7 +108,6 @@ export function App(): JSX.Element {
 }
 
 function AppContent(): JSX.Element {
-  const { t } = useI18n();
   const [selected, setSelected] = useState<Finding | null>(null);
   const [library, setLibrary] = useState<LeaseMetadata[]>([]);
   const [selectedPage, setSelectedPage] = useState<number | null>(null);
@@ -409,167 +394,50 @@ function AppContent(): JSX.Element {
       )}
 
       {view === 'current' && status.kind === 'analyzed' && (
-        <div className="results">
-          <div className="results-actions">
-            <button type="button" onClick={onExportJson}>
-              {t('findings.export.json')}
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                if (status.kind !== 'analyzed') return;
-                exportFindingsAsHtml({
-                  fileName: status.fileName,
-                  doc: status.result.doc,
-                  findings: status.result.findings,
-                });
-              }}
-            >
-              {t('findings.export.html')}
-            </button>
-            {signingKey.publicKey !== null && (
-              <button type="button" onClick={() => void onExportSignedJson()}>
-                {t('findings.export.signed')}
-              </button>
-            )}
-          </div>
-          {(() => {
-            const ocr = needsOcr(status.result.doc);
-            if (!ocr.likelyScanned) return null;
-            return (
-              <div role="status" className="ocr-banner">
-                <p>
-                  This PDF looks scanned (avg {Math.round(ocr.avgCharsPerPage)} chars/page). Text
-                  extraction may be incomplete.
-                </p>
-                {status.bytes && ocrState.kind !== 'running' && (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setSelected(null);
-                      void pipeline.ocr(ocrLanguage);
-                    }}
-                  >
-                    Attempt OCR
-                  </button>
-                )}
-                <OcrLanguagePickerPanel
-                  available={ocrLanguages}
-                  selected={ocrLanguage}
-                  onChange={setOcrLanguage}
-                />
-                {ocrState.kind === 'running' && (
-                  <p aria-live="polite" className="ocr-progress">
-                    Running OCR: {ocrState.stage} ({Math.round(ocrState.pct * 100)}%)
-                  </p>
-                )}
-                {ocrState.kind === 'error' && <p role="alert">OCR failed: {ocrState.message}</p>}
-              </div>
-            );
-          })()}
-          <div className="split">
-            <FindingsPanel
-              findings={status.result.findings}
-              onSelect={(f) => {
-                setSelected(f);
-                setSelectedPage(f.page);
-              }}
-              definitions={extractLeaseFacts(status.result.doc).definitions}
-              glossary={glossaryEntries}
-              plainEnglishByRuleId={plainEnglishByRuleId}
-              suggestedTextByRuleId={suggestedTextByRuleId}
-              onApplySuggestion={(f, pIdx, text) => {
-                if (status.kind !== 'analyzed' || !status.leaseId) return;
-                void redline
-                  .applySuggestion({
-                    finding: f,
-                    paragraphIndex: pIdx,
-                    suggestedText: text,
-                    doc: status.result.doc,
-                  })
-                  .then(() => setView('redline'));
-              }}
-              onPromoteToStandard={(leaseId, paragraphIndex) => {
-                if (status.kind !== 'analyzed') return;
-                void (async (): Promise<void> => {
-                  const text = status.result.doc.paragraphs[paragraphIndex]?.text ?? '';
-                  const name = text.slice(0, 60).trim() || `Clause from ${leaseId}`;
-                  await promoteToStandard({
-                    name,
-                    sourceLeaseId: leaseId,
-                    sourceParagraphIndex: paragraphIndex,
-                    normalizedText: text,
-                  });
-                  await refreshStandardSuite();
-                  void refreshAuditLog();
-                })();
-              }}
-            />
-            <PdfViewer
-              bytes={status.bytes}
-              pageCount={status.result.doc.pages.length}
-              selectedPage={selectedPage}
-              pages={status.result.doc.pages}
-              highlight={
-                selected
-                  ? (status.result.doc.paragraphs[selected.paragraphIndex]?.bbox ?? null)
-                  : null
-              }
-            />
-          </div>
-          {selected && (
-            <article aria-label="selected finding">
-              <h3>{selected.title}</h3>
-              <p>{selected.explanation}</p>
-              <blockquote>{selected.snippet}</blockquote>
-              <small>Page {selected.page}</small>
-            </article>
-          )}
-          <AnnotationsPanel
-            leaseId={analyzedLeaseId ?? ''}
-            paragraphIndex={selected ? selected.paragraphIndex : null}
-            annotations={annotationsApi.annotations}
-            onSave={(text) => {
-              if (!analyzedLeaseId || selected === null) return;
-              void annotationsApi.save({
-                leaseId: analyzedLeaseId,
-                paragraphIndex: selected.paragraphIndex,
-                text,
+        <AppCurrentPane
+          status={status}
+          selected={selected}
+          selectedPage={selectedPage}
+          setSelected={setSelected}
+          setSelectedPage={setSelectedPage}
+          ocrState={ocrState}
+          ocrLanguage={ocrLanguage}
+          setOcrLanguage={setOcrLanguage}
+          ocrLanguages={ocrLanguages}
+          hasSigningKey={signingKey.publicKey !== null}
+          glossaryEntries={glossaryEntries}
+          templates={templates}
+          plainEnglishByRuleId={plainEnglishByRuleId}
+          suggestedTextByRuleId={suggestedTextByRuleId}
+          suggestedEditByRuleId={suggestedEditByRuleId}
+          redline={redline}
+          counters={counters}
+          annotationsApi={annotationsApi}
+          analyzedLeaseId={analyzedLeaseId}
+          onExportJson={onExportJson}
+          onExportSignedJson={() => void onExportSignedJson()}
+          onBuildIcs={onBuildIcs}
+          onAttemptOcr={() => {
+            setSelected(null);
+            void pipeline.ocr(ocrLanguage);
+          }}
+          onPromoteToStandard={(leaseId, paragraphIndex) => {
+            if (status.kind !== 'analyzed') return;
+            void (async (): Promise<void> => {
+              const text = status.result.doc.paragraphs[paragraphIndex]?.text ?? '';
+              const name = text.slice(0, 60).trim() || `Clause from ${leaseId}`;
+              await promoteToStandard({
+                name,
+                sourceLeaseId: leaseId,
+                sourceParagraphIndex: paragraphIndex,
+                normalizedText: text,
               });
-            }}
-            onUpdate={(id, text) => void annotationsApi.update(id, text)}
-            onDelete={(id) => void annotationsApi.remove(id)}
-          />
-          <CounterOfferPanel
-            finding={selected}
-            counters={counters.counterOffers}
-            onSave={(ruleId, name, text) => void counters.save(ruleId, name, text)}
-            onDelete={(id) => void counters.remove(id)}
-            suggestedEdit={selected ? suggestedEditByRuleId[selected.ruleId] : undefined}
-          />
-          <TemplateMatchesPanel matches={matchTemplates(templates, status.result.doc)} />
-          <LeaseFactsPanel facts={extractLeaseFacts(status.result.doc)} />
-          <WorkflowPanel
-            leaseName={status.fileName}
-            findings={status.result.findings}
-            onBuildIcs={onBuildIcs}
-            onCopySummary={async () => {
-              if (status.kind !== 'analyzed') return;
-              await copyToClipboard(
-                buildSummary({ leaseName: status.fileName, findings: status.result.findings }),
-              );
-            }}
-            onDownloadHandoff={() => {
-              if (status.kind !== 'analyzed') return;
-              downloadHandoffZip({
-                fileName: status.fileName,
-                doc: status.result.doc,
-                findings: status.result.findings,
-                bytes: status.bytes,
-              });
-            }}
-          />
-        </div>
+              await refreshStandardSuite();
+              void refreshAuditLog();
+            })();
+          }}
+          setView={setView}
+        />
       )}
 
       <LibraryPanel

--- a/app/src/ui/AppCurrentPane.test.tsx
+++ b/app/src/ui/AppCurrentPane.test.tsx
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AppCurrentPane } from './AppCurrentPane';
+import { I18nProvider } from '../i18n/I18nProvider';
+import type { LeaseDocument } from '../parser/types';
+import type { Finding } from '../rules/types';
+
+function makeDoc(): LeaseDocument {
+  return {
+    pages: [{ pageNumber: 1, width: 612, height: 792, items: [] }],
+    paragraphs: [{ text: 'Tenant shall pay rent.', page: 1 }],
+    sections: [],
+    raw: 'Tenant shall pay rent.',
+  };
+}
+
+function makeStatus() {
+  return {
+    kind: 'analyzed' as const,
+    fileName: 'lease.pdf',
+    bytes: null,
+    leaseId: 'L1',
+    result: {
+      doc: makeDoc(),
+      findings: [
+        {
+          ruleId: 'r1',
+          severity: 'medium',
+          category: 'general',
+          title: 'Test finding',
+          explanation: 'Why it matters',
+          citation: null,
+          page: 1,
+          paragraphIndex: 0,
+          snippet: 'Tenant shall pay rent.',
+          span: { start: 0, end: 8 },
+          confidence: 0.9,
+          negated: false,
+          rulePackVersion: '1.0.0',
+        },
+      ] as Finding[],
+    },
+  };
+}
+
+function defaults(over: Partial<React.ComponentProps<typeof AppCurrentPane>> = {}) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fakeRedline: any = {
+    redlineEdits: [],
+    editParagraph: vi.fn(),
+    deleteParagraphEdit: vi.fn(),
+    buildHtml: vi.fn(() => ''),
+    replaceAll: vi.fn(),
+    refresh: vi.fn(),
+    applySuggestion: vi.fn(async () => undefined),
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fakeCounters: any = {
+    counterOffers: [],
+    save: vi.fn(),
+    remove: vi.fn(),
+    refresh: vi.fn(),
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fakeAnnotations: any = {
+    annotations: [],
+    save: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+    refresh: vi.fn(),
+  };
+  const props: React.ComponentProps<typeof AppCurrentPane> = {
+    status: makeStatus(),
+    selected: null,
+    selectedPage: null,
+    setSelected: vi.fn(),
+    setSelectedPage: vi.fn(),
+    ocrState: { kind: 'idle' },
+    ocrLanguage: 'eng',
+    setOcrLanguage: vi.fn(),
+    ocrLanguages: [],
+    hasSigningKey: false,
+    glossaryEntries: [],
+    templates: [],
+    plainEnglishByRuleId: {},
+    suggestedTextByRuleId: {},
+    suggestedEditByRuleId: {},
+    redline: fakeRedline,
+    counters: fakeCounters,
+    annotationsApi: fakeAnnotations,
+    analyzedLeaseId: 'L1',
+    onExportJson: vi.fn(),
+    onExportSignedJson: vi.fn(),
+    onBuildIcs: vi.fn(),
+    onAttemptOcr: vi.fn(),
+    onPromoteToStandard: vi.fn(),
+    setView: vi.fn(),
+    ...over,
+  };
+  return render(
+    <I18nProvider>
+      <AppCurrentPane {...props} />
+    </I18nProvider>,
+  );
+}
+
+describe('AppCurrentPane', () => {
+  it('renders the analyzed-view scaffold (findings panel + workflow panel)', () => {
+    defaults();
+    expect(screen.getByRole('complementary', { name: /findings/i })).toBeInTheDocument();
+    // WorkflowPanel mounts an .ics button.
+    expect(screen.getByRole('button', { name: /\.ics/i })).toBeInTheDocument();
+  });
+
+  it('renders the signed-export button only when hasSigningKey is true', () => {
+    const { rerender } = defaults({ hasSigningKey: false });
+    expect(screen.queryByRole('button', { name: /signed/i })).toBeNull();
+    rerender(
+      <I18nProvider>
+        <AppCurrentPane
+          {...{
+            status: makeStatus(),
+            selected: null,
+            selectedPage: null,
+            setSelected: vi.fn(),
+            setSelectedPage: vi.fn(),
+            ocrState: { kind: 'idle' },
+            ocrLanguage: 'eng',
+            setOcrLanguage: vi.fn(),
+            ocrLanguages: [],
+            hasSigningKey: true,
+            glossaryEntries: [],
+            templates: [],
+            plainEnglishByRuleId: {},
+            suggestedTextByRuleId: {},
+            suggestedEditByRuleId: {},
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            redline: { redlineEdits: [], applySuggestion: vi.fn() } as any,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            counters: { counterOffers: [], save: vi.fn(), remove: vi.fn() } as any,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            annotationsApi: {
+              annotations: [],
+              save: vi.fn(),
+              update: vi.fn(),
+              remove: vi.fn(),
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any,
+            analyzedLeaseId: 'L1',
+            onExportJson: vi.fn(),
+            onExportSignedJson: vi.fn(),
+            onBuildIcs: vi.fn(),
+            onAttemptOcr: vi.fn(),
+            onPromoteToStandard: vi.fn(),
+            setView: vi.fn(),
+          }}
+        />
+      </I18nProvider>,
+    );
+    expect(screen.getByRole('button', { name: /signed/i })).toBeInTheDocument();
+  });
+
+  it('fires onExportJson when the JSON-export button is clicked', async () => {
+    const onExportJson = vi.fn();
+    defaults({ onExportJson });
+    const btn = screen.getAllByRole('button').find((b) => /json/i.test(b.textContent ?? ''));
+    expect(btn).toBeDefined();
+    await userEvent.click(btn!);
+    expect(onExportJson).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the OCR banner when the doc looks scanned', () => {
+    const status = makeStatus();
+    // Empty paragraphs / items make needsOcr fire.
+    status.result.doc = {
+      pages: [{ pageNumber: 1, width: 612, height: 792, items: [] }],
+      paragraphs: [],
+      sections: [],
+      raw: '',
+    };
+    defaults({ status });
+    expect(screen.getByText(/looks scanned/i)).toBeInTheDocument();
+  });
+});

--- a/app/src/ui/AppCurrentPane.tsx
+++ b/app/src/ui/AppCurrentPane.tsx
@@ -1,0 +1,241 @@
+// Wave 20 Part B — extracted JSX for the `view === 'current' &&
+// status.kind === 'analyzed'` block of App.tsx. Pure presentational
+// (no IDB / audit imports beyond the helpers needed to compute
+// derived data inline). Prop count is wide (~18) because App's
+// state is heavily intertwined with this view; further consolidation
+// (lifting the inline `extractLeaseFacts` / `matchTemplates` /
+// `needsOcr` derivations into a dedicated hook) is a Wave 21
+// candidate.
+
+import type { Dispatch, SetStateAction } from 'react';
+import type { OcrLanguage } from '../ocr/availableLanguages';
+import { FindingsPanel } from './FindingsPanel';
+import { PdfViewer } from './PdfViewer';
+import { OcrLanguagePickerPanel } from './OcrLanguagePickerPanel';
+import { AnnotationsPanel } from './AnnotationsPanel';
+import { CounterOfferPanel } from './CounterOfferPanel';
+import { TemplateMatchesPanel } from './TemplateMatchesPanel';
+import { LeaseFactsPanel } from './LeaseFactsPanel';
+import { WorkflowPanel } from './WorkflowPanel';
+import { extractLeaseFacts } from '../facts/extractFacts';
+import { needsOcr } from '../compare/needsOcr';
+import { matchTemplates } from '../templates/matchTemplates';
+import { buildSummary, copyToClipboard } from '../workflow/copySummary';
+import { exportFindingsAsHtml, downloadHandoffZip } from '../App/appHelpers';
+import { useI18n } from '../i18n/I18nContext';
+import type { Finding } from '../rules/types';
+import type { LeaseDocument } from '../parser/types';
+import type { ClauseTemplate } from '../templates/types';
+import type { GlossaryEntry } from '../glossary/loadGlossary';
+import type { UseRedlineStateApi } from '../App/useRedlineState';
+import type { UseAnnotationsApi } from '../App/useAnnotations';
+import type { UseCounterOffersApi } from '../App/useCounterOffers';
+
+interface AnalyzedStatus {
+  kind: 'analyzed';
+  fileName: string;
+  bytes: Uint8Array | null;
+  leaseId: string | null;
+  result: {
+    doc: LeaseDocument;
+    findings: Finding[];
+  };
+}
+
+type OcrState =
+  | { kind: 'idle' }
+  | { kind: 'running'; pct: number; stage: string }
+  | { kind: 'error'; message: string };
+
+interface AppCurrentPaneProps {
+  status: AnalyzedStatus;
+  selected: Finding | null;
+  selectedPage: number | null;
+  setSelected: Dispatch<SetStateAction<Finding | null>>;
+  setSelectedPage: Dispatch<SetStateAction<number | null>>;
+  ocrState: OcrState;
+  ocrLanguage: string;
+  setOcrLanguage: (next: string) => void;
+  ocrLanguages: OcrLanguage[];
+  hasSigningKey: boolean;
+  glossaryEntries: GlossaryEntry[];
+  templates: ClauseTemplate[];
+  plainEnglishByRuleId: Record<string, string>;
+  suggestedTextByRuleId: Record<string, string>;
+  suggestedEditByRuleId: Record<string, string>;
+  redline: UseRedlineStateApi;
+  counters: UseCounterOffersApi;
+  annotationsApi: UseAnnotationsApi;
+  analyzedLeaseId: string | null;
+  onExportJson: () => void;
+  onExportSignedJson: () => void;
+  onBuildIcs: () => void;
+  onAttemptOcr: () => void;
+  onPromoteToStandard: (leaseId: string, paragraphIndex: number) => void;
+  setView: (view: 'redline') => void;
+}
+
+export function AppCurrentPane({
+  status,
+  selected,
+  selectedPage,
+  setSelected,
+  setSelectedPage,
+  ocrState,
+  ocrLanguage,
+  setOcrLanguage,
+  ocrLanguages,
+  hasSigningKey,
+  glossaryEntries,
+  templates,
+  plainEnglishByRuleId,
+  suggestedTextByRuleId,
+  suggestedEditByRuleId,
+  redline,
+  counters,
+  annotationsApi,
+  analyzedLeaseId,
+  onExportJson,
+  onExportSignedJson,
+  onBuildIcs,
+  onAttemptOcr,
+  onPromoteToStandard,
+  setView,
+}: AppCurrentPaneProps): JSX.Element {
+  const { t } = useI18n();
+  const ocr = needsOcr(status.result.doc);
+  return (
+    <div className="results">
+      <div className="results-actions">
+        <button type="button" onClick={onExportJson}>
+          {t('findings.export.json')}
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            exportFindingsAsHtml({
+              fileName: status.fileName,
+              doc: status.result.doc,
+              findings: status.result.findings,
+            })
+          }
+        >
+          {t('findings.export.html')}
+        </button>
+        {hasSigningKey && (
+          <button type="button" onClick={onExportSignedJson}>
+            {t('findings.export.signed')}
+          </button>
+        )}
+      </div>
+      {ocr.likelyScanned && (
+        <div role="status" className="ocr-banner">
+          <p>
+            This PDF looks scanned (avg {Math.round(ocr.avgCharsPerPage)} chars/page). Text
+            extraction may be incomplete.
+          </p>
+          {status.bytes && ocrState.kind !== 'running' && (
+            <button type="button" onClick={onAttemptOcr}>
+              Attempt OCR
+            </button>
+          )}
+          <OcrLanguagePickerPanel
+            available={ocrLanguages}
+            selected={ocrLanguage}
+            onChange={setOcrLanguage}
+          />
+          {ocrState.kind === 'running' && (
+            <p aria-live="polite" className="ocr-progress">
+              Running OCR: {ocrState.stage} ({Math.round(ocrState.pct * 100)}%)
+            </p>
+          )}
+          {ocrState.kind === 'error' && <p role="alert">OCR failed: {ocrState.message}</p>}
+        </div>
+      )}
+      <div className="split">
+        <FindingsPanel
+          findings={status.result.findings}
+          onSelect={(f) => {
+            setSelected(f);
+            setSelectedPage(f.page);
+          }}
+          definitions={extractLeaseFacts(status.result.doc).definitions}
+          glossary={glossaryEntries}
+          plainEnglishByRuleId={plainEnglishByRuleId}
+          suggestedTextByRuleId={suggestedTextByRuleId}
+          onApplySuggestion={(f, pIdx, text) => {
+            if (!status.leaseId) return;
+            void redline
+              .applySuggestion({
+                finding: f,
+                paragraphIndex: pIdx,
+                suggestedText: text,
+                doc: status.result.doc,
+              })
+              .then(() => setView('redline'));
+          }}
+          onPromoteToStandard={onPromoteToStandard}
+        />
+        <PdfViewer
+          bytes={status.bytes}
+          pageCount={status.result.doc.pages.length}
+          selectedPage={selectedPage}
+          pages={status.result.doc.pages}
+          highlight={
+            selected ? (status.result.doc.paragraphs[selected.paragraphIndex]?.bbox ?? null) : null
+          }
+        />
+      </div>
+      {selected && (
+        <article aria-label="selected finding">
+          <h3>{selected.title}</h3>
+          <p>{selected.explanation}</p>
+          <blockquote>{selected.snippet}</blockquote>
+          <small>Page {selected.page}</small>
+        </article>
+      )}
+      <AnnotationsPanel
+        leaseId={analyzedLeaseId ?? ''}
+        paragraphIndex={selected ? selected.paragraphIndex : null}
+        annotations={annotationsApi.annotations}
+        onSave={(text) => {
+          if (!analyzedLeaseId || selected === null) return;
+          void annotationsApi.save({
+            leaseId: analyzedLeaseId,
+            paragraphIndex: selected.paragraphIndex,
+            text,
+          });
+        }}
+        onUpdate={(id, text) => void annotationsApi.update(id, text)}
+        onDelete={(id) => void annotationsApi.remove(id)}
+      />
+      <CounterOfferPanel
+        finding={selected}
+        counters={counters.counterOffers}
+        onSave={(ruleId, name, text) => void counters.save(ruleId, name, text)}
+        onDelete={(id) => void counters.remove(id)}
+        suggestedEdit={selected ? suggestedEditByRuleId[selected.ruleId] : undefined}
+      />
+      <TemplateMatchesPanel matches={matchTemplates(templates, status.result.doc)} />
+      <LeaseFactsPanel facts={extractLeaseFacts(status.result.doc)} />
+      <WorkflowPanel
+        leaseName={status.fileName}
+        findings={status.result.findings}
+        onBuildIcs={onBuildIcs}
+        onCopySummary={async () => {
+          await copyToClipboard(
+            buildSummary({ leaseName: status.fileName, findings: status.result.findings }),
+          );
+        }}
+        onDownloadHandoff={() => {
+          downloadHandoffZip({
+            fileName: status.fileName,
+            doc: status.result.doc,
+            findings: status.result.findings,
+            bytes: status.bytes,
+          });
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Extracts the analyzed-view JSX block (FindingsPanel + PdfViewer split, selected-finding article, AnnotationsPanel, CounterOfferPanel, TemplateMatchesPanel, LeaseFactsPanel, WorkflowPanel, OCR banner) into \`app/src/ui/AppCurrentPane.tsx\`.

App.tsx: **771 → 639 lines (−132)**.

## Cap miss documented (cap was ≤550)
Miss by 89 lines. Same pattern as prior decomp waves — file-count cap (≤4 new files) plus state-coupling limits per-wave reach. Used 2 of 4 file slots (component + test). Did **not** add \`useCurrentViewState\` because the local state (\`selected\`/\`selectedPage\`/\`ocrLanguage\`) is also referenced outside the analyzed view, so a hook lift would have been cosmetic.

The remaining ~90-line drop rolls to Wave 21.

## Cap discipline
- 2 of ≤4 new files used ✓
- Coverage thresholds held: stmt 97.13 / branch 89.36 / func 93.74 / line 97.13 (above floors; branch slightly improved over Part A's 89.22)
- Zero behavior changes; existing tests pass unchanged ✓

## Note
Prop interface is wide (~24 props) — wider than the plan's ≤12 ideal. The plan's escape hatch ("ship a smaller sub-component") would have meant extracting just the actions toolbar (~5 props, ~25 line drop) — net not worth a new file pair. Wider interface trades discipline for line-drop; documented for Wave 21 to consolidate via state lifting.

## Test plan
- [x] \`npm run typecheck\` green.
- [x] \`npm run lint\` green.
- [x] \`npm run test:coverage\` — 1168 tests passing; thresholds intact.
- [x] 4 new tests in \`AppCurrentPane.test.tsx\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)