### PR TITLE
wave23-B: wire loadClassifier into usePipeline (Phase 18 real path)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -184,6 +184,7 @@ function AppContent(): JSX.Element {
   const pipeline = usePipeline({
     onLibraryChange: refreshLibrary,
     rules: packs.activeRules,
+    audit: safeAudit,
   });
   const { status, ocrState, comparison } = pipeline;
   const analyzedLeaseId = status.kind === 'analyzed' ? status.leaseId : null;

--- a/app/src/App/usePipeline.test.ts
+++ b/app/src/App/usePipeline.test.ts
@@ -126,6 +126,55 @@ describe('usePipeline', () => {
     }
   });
 
+  it('ocr() falls back to deterministic-only when Phase 18 flag is off', async () => {
+    // Wave 23-B regression check: with the flag default-off, the audit
+    // callback never fires (no llm-classify entries) and the result
+    // shape matches the deterministic-only path.
+    const audit = vi.fn(async () => undefined);
+    const { result } = renderHook(() => usePipeline({ audit }));
+    const bytes = await makeBytes();
+    await act(async () => {
+      await result.current.upload(bytes, 'lease.pdf');
+    });
+    await act(async () => {
+      await result.current.ocr();
+    });
+    // No llm-classify entries when flag is off (the only kind audit
+    // would receive from the OCR path is llm-classify; analyze /
+    // save-lease are wired elsewhere).
+    const llmClassifyCalls = audit.mock.calls.filter(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (c: any[]) => c[0]?.kind === 'llm-classify',
+    );
+    expect(llmClassifyCalls).toHaveLength(0);
+  });
+
+  it('ocr() falls back gracefully when loadClassifier throws', async () => {
+    // Force the flag on for this test, then expect the inner load to
+    // fail (jsdom can't run @xenova/transformers) and the pipeline to
+    // still complete with deterministic findings.
+    Object.defineProperty(window, 'location', {
+      value: new URL('http://localhost/?phase18=on'),
+      writable: true,
+    });
+    const audit = vi.fn(async () => undefined);
+    const { result } = renderHook(() => usePipeline({ audit }));
+    const bytes = await makeBytes();
+    await act(async () => {
+      await result.current.upload(bytes, 'lease.pdf');
+    });
+    await act(async () => {
+      await result.current.ocr();
+    });
+    // Status reaches 'analyzed' regardless of classifier load failure.
+    expect(result.current.status.kind).toBe('analyzed');
+    // Restore.
+    Object.defineProperty(window, 'location', {
+      value: new URL('http://localhost/'),
+      writable: true,
+    });
+  });
+
   it('open() sets status to analyzed from a LeaseRecord', async () => {
     const { result } = renderHook(() => usePipeline());
     act(() => {
@@ -193,8 +242,7 @@ describe('usePipeline', () => {
   it('reanalyze() re-runs rules over the current doc with current rules', async () => {
     // Start with an empty rule set — no findings after upload.
     const { result, rerender } = renderHook(
-      (props: { rules: import('../rules/types').Rule[] }) =>
-        usePipeline({ rules: props.rules }),
+      (props: { rules: import('../rules/types').Rule[] }) => usePipeline({ rules: props.rules }),
       { initialProps: { rules: [] as import('../rules/types').Rule[] } },
     );
     const bytes = await makeBytes();

--- a/app/src/App/usePipeline.ts
+++ b/app/src/App/usePipeline.ts
@@ -4,6 +4,7 @@ import { runOcr } from '../ocr/runOcr';
 import { analyze } from '../rules/analyze';
 import { runHybridAnalyze, type EmbedFunction } from '../rules/hybridAnalyze';
 import { isPhase18Enabled } from '../llm/featureFlag';
+import { DEFAULT_MODEL_ID, loadClassifier } from '../llm/loadClassifier';
 import { RULE_PACK_V1 } from '../rules/packV1';
 import type { Rule } from '../rules/types';
 import { getLease, getStandardId, saveLease, type LeaseRecord } from '../storage/storage';
@@ -73,6 +74,32 @@ export interface UsePipelineDeps {
    * main-thread pipeline).
    */
   pipelineClient?: PipelineClient;
+  /**
+   * Optional audit callback. When supplied AND Phase 18's flag is on,
+   * the hybrid analyze path threads this through `runHybridAnalyze`'s
+   * `audit` parameter so each LLM-derived finding fires one
+   * `kind: 'llm-classify'` entry. App.tsx passes its `safeAudit`
+   * wrapper here so audit-write failures stay swallowed.
+   *
+   * Wave 23-B addition — purely additive; existing callers (tests
+   * that don't care about audit attestation) can omit it.
+   */
+  audit?: (entry: { kind: string; payload: Record<string, unknown> }) => Promise<void> | void;
+}
+
+/**
+ * Best-effort load of the on-device classifier. Returns null when the
+ * model files haven't been dropped (`npm run build:classifier-assets`
+ * not run) OR when transformers.js fails to bootstrap (e.g. WebGPU
+ * unavailable in jsdom). Either way the hybrid path silently falls
+ * back to the deterministic engine.
+ */
+async function loadClassifierEmbedFn(): Promise<EmbedFunction | null> {
+  try {
+    return await loadClassifier();
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -93,7 +120,7 @@ export function usePipeline(deps: UsePipelineDeps = {}): PipelineApi {
     null,
   );
 
-  const { onLibraryChange, rules, pipelineClient } = deps;
+  const { onLibraryChange, rules, pipelineClient, audit } = deps;
   const activeRules = rules ?? RULE_PACK_V1;
 
   // Memoize the auto-selected client so we don't spin up a new Worker per
@@ -161,16 +188,21 @@ export function usePipeline(deps: UsePipelineDeps = {}): PipelineApi {
         });
         // Phase 18 hybrid path: deterministic engine first; the optional
         // classifier pass only adds findings when the flag is on AND an
-        // embedFn is supplied. Wave 21 ships the seam — no production
-        // caller fetches the real model yet, so embedFn stays null and
-        // the wrapper degrades to plain analyze() at runtime. Wave 22+
-        // wires loadClassifier into this site.
-        const hybridEmbedFn: EmbedFunction | null = null;
+        // embedFn loads cleanly. Wave 23-B wires loadClassifier here;
+        // when the classifier files are missing OR transformers.js fails
+        // to bootstrap (e.g. jsdom, no WebGPU), `loadClassifierEmbedFn`
+        // returns null and the wrapper degrades to plain analyze().
+        const hybridEnabled = isPhase18Enabled();
+        const hybridEmbedFn: EmbedFunction | null = hybridEnabled
+          ? await loadClassifierEmbedFn()
+          : null;
         const findings = await runHybridAnalyze({
           doc,
           rules: activeRules,
-          enabled: isPhase18Enabled(),
+          enabled: hybridEnabled,
           embedFn: hybridEmbedFn,
+          ...(audit ? { audit } : {}),
+          modelId: DEFAULT_MODEL_ID,
         });
         setStatus({
           kind: 'analyzed',
@@ -184,7 +216,7 @@ export function usePipeline(deps: UsePipelineDeps = {}): PipelineApi {
         setOcrState({ kind: 'error', message: friendlyError(err) });
       }
     },
-    [status, activeRules],
+    [status, activeRules, audit],
   );
 
   const reanalyze = useCallback((): void => {


### PR DESCRIPTION
## Summary
- \`usePipeline.ts\` imports \`loadClassifier\` + \`DEFAULT_MODEL_ID\`. New \`loadClassifierEmbedFn()\` helper does a best-effort load that swallows transformers.js bootstrap failures (missing classifier files OR jsdom without WebGPU); returns null on any failure → hybrid path degrades to deterministic-only.
- \`UsePipelineDeps\` gains optional \`audit\` callback. \`App.tsx\` threads \`safeAudit\` through so the existing \`'llm-classify'\` attestation entries (Wave 22-A) actually fire when the classifier loads.
- The OCR-fallback path (Wave 21-A's edit point) now passes a real \`embedFn\` + \`audit\` + \`modelId\` to \`runHybridAnalyze\`. **Worker path is intentionally unchanged** — Wave 24+ wires the worker.

## Cap discipline
- 1 src edit (\`usePipeline.ts\`) + 1 small \`App.tsx\` threading edit ✓
- 1 test extension (2 new cases) ✓
- No new files ✓
- Worker path untouched ✓
- Coverage held: stmt 97.19 / branch 89.36 / func 93.7 / line 97.19 ✓

## Test plan
- [x] \`npm run typecheck && npm run lint && npm run test:coverage\` — 1203 tests passing.
- [x] 2 new \`usePipeline.test.ts\` cases:
  - flag-off → deterministic equivalence (no \`llm-classify\` entries).
  - flag-on + classifier load failure → pipeline still completes (jsdom can't run @xenova/transformers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)