### PR TITLE
wave21-A: Phase 18 hybrid analyze() infrastructure (off by default)

### DIFF
--- a/app/src/App/usePipeline.ts
+++ b/app/src/App/usePipeline.ts
@@ -2,6 +2,8 @@ import { useCallback, useMemo, useState } from 'react';
 import { type AnalysisResult } from '../ui/analyzeFile';
 import { runOcr } from '../ocr/runOcr';
 import { analyze } from '../rules/analyze';
+import { runHybridAnalyze, type EmbedFunction } from '../rules/hybridAnalyze';
+import { isPhase18Enabled } from '../llm/featureFlag';
 import { RULE_PACK_V1 } from '../rules/packV1';
 import type { Rule } from '../rules/types';
 import { getLease, getStandardId, saveLease, type LeaseRecord } from '../storage/storage';
@@ -109,10 +111,7 @@ export function usePipeline(deps: UsePipelineDeps = {}): PipelineApi {
         // hand the worker (or inline pipeline) a dedicated copy and keep
         // the original for the viewer. The worker-backed client also
         // transfers the copy's buffer; the viewer's copy is untouched.
-        const result: AnalysisResult = await client.parseAndAnalyze(
-          copyBytes(bytes),
-          activeRules,
-        );
+        const result: AnalysisResult = await client.parseAndAnalyze(copyBytes(bytes), activeRules);
         const newId = await saveLease({
           name: fileName,
           doc: result.doc,
@@ -149,29 +148,44 @@ export function usePipeline(deps: UsePipelineDeps = {}): PipelineApi {
     [onLibraryChange, activeRules, client],
   );
 
-  const ocr = useCallback(async (language?: string): Promise<void> => {
-    if (status.kind !== 'analyzed' || !status.bytes) return;
-    setOcrState({ kind: 'running', pct: 0, stage: 'starting' });
-    try {
-      // pdf.js transfers the ArrayBuffer during parse, so hand runOcr a copy
-      // and keep the original for the viewer.
-      const doc = await runOcr(copyBytes(status.bytes), {
-        onProgress: (p) => setOcrState({ kind: 'running', pct: p.pct, stage: p.stage }),
-        ...(language ? { language } : {}),
-      });
-      const findings = analyze(doc, activeRules);
-      setStatus({
-        kind: 'analyzed',
-        fileName: status.fileName,
-        result: { doc, findings },
-        bytes: status.bytes,
-        leaseId: status.leaseId,
-      });
-      setOcrState({ kind: 'idle' });
-    } catch (err) {
-      setOcrState({ kind: 'error', message: friendlyError(err) });
-    }
-  }, [status, activeRules]);
+  const ocr = useCallback(
+    async (language?: string): Promise<void> => {
+      if (status.kind !== 'analyzed' || !status.bytes) return;
+      setOcrState({ kind: 'running', pct: 0, stage: 'starting' });
+      try {
+        // pdf.js transfers the ArrayBuffer during parse, so hand runOcr a copy
+        // and keep the original for the viewer.
+        const doc = await runOcr(copyBytes(status.bytes), {
+          onProgress: (p) => setOcrState({ kind: 'running', pct: p.pct, stage: p.stage }),
+          ...(language ? { language } : {}),
+        });
+        // Phase 18 hybrid path: deterministic engine first; the optional
+        // classifier pass only adds findings when the flag is on AND an
+        // embedFn is supplied. Wave 21 ships the seam — no production
+        // caller fetches the real model yet, so embedFn stays null and
+        // the wrapper degrades to plain analyze() at runtime. Wave 22+
+        // wires loadClassifier into this site.
+        const hybridEmbedFn: EmbedFunction | null = null;
+        const findings = await runHybridAnalyze({
+          doc,
+          rules: activeRules,
+          enabled: isPhase18Enabled(),
+          embedFn: hybridEmbedFn,
+        });
+        setStatus({
+          kind: 'analyzed',
+          fileName: status.fileName,
+          result: { doc, findings },
+          bytes: status.bytes,
+          leaseId: status.leaseId,
+        });
+        setOcrState({ kind: 'idle' });
+      } catch (err) {
+        setOcrState({ kind: 'error', message: friendlyError(err) });
+      }
+    },
+    [status, activeRules],
+  );
 
   const reanalyze = useCallback((): void => {
     setStatus((prev) => {
@@ -206,12 +220,9 @@ export function usePipeline(deps: UsePipelineDeps = {}): PipelineApi {
     setStatus({ kind: 'error', message });
   }, []);
 
-  const setComparison = useCallback(
-    (pair: { a: LeaseRecord; b: LeaseRecord } | null): void => {
-      setComparisonState(pair);
-    },
-    [],
-  );
+  const setComparison = useCallback((pair: { a: LeaseRecord; b: LeaseRecord } | null): void => {
+    setComparisonState(pair);
+  }, []);
 
   return {
     status,

--- a/app/src/llm/featureFlag.test.ts
+++ b/app/src/llm/featureFlag.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { isPhase18Enabled, setPhase18Override } from './featureFlag';
+
+const ORIGINAL_LOCATION = window.location;
+let store: Map<string, string>;
+
+beforeEach(() => {
+  // Node 25's built-in localStorage stub is incomplete (no removeItem);
+  // replace with a fresh in-memory Storage for each test.
+  store = new Map();
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+    key: (n: number) => Array.from(store.keys())[n] ?? null,
+    get length() {
+      return store.size;
+    },
+  });
+  Object.defineProperty(window, 'location', {
+    value: new URL('http://localhost/'),
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(window, 'location', { value: ORIGINAL_LOCATION, writable: true });
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('isPhase18Enabled', () => {
+  it('returns false by default (no URL param, no localStorage)', () => {
+    expect(isPhase18Enabled()).toBe(false);
+  });
+
+  it('returns true when ?phase18=on is in the URL', () => {
+    Object.defineProperty(window, 'location', {
+      value: new URL('http://localhost/?phase18=on'),
+      writable: true,
+    });
+    expect(isPhase18Enabled()).toBe(true);
+  });
+
+  it('returns false when ?phase18=off is in the URL', () => {
+    Object.defineProperty(window, 'location', {
+      value: new URL('http://localhost/?phase18=off'),
+      writable: true,
+    });
+    expect(isPhase18Enabled()).toBe(false);
+  });
+
+  it('returns true when localStorage has phase18 set to "on"', () => {
+    setPhase18Override('on');
+    expect(isPhase18Enabled()).toBe(true);
+  });
+
+  it('returns false when localStorage has phase18 set to anything else', () => {
+    setPhase18Override('off');
+    expect(isPhase18Enabled()).toBe(false);
+  });
+
+  it('URL "on" overrides localStorage "off" (OR semantics)', () => {
+    setPhase18Override('off');
+    Object.defineProperty(window, 'location', {
+      value: new URL('http://localhost/?phase18=on'),
+      writable: true,
+    });
+    expect(isPhase18Enabled()).toBe(true);
+  });
+
+  it('localStorage "on" overrides absent URL param', () => {
+    setPhase18Override('on');
+    expect(isPhase18Enabled()).toBe(true);
+  });
+
+  it('setPhase18Override(null) clears the persisted override', () => {
+    setPhase18Override('on');
+    expect(isPhase18Enabled()).toBe(true);
+    setPhase18Override(null);
+    expect(isPhase18Enabled()).toBe(false);
+  });
+});

--- a/app/src/llm/featureFlag.ts
+++ b/app/src/llm/featureFlag.ts
@@ -1,0 +1,51 @@
+// Wave 21 — Phase 18 feature flag. Off by default; enabled via either
+// a URL search param (?phase18=on) or a localStorage entry (set with
+// `setPhase18Override('on')` from a dev console). Pure read; no side
+// effects on import.
+//
+// Why two channels? URL param survives a page refresh in dev without
+// touching local state; localStorage persists across navigations
+// without dirtying the URL. Either is sufficient — they OR together.
+
+const STORAGE_KEY = 'leaseguard.phase18';
+
+/**
+ * Returns true iff Phase 18's hybrid analyze() path should run.
+ * The deterministic rules engine still runs; this only gates whether
+ * the optional classifier pass adds extra findings.
+ */
+export function isPhase18Enabled(): boolean {
+  return readUrlParam() === 'on' || readStorage() === 'on';
+}
+
+/**
+ * Test + dev-console helper. Pass 'on' / 'off' to override; null to
+ * clear the override (returns to URL-only behavior).
+ */
+export function setPhase18Override(value: 'on' | 'off' | null): void {
+  if (typeof localStorage === 'undefined') return;
+  if (value === null) {
+    localStorage.removeItem(STORAGE_KEY);
+    return;
+  }
+  localStorage.setItem(STORAGE_KEY, value);
+}
+
+function readUrlParam(): string | null {
+  if (typeof window === 'undefined' || !window.location) return null;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('phase18');
+  } catch {
+    return null;
+  }
+}
+
+function readStorage(): string | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}

--- a/app/src/rules/hybridAnalyze.test.ts
+++ b/app/src/rules/hybridAnalyze.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runHybridAnalyze, type EmbedFunction } from './hybridAnalyze';
+import type { LeaseDocument } from '../parser/types';
+import type { Rule } from './types';
+
+function doc(paragraphs: string[]): LeaseDocument {
+  return {
+    pages: [{ pageNumber: 1, width: 612, height: 792, items: [] }],
+    paragraphs: paragraphs.map((text) => ({ text, page: 1 })),
+    sections: [],
+    raw: paragraphs.join('\n\n'),
+  };
+}
+
+function rule(over: Partial<Rule> = {}): Rule {
+  return {
+    id: 'r1',
+    title: 'Auto-renewal clause',
+    severity: 'medium',
+    category: 'general',
+    explanation: 'A rule about renewal',
+    citation: null,
+    match: { type: 'regex', pattern: 'auto[- ]?renew' },
+    ...over,
+  } as Rule;
+}
+
+/**
+ * Stub embedder: maps each input string to a deterministic vector
+ * derived from the string, so we can reason about similarity in tests
+ * without booting a real model.
+ *
+ *   - Strings sharing a common keyword have overlapping non-zero
+ *     dimensions (high similarity).
+ *   - Disjoint strings produce orthogonal vectors (similarity ~ 0).
+ */
+function makeStubEmbedder(): EmbedFunction {
+  // Each unique 4+-char word becomes a dimension. Vector is the
+  // L2-normalized count of those words in the input.
+  const dimByWord = new Map<string, number>();
+  function dimOf(w: string): number {
+    let d = dimByWord.get(w);
+    if (d === undefined) {
+      d = dimByWord.size;
+      dimByWord.set(w, d);
+    }
+    return d;
+  }
+  return async (texts: string[]) => {
+    return texts.map((t) => {
+      const counts = new Map<number, number>();
+      for (const w of t
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter((w) => w.length >= 4)) {
+        counts.set(dimOf(w), (counts.get(dimOf(w)) ?? 0) + 1);
+      }
+      const dim = dimByWord.size + 32; // pad
+      const vec = new Float32Array(dim);
+      let n = 0;
+      for (const [d, c] of counts) {
+        vec[d] = c;
+        n += c * c;
+      }
+      const norm = Math.sqrt(n) || 1;
+      for (let i = 0; i < vec.length; i++) vec[i] = (vec[i] ?? 0) / norm;
+      return vec;
+    });
+  };
+}
+
+describe('runHybridAnalyze', () => {
+  it('flag off: returns analyze() output verbatim, no embedFn calls', async () => {
+    const embedFn = vi.fn(makeStubEmbedder());
+    const findings = await runHybridAnalyze({
+      doc: doc(['This lease shall auto-renew annually.', 'Another paragraph.']),
+      rules: [rule()],
+      enabled: false,
+      embedFn,
+    });
+    expect(findings).toHaveLength(1); // regex catches auto-renew
+    expect(findings[0]?.confidence).toBeCloseTo(0.9, 1);
+    expect(embedFn).not.toHaveBeenCalled();
+  });
+
+  it('flag on but embedFn null: returns analyze() output verbatim', async () => {
+    const findings = await runHybridAnalyze({
+      doc: doc(['This lease shall auto-renew annually.']),
+      rules: [rule()],
+      enabled: true,
+      embedFn: null,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it('flag on + stub embedder: adds a soft finding when keyword overlaps and similarity is high', async () => {
+    const embedFn = vi.fn(makeStubEmbedder());
+    // Paragraph 0: matches the regex (auto-renew). Paragraph 1: doesn't,
+    // but shares the word "renewal" with the rule title.
+    const findings = await runHybridAnalyze({
+      doc: doc([
+        'This lease shall auto-renew annually.',
+        'The renewal clause grants additional renewal terms upon notice.',
+      ]),
+      rules: [rule()],
+      enabled: true,
+      embedFn,
+      threshold: 0.3,
+    });
+    expect(embedFn).toHaveBeenCalled();
+    // 1 deterministic + 1 hybrid (paragraph 1).
+    expect(findings).toHaveLength(2);
+    const hybrid = findings.find((f) => f.confidence === 0.5);
+    expect(hybrid).toBeDefined();
+    expect(hybrid?.paragraphIndex).toBe(1);
+    expect(hybrid?.ruleId).toBe('r1');
+  });
+
+  it('flag on + stub embedder: similarity below threshold → no extra finding', async () => {
+    const embedFn = vi.fn(makeStubEmbedder());
+    // Paragraph contains the bare keyword "renewal" but is otherwise
+    // disjoint; with a 0.99 threshold, the hybrid pass should NOT fire.
+    const findings = await runHybridAnalyze({
+      doc: doc(['Renewal of insurance is the tenant responsibility.']),
+      rules: [rule()],
+      enabled: true,
+      embedFn,
+      threshold: 0.99,
+    });
+    expect(findings).toHaveLength(0);
+    expect(embedFn).toHaveBeenCalled();
+  });
+
+  it('hybrid never removes a deterministic finding', async () => {
+    const embedFn = vi.fn(makeStubEmbedder());
+    const findings = await runHybridAnalyze({
+      doc: doc(['This lease shall auto-renew annually.']),
+      rules: [rule()],
+      enabled: true,
+      embedFn,
+      threshold: 0.3,
+    });
+    // Paragraph 0 already has a deterministic hit; the hybrid pass
+    // skips paragraphs with at least one finding. Result is 1, not 2.
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.confidence).toBeCloseTo(0.9, 1);
+  });
+
+  it('maxLlmCalls=0 prevents any embedder calls even when enabled', async () => {
+    const embedFn = vi.fn(makeStubEmbedder());
+    const findings = await runHybridAnalyze({
+      doc: doc(['Renewal text here.']),
+      rules: [rule()],
+      enabled: true,
+      embedFn,
+      maxLlmCalls: 0,
+    });
+    expect(embedFn).not.toHaveBeenCalled();
+    expect(findings).toHaveLength(0);
+  });
+
+  it('skips rules whose title has no 4+-char tokens (cheap pre-filter is empty)', async () => {
+    const embedFn = vi.fn(makeStubEmbedder());
+    const shortTitle = rule({ title: 'A B C' });
+    const findings = await runHybridAnalyze({
+      doc: doc(['No renewal here.']),
+      rules: [shortTitle],
+      enabled: true,
+      embedFn,
+    });
+    expect(findings).toEqual([]);
+    expect(embedFn).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/rules/hybridAnalyze.ts
+++ b/app/src/rules/hybridAnalyze.ts
@@ -1,0 +1,163 @@
+// Wave 21 Part A — Phase 18 hybrid analyze() wrapper.
+//
+// Contract:
+//   - The deterministic rules engine (analyze) is the authority. It
+//     always runs; the classifier never removes or overrides its
+//     findings.
+//   - When the feature flag is off OR no embedFn is supplied, the
+//     hybrid path returns analyze()'s output verbatim. Default off.
+//   - When enabled, paragraphs that produced ZERO deterministic
+//     findings get a second pass. For each rule whose title shares
+//     at least one keyword with the paragraph (cheap pre-filter),
+//     compute cosine similarity between paragraph and rule title
+//     embeddings and emit a Finding when similarity >= threshold.
+//   - Hybrid findings carry confidence = 0.5 (visibly "soft") so
+//     downstream consumers can distinguish them from regex/proximity
+//     hits. They use the rule's existing severity/category/title.
+//   - maxLlmCalls caps total embedding calls per lease so a worst-
+//     case parse can't fan out unboundedly. Default 50.
+
+import type { LeaseDocument } from '../parser/types';
+import { analyze, RULE_PACK_VERSION } from './analyze';
+import type { Finding, Rule } from './types';
+import type { CompiledRule } from './compileRules';
+
+export interface EmbedFunction {
+  (texts: string[]): Promise<Float32Array[]>;
+}
+
+export interface HybridAnalyzeOptions {
+  doc: LeaseDocument;
+  rules: Rule[] | CompiledRule[];
+  enabled: boolean;
+  embedFn: EmbedFunction | null;
+  threshold?: number;
+  maxLlmCalls?: number;
+}
+
+const DEFAULT_THRESHOLD = 0.7;
+const DEFAULT_MAX_LLM_CALLS = 50;
+
+/**
+ * Run the deterministic engine, then optionally augment with a
+ * classifier pass. See module header for the contract.
+ */
+export async function runHybridAnalyze(opts: HybridAnalyzeOptions): Promise<Finding[]> {
+  const { doc, rules, enabled, embedFn } = opts;
+  const threshold = opts.threshold ?? DEFAULT_THRESHOLD;
+  const maxLlmCalls = opts.maxLlmCalls ?? DEFAULT_MAX_LLM_CALLS;
+
+  const baseFindings = analyze(doc, rules);
+
+  if (!enabled || embedFn === null || maxLlmCalls <= 0) return baseFindings;
+
+  // Index of paragraphs that already have at least one finding —
+  // these are skipped on the classifier pass.
+  const flagged = new Set<number>();
+  for (const f of baseFindings) flagged.add(f.paragraphIndex);
+
+  // Pre-compute keyword sets for each rule (lowercased word set from
+  // rule title). Rule title is the cheapest "anchor" we have without
+  // synthesizing prompts.
+  const rulesArr = rules as Rule[];
+  const ruleKeywords = rulesArr.map((r) => {
+    const tokens = r.title
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((w) => w.length >= 4);
+    return new Set(tokens);
+  });
+
+  // Build the work queue: (paragraphIndex, ruleIndex) pairs where the
+  // paragraph has zero findings AND shares at least one keyword with
+  // the rule title. Bounded by maxLlmCalls.
+  type Work = { pIdx: number; rIdx: number };
+  const work: Work[] = [];
+  for (let pIdx = 0; pIdx < doc.paragraphs.length; pIdx++) {
+    if (flagged.has(pIdx)) continue;
+    const para = doc.paragraphs[pIdx];
+    if (!para) continue;
+    const lower = para.text.toLowerCase();
+    for (let rIdx = 0; rIdx < rulesArr.length; rIdx++) {
+      const kws = ruleKeywords[rIdx];
+      if (!kws || kws.size === 0) continue;
+      let overlaps = false;
+      for (const kw of kws) {
+        if (lower.includes(kw)) {
+          overlaps = true;
+          break;
+        }
+      }
+      if (overlaps) work.push({ pIdx, rIdx });
+      if (work.length >= maxLlmCalls) break;
+    }
+    if (work.length >= maxLlmCalls) break;
+  }
+
+  if (work.length === 0) return baseFindings;
+
+  // Embed paragraphs and rule titles in two batched calls. De-dupe.
+  const paraIdxs = Array.from(new Set(work.map((w) => w.pIdx)));
+  const ruleIdxs = Array.from(new Set(work.map((w) => w.rIdx)));
+  const paraTexts = paraIdxs.map((i) => doc.paragraphs[i]?.text ?? '');
+  const ruleTexts = ruleIdxs.map((i) => rulesArr[i]?.title ?? '');
+
+  const [paraVecs, ruleVecs] = await Promise.all([embedFn(paraTexts), embedFn(ruleTexts)]);
+
+  const paraVecByIdx = new Map<number, Float32Array>();
+  paraIdxs.forEach((i, k) => {
+    const v = paraVecs[k];
+    if (v) paraVecByIdx.set(i, v);
+  });
+  const ruleVecByIdx = new Map<number, Float32Array>();
+  ruleIdxs.forEach((i, k) => {
+    const v = ruleVecs[k];
+    if (v) ruleVecByIdx.set(i, v);
+  });
+
+  const extras: Finding[] = [];
+  for (const w of work) {
+    const pv = paraVecByIdx.get(w.pIdx);
+    const rv = ruleVecByIdx.get(w.rIdx);
+    if (!pv || !rv) continue;
+    const sim = cosine(pv, rv);
+    if (sim < threshold) continue;
+    const rule = rulesArr[w.rIdx];
+    const para = doc.paragraphs[w.pIdx];
+    if (!rule || !para) continue;
+    extras.push({
+      ruleId: rule.id,
+      severity: rule.severity,
+      category: rule.category,
+      title: rule.title,
+      explanation: rule.plainEnglish ?? rule.title,
+      citation: rule.citation,
+      page: para.page,
+      paragraphIndex: w.pIdx,
+      snippet: para.text.slice(0, 200),
+      span: { start: 0, end: Math.min(para.text.length, 200) },
+      confidence: 0.5,
+      negated: false,
+      rulePackVersion: RULE_PACK_VERSION,
+    });
+  }
+
+  return [...baseFindings, ...extras];
+}
+
+function cosine(a: Float32Array, b: Float32Array): number {
+  const n = Math.min(a.length, b.length);
+  if (n === 0) return 0;
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < n; i++) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    dot += av * bv;
+    na += av * av;
+    nb += bv * bv;
+  }
+  if (na === 0 || nb === 0) return 0;
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}


### PR DESCRIPTION
## Summary
Wires Wave 20-C's \`loadClassifier\`-shaped \`EmbedFunction\` into the analyze pipeline behind a URL/localStorage feature flag. **Off by default; no production source fetches the real model yet.** Wave 22+ ships the actual model wiring + Workbox precache + CSP audit + new audit kind.

## What ships
- **\`app/src/llm/featureFlag.ts\`** (NEW) — \`isPhase18Enabled()\` returns true iff URL has \`?phase18=on\` OR \`localStorage['leaseguard.phase18'] === 'on'\`.
- **\`app/src/rules/hybridAnalyze.ts\`** (NEW) — \`runHybridAnalyze()\` wrapper. Always runs deterministic \`analyze()\` first; when flag on AND \`embedFn\` supplied, adds soft findings (confidence 0.5) for paragraphs with zero deterministic findings AND keyword overlap with a rule title AND cosine similarity ≥ threshold (default 0.7). \`maxLlmCalls\` cap (default 50) bounds the embedding budget. **Hybrid path NEVER removes a deterministic finding.**
- **\`app/src/App/usePipeline.ts\`** — single edit: the OCR fallback path now calls \`runHybridAnalyze\` (instead of \`analyze\` directly). \`embedFn\` is passed \`null\` in Wave 21 so the wrapper degrades to plain \`analyze()\` at runtime.

## Cap discipline
- 3 of ≤3 new src files used ✓
- 2 of ≤2 new test files used (8 + 7 = 15 cases) ✓
- 1 \`usePipeline\` edit ✓
- No UI changes; no new audit kind; no production model fetch; no new dep ✓
- Coverage held: stmt 97.07 / branch 89.11 / func 93.81 / line 97.07. Tests: 1186 passing.

## Test plan
- [x] \`npm run typecheck\` green.
- [x] \`npm run lint\` green.
- [x] \`npm run test:coverage\` — 1186 tests passing; thresholds intact.
- [x] 8 new \`featureFlag\` tests + 7 new \`hybridAnalyze\` tests.
- [x] Existing \`App.test.tsx\` + \`App.panels.test.tsx\` + \`usePipeline.test.ts\` pass unchanged (flag default-off, no behavior change at the React layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)