### PR TITLE
wave22-A: kind 'llm-classify' audit entry per hybrid finding

### DIFF
--- a/app/src/rules/hybridAnalyze.test.ts
+++ b/app/src/rules/hybridAnalyze.test.ts
@@ -159,6 +159,81 @@ describe('runHybridAnalyze', () => {
     expect(findings).toHaveLength(0);
   });
 
+  it('fires one llm-classify audit entry per hybrid finding when audit is supplied', async () => {
+    const embedFn = vi.fn(makeStubEmbedder());
+    const audit = vi.fn<[{ kind: string; payload: Record<string, unknown> }], Promise<void>>(
+      async () => undefined,
+    );
+    const findings = await runHybridAnalyze({
+      doc: doc(['The renewal clause grants additional renewal terms upon notice.']),
+      rules: [rule()],
+      enabled: true,
+      embedFn,
+      audit,
+      modelId: 'Xenova/test-model',
+      threshold: 0.3,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.confidence).toBe(0.5);
+    expect(audit).toHaveBeenCalledTimes(1);
+    const payload = audit.mock.calls[0]?.[0];
+    expect(payload?.kind).toBe('llm-classify');
+    expect(payload?.payload).toMatchObject({
+      ruleId: 'r1',
+      paragraphIndex: 0,
+      modelId: 'Xenova/test-model',
+    });
+    expect(typeof (payload?.payload as { similarity?: unknown }).similarity).toBe('number');
+  });
+
+  it('does not fire any audit entries when the flag is off', async () => {
+    const embedFn = vi.fn(makeStubEmbedder());
+    const audit = vi.fn<[{ kind: string; payload: Record<string, unknown> }], Promise<void>>(
+      async () => undefined,
+    );
+    await runHybridAnalyze({
+      doc: doc(['Renewal text here.']),
+      rules: [rule()],
+      enabled: false,
+      embedFn,
+      audit,
+    });
+    expect(audit).not.toHaveBeenCalled();
+  });
+
+  it('does not fire any audit entries when zero hybrid findings are emitted', async () => {
+    const embedFn = vi.fn(makeStubEmbedder());
+    const audit = vi.fn<[{ kind: string; payload: Record<string, unknown> }], Promise<void>>(
+      async () => undefined,
+    );
+    await runHybridAnalyze({
+      doc: doc(['Renewal text but with very high threshold.']),
+      rules: [rule()],
+      enabled: true,
+      embedFn,
+      audit,
+      threshold: 0.99,
+    });
+    expect(audit).not.toHaveBeenCalled();
+  });
+
+  it('audit payload defaults modelId to "unknown" when not supplied', async () => {
+    const embedFn = vi.fn(makeStubEmbedder());
+    const audit = vi.fn<[{ kind: string; payload: Record<string, unknown> }], Promise<void>>(
+      async () => undefined,
+    );
+    await runHybridAnalyze({
+      doc: doc(['The renewal clause grants additional renewal terms upon notice.']),
+      rules: [rule()],
+      enabled: true,
+      embedFn,
+      audit,
+      threshold: 0.3,
+    });
+    const payload = audit.mock.calls[0]?.[0]?.payload as { modelId?: string };
+    expect(payload?.modelId).toBe('unknown');
+  });
+
   it('skips rules whose title has no 4+-char tokens (cheap pre-filter is empty)', async () => {
     const embedFn = vi.fn(makeStubEmbedder());
     const shortTitle = rule({ title: 'A B C' });

--- a/app/src/rules/hybridAnalyze.ts
+++ b/app/src/rules/hybridAnalyze.ts
@@ -26,6 +26,11 @@ export interface EmbedFunction {
   (texts: string[]): Promise<Float32Array[]>;
 }
 
+export interface HybridAnalyzeAuditEntry {
+  kind: string;
+  payload: Record<string, unknown>;
+}
+
 export interface HybridAnalyzeOptions {
   doc: LeaseDocument;
   rules: Rule[] | CompiledRule[];
@@ -33,6 +38,20 @@ export interface HybridAnalyzeOptions {
   embedFn: EmbedFunction | null;
   threshold?: number;
   maxLlmCalls?: number;
+  /**
+   * Optional audit callback. When supplied, fires one
+   * `kind: 'llm-classify'` entry per hybrid finding emitted, with a
+   * `{ ruleId, paragraphIndex, modelId, similarity }` payload. Wave 23
+   * will pass `safeAudit` here when it wires the real model. No-op
+   * if the flag is off or the classifier emits zero hybrid findings.
+   */
+  audit?: (entry: HybridAnalyzeAuditEntry) => Promise<void> | void;
+  /**
+   * Identifies the model that produced the embeddings — used in audit
+   * payloads. Defaults to `'unknown'` so callers without a real model
+   * can still ship attestation entries with sane shape.
+   */
+  modelId?: string;
 }
 
 const DEFAULT_THRESHOLD = 0.7;
@@ -46,6 +65,8 @@ export async function runHybridAnalyze(opts: HybridAnalyzeOptions): Promise<Find
   const { doc, rules, enabled, embedFn } = opts;
   const threshold = opts.threshold ?? DEFAULT_THRESHOLD;
   const maxLlmCalls = opts.maxLlmCalls ?? DEFAULT_MAX_LLM_CALLS;
+  const audit = opts.audit;
+  const modelId = opts.modelId ?? 'unknown';
 
   const baseFindings = analyze(doc, rules);
 
@@ -140,6 +161,21 @@ export async function runHybridAnalyze(opts: HybridAnalyzeOptions): Promise<Find
       negated: false,
       rulePackVersion: RULE_PACK_VERSION,
     });
+    if (audit) {
+      // Fire-and-await one attestation per hybrid finding. Errors in
+      // the audit callback do NOT abort the analyze pipeline (the
+      // safeAudit pattern is the caller's responsibility — see
+      // App.tsx's safeAudit wrapper for the production version).
+      await audit({
+        kind: 'llm-classify',
+        payload: {
+          ruleId: rule.id,
+          paragraphIndex: w.pIdx,
+          modelId,
+          similarity: sim,
+        },
+      });
+    }
   }
 
   return [...baseFindings, ...extras];

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -154,7 +154,10 @@ New UI panels live in `src/ui/` and follow a four-file convention:
    `kind` (`analyze`, `export`, `import-pack`, `pack-signature-verified`,
    `pack-signature-invalid`, `save-lease`, `delete-lease`, `bulk-import`,
    `custom-rule-save`, `redline-edit`, `version-save`, `version-restore`,
-   `version-delete`) or add a new one — `kind` is a free-form string.
+   `version-delete`, `llm-classify`) or add a new one — `kind` is a
+   free-form string. `llm-classify` fires once per Phase 18 hybrid
+   finding (Wave 22-A); payload includes `{ ruleId, paragraphIndex,
+   modelId, similarity }`.
 
 ## Testing patterns
 


### PR DESCRIPTION
## Summary
Extends \`runHybridAnalyze\` with two optional parameters:
- \`audit?: (entry: { kind, payload }) => Promise<void> | void\`
- \`modelId?: string\` (defaults to \`'unknown'\`)

When supplied AND the flag is on AND hybrid findings are emitted, fires **one \`kind: 'llm-classify'\` audit entry per finding** with payload \`{ ruleId, paragraphIndex, modelId, similarity }\`.

\`usePipeline.ts\` is **intentionally NOT edited** — Wave 23 wires \`safeAudit\` through when it ships the real model.

\`docs/CLAUDE.md\` updated: \`'llm-classify'\` added to the documented kinds list.

## Cap discipline
- 1 src edit (\`hybridAnalyze.ts\`) ✓
- 4 of ≤4 new test cases used ✓
- 1 doc edit (\`CLAUDE.md\`) ✓
- No \`usePipeline.ts\` edit ✓
- No new audit-log schema ✓

## Test plan
- [x] \`npm run typecheck && npm run lint && npm run test:coverage\` — 1193 tests passing.
- [x] 4 new tests in \`hybridAnalyze.test.ts\` pin: audit fires per hybrid finding, none when flag off, none when 0 findings, modelId defaults to "unknown".

🤖 Generated with [Claude Code](https://claude.com/claude-code)