### PR TITLE
wave22-B: branch-coverage push (89.07 → 89.34; threshold SKIPS)

### DIFF
--- a/app/src/llm/featureFlag.test.ts
+++ b/app/src/llm/featureFlag.test.ts
@@ -87,4 +87,34 @@ describe('isPhase18Enabled', () => {
     setPhase18Override(null);
     expect(isPhase18Enabled()).toBe(false);
   });
+
+  it('URL parsing throws are swallowed (returns null, not crash)', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        get search() {
+          throw new Error('synthetic search getter failure');
+        },
+      },
+      writable: true,
+    });
+    // Should not throw; default-off applies.
+    expect(isPhase18Enabled()).toBe(false);
+  });
+
+  it('localStorage read errors are swallowed (returns null, not crash)', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('synthetic storage getter failure');
+      },
+      setItem: () => {},
+      removeItem: () => {},
+    });
+    expect(isPhase18Enabled()).toBe(false);
+  });
+
+  it('setPhase18Override is a no-op when localStorage is undefined', () => {
+    vi.stubGlobal('localStorage', undefined);
+    // Should not throw.
+    expect(() => setPhase18Override('on')).not.toThrow();
+  });
 });

--- a/app/src/rules/hybridAnalyze.test.ts
+++ b/app/src/rules/hybridAnalyze.test.ts
@@ -234,6 +234,32 @@ describe('runHybridAnalyze', () => {
     expect(payload?.modelId).toBe('unknown');
   });
 
+  it('cosine returns 0 for zero-length vectors (no extra finding emitted)', async () => {
+    const zeroEmbedder: EmbedFunction = async (texts) => texts.map(() => new Float32Array(0));
+    const findings = await runHybridAnalyze({
+      doc: doc(['Renewal text here.']),
+      rules: [rule()],
+      enabled: true,
+      embedFn: zeroEmbedder,
+      threshold: 0.0001,
+    });
+    // Empty vectors → similarity 0 < threshold → no extra finding.
+    expect(findings).toHaveLength(0);
+  });
+
+  it('cosine returns 0 for all-zero vectors (no extra finding emitted)', async () => {
+    const zeroEmbedder: EmbedFunction = async (texts) =>
+      texts.map(() => new Float32Array([0, 0, 0]));
+    const findings = await runHybridAnalyze({
+      doc: doc(['Renewal text here.']),
+      rules: [rule()],
+      enabled: true,
+      embedFn: zeroEmbedder,
+      threshold: 0.0001,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
   it('skips rules whose title has no 4+-char tokens (cheap pre-filter is empty)', async () => {
     const embedFn = vi.fn(makeStubEmbedder());
     const shortTitle = rule({ title: 'A B C' });

--- a/app/src/ui/AppCurrentPane.test.tsx
+++ b/app/src/ui/AppCurrentPane.test.tsx
@@ -182,4 +182,56 @@ describe('AppCurrentPane', () => {
     defaults({ status });
     expect(screen.getByText(/looks scanned/i)).toBeInTheDocument();
   });
+
+  it('renders the selected-finding article when a finding is selected', () => {
+    const finding = {
+      ruleId: 'r1',
+      severity: 'medium',
+      category: 'general',
+      title: 'Picked finding',
+      explanation: 'Why it matters here',
+      citation: null,
+      page: 1,
+      paragraphIndex: 0,
+      snippet: 'Tenant shall pay rent.',
+      span: { start: 0, end: 8 },
+      confidence: 0.9,
+      negated: false,
+      rulePackVersion: '1.0.0',
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    defaults({ selected: finding as any });
+    expect(screen.getByRole('article', { name: /selected finding/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /picked finding/i })).toBeInTheDocument();
+  });
+
+  it('renders the OCR running progress when ocrState.kind is "running"', () => {
+    const status = makeStatus();
+    status.result.doc = {
+      pages: [{ pageNumber: 1, width: 612, height: 792, items: [] }],
+      paragraphs: [],
+      sections: [],
+      raw: '',
+    };
+    defaults({
+      status,
+      ocrState: { kind: 'running', pct: 0.42, stage: 'recognizing' },
+    });
+    expect(screen.getByText(/Running OCR.*recognizing.*42%/i)).toBeInTheDocument();
+  });
+
+  it('renders the OCR error alert when ocrState.kind is "error"', () => {
+    const status = makeStatus();
+    status.result.doc = {
+      pages: [{ pageNumber: 1, width: 612, height: 792, items: [] }],
+      paragraphs: [],
+      sections: [],
+      raw: '',
+    };
+    defaults({
+      status,
+      ocrState: { kind: 'error', message: 'no traineddata' },
+    });
+    expect(screen.getByRole('alert')).toHaveTextContent(/OCR failed: no traineddata/);
+  });
 });


### PR DESCRIPTION
## Summary
+8 targeted test cases across 3 existing test files. Branches **89.07 → 89.34** (+0.27).

## Threshold bump SKIPS again
Need ≥89.5% for the 0.5% buffer. We're at 89.34 — short by 0.16%. Fifth wave running where the bump skips. Bump rolls to Wave 23+.

## Per-file gains
- \`hybridAnalyze.test.ts\` (+2): cosine zero-length + all-zero edge cases. **77.08 → 82.69**.
- \`featureFlag.test.ts\` (+3): URL/localStorage throw paths + undefined-localStorage. **66.66 → 84.61**.
- \`AppCurrentPane.test.tsx\` (+3): selected-finding article, OCR running progress, OCR error alert.

## Why the buffer keeps slipping
Each Wave-21+ extraction added defensive `?? ''` / `!x || !y` paths that v8 counts as branches but runtime can't reach. The remaining missed branches in `hybridAnalyze.ts` (lines 143, 148, 191-192) are `noUncheckedIndexedAccess` guards that fire only if we corrupt the de-duped index maps — not testable without invasive mocking. Wave 23+ should decide between (a) accepting 89-90% as the natural ceiling and stopping the chase, or (b) dropping a few defensive guards in a follow-up cleanup.

## Cap discipline
- 0 of ≤4 NEW test files; 8 of ≤20 cases ✓
- 0 src edits ✓
- All-files coverage: stmt 97.17 / branch 89.34 / func 93.69 / line 97.17 (above floors) ✓

## Test plan
- [x] \`npm run typecheck && npm run lint && npm run test:coverage\` — 1201 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)