### PR TITLE
wave23-C: Finding.evidence + CSP wasm-unsafe-eval audit

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; font-src 'self' data:; connect-src 'self' blob:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'"
+      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; font-src 'self' data:; connect-src 'self' blob:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'"
     />
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <title>LeaseGuard</title>

--- a/app/src/rules/hybridAnalyze.test.ts
+++ b/app/src/rules/hybridAnalyze.test.ts
@@ -234,6 +234,29 @@ describe('runHybridAnalyze', () => {
     expect(payload?.modelId).toBe('unknown');
   });
 
+  it('hybrid findings carry evidence: { modelId, similarity }; deterministic findings do not', async () => {
+    const embedFn = vi.fn(makeStubEmbedder());
+    const findings = await runHybridAnalyze({
+      doc: doc([
+        'This lease shall auto-renew annually.',
+        'The renewal clause grants additional renewal terms upon notice.',
+      ]),
+      rules: [rule()],
+      enabled: true,
+      embedFn,
+      modelId: 'Xenova/test-model',
+      threshold: 0.3,
+    });
+    expect(findings).toHaveLength(2);
+    const deterministic = findings.find((f) => f.confidence >= 0.7);
+    const hybrid = findings.find((f) => f.confidence === 0.5);
+    expect(deterministic?.evidence).toBeUndefined();
+    expect(hybrid?.evidence).toEqual({
+      modelId: 'Xenova/test-model',
+      similarity: expect.any(Number),
+    });
+  });
+
   it('cosine returns 0 for zero-length vectors (no extra finding emitted)', async () => {
     const zeroEmbedder: EmbedFunction = async (texts) => texts.map(() => new Float32Array(0));
     const findings = await runHybridAnalyze({

--- a/app/src/rules/hybridAnalyze.ts
+++ b/app/src/rules/hybridAnalyze.ts
@@ -160,6 +160,7 @@ export async function runHybridAnalyze(opts: HybridAnalyzeOptions): Promise<Find
       confidence: 0.5,
       negated: false,
       rulePackVersion: RULE_PACK_VERSION,
+      evidence: { modelId, similarity: sim },
     });
     if (audit) {
       // Fire-and-await one attestation per hybrid finding. Errors in

--- a/app/src/rules/types.ts
+++ b/app/src/rules/types.ts
@@ -85,6 +85,15 @@ export interface Finding {
    * existing finding consumers keep working unchanged.
    */
   deviation?: { fromFingerprint: string };
+  /**
+   * Wave 23 Part C — Phase 18 hybrid attestation. Set on findings
+   * emitted by the on-device classifier pass (confidence 0.5);
+   * absent on deterministic regex/proximity findings. Mirrors the
+   * Wave 22-A `'llm-classify'` audit-log payload so consumers that
+   * don't have access to the audit log can still display the LLM
+   * provenance (future UI badge, JSON export attestation).
+   */
+  evidence?: { modelId: string; similarity: number };
 }
 
 export interface RuleMatch {

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -12,7 +12,9 @@ items closed out in Wave 11 (see `docs/BACKLOG.md` → "Known unknowns &
 risk register"). When a related design changes, update the matching
 section here in the same PR.
 
-**Last review:** 2026-04-25 (Wave 16-F).
+**Last review:** 2026-04-26 (Wave 23-C — CSP `'wasm-unsafe-eval'`
+added to `script-src` for Phase 18 ONNX runtime; static analysis
+only, empirical Chrome verification deferred to Wave 24 e2e).
 
 Findings from the 2026-04-25 pass:
 
@@ -145,7 +147,8 @@ specific lease, the stack trace can encode the **shape** of the trigger
 `app/index.html` sets:
 
 ```
-Content-Security-Policy: default-src 'self'; script-src 'self';
+Content-Security-Policy: default-src 'self';
+  script-src 'self' 'wasm-unsafe-eval';
   style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:;
   font-src 'self' data:; connect-src 'self' blob:;
   worker-src 'self' blob:; object-src 'none'; base-uri 'self';
@@ -153,9 +156,21 @@ Content-Security-Policy: default-src 'self'; script-src 'self';
 ```
 
 This is the Phase 0 / Phase 6 promise: zero third-party origins, no
-inline scripts, no eval. Workers and blob URLs are permitted because
-the PWA ships `pdf.worker`, the lease-analysis Web Worker, and the
-tesseract worker — all served same-origin.
+inline scripts. Workers and blob URLs are permitted because the PWA
+ships `pdf.worker`, the lease-analysis Web Worker, and the tesseract
+worker — all served same-origin.
+
+`'wasm-unsafe-eval'` was added in Wave 23-C to allow Phase 18's
+ONNX Runtime Web (used by `@xenova/transformers`) to instantiate
+its WebAssembly module from a fetched buffer. Chrome's CSP enforcer
+requires this directive for any `WebAssembly.instantiate` /
+`WebAssembly.compile` call when CSP is set via `<meta>`. The
+classifier itself is served same-origin from `/classifier/` (Wave
+23-A); the directive does NOT loosen `default-src` or allow
+arbitrary external WebAssembly. Empirical runtime verification
+(loading the model in real Chrome and watching the console for CSP
+violations) is the manual follow-up tracked as Wave 24's e2e work
+— this section reflects the static analysis only.
 
 ### Build-time gate (`npm run check:csp`)
 


### PR DESCRIPTION
## Summary
Two additions bundled — both small, both Phase-18-related.

### C1 — \`Finding.evidence\` field
Wave 16-C's BACKLOG row asked for per-finding LLM attestation. Wave 22-A added the audit-log entry; Part C now puts the same data on the \`Finding\` itself so consumers without access to the audit log can display LLM provenance (future UI badge, JSON export).

- \`Finding.evidence?: { modelId: string; similarity: number }\` — set on hybrid findings, absent on deterministic.
- \`hybridAnalyze.ts\` populates it on hybrid findings (same payload as the \`'llm-classify'\` audit entry).
- 1 new test case pins the contract.

### C2 — CSP \`'wasm-unsafe-eval'\`
\`@xenova/transformers\` + ONNX Runtime Web call \`WebAssembly.instantiate\` from a fetched buffer; Chrome's CSP enforcer blocks this with the current \`script-src 'self'\` when CSP is set via \`<meta>\`. Standard fix:

- \`app/index.html\` CSP: \`script-src 'self' 'wasm-unsafe-eval'\`. Other directives unchanged.
- \`docs/SECURITY.md\` § 3 documents the directive's purpose + the explicit non-loosening (still no third-party origins; classifier served same-origin from \`/classifier/\`).
- "Last review" date bumped to 2026-04-26.

**Empirical Chrome verification (loading the model, watching console for CSP violations) is the manual follow-up — tracked as Wave 24 e2e work.**

\`npm run check:csp\` unchanged (that script scans for third-party URLs, doesn't validate directive content).

## Cap discipline
- 2 src edits + 1 doc + 1 CSP edit ✓
- 1 new test case ✓
- 0 \`check-csp.mjs\` changes (not needed) ✓
- Coverage: branch 89.37 / line 97.19 (above floors) ✓
- 1204 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)