### PR TITLE
wave24-A: hybrid classifier pass on the upload path

### DIFF
--- a/app/src/App/usePipeline.test.ts
+++ b/app/src/App/usePipeline.test.ts
@@ -1,5 +1,12 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
+vi.mock('../llm/loadClassifier', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../llm/loadClassifier')>();
+  return {
+    ...mod,
+    loadClassifier: vi.fn(mod.loadClassifier),
+  };
+});
 vi.mock('../ocr/runOcr', () => ({
   runOcr: vi.fn(async (_bytes: Uint8Array) => ({
     pages: [{ pageNumber: 1, width: 612, height: 792, items: [] }],
@@ -11,6 +18,7 @@ vi.mock('../ocr/runOcr', () => ({
   })),
 }));
 import { usePipeline } from './usePipeline';
+import { loadClassifier } from '../llm/loadClassifier';
 import { makePdf } from '../parser/testFixtures';
 import {
   _resetDbForTests,
@@ -279,6 +287,86 @@ describe('usePipeline', () => {
     });
     if (result.current.status.kind !== 'error') throw new Error('expected error');
     expect(result.current.status.message).toBe('boom');
+  });
+
+  // Wave 24-A: upload() now runs the classifier pass on the main thread
+  // after the worker returns, when Phase 18 is enabled AND the classifier
+  // loads. These two tests pin the flag-on success path (extras appended)
+  // and the flag-on load-fails fallback (deterministic findings unchanged
+  // — no error surfaced).
+  it('upload() appends hybrid findings when Phase 18 flag is on and classifier loads', async () => {
+    Object.defineProperty(window, 'location', {
+      value: new URL('http://localhost/?phase18=on'),
+      writable: true,
+    });
+    // Inject a stub embedder that produces high similarity for any pair
+    // (returns identical unit vectors). The fixture paragraphs include
+    // "renewal" / "arbitration" / "jury" tokens that the rule pack
+    // pre-filter will key on, so the classifier pass has work to do.
+    const stubEmbed = async (texts: string[]): Promise<Float32Array[]> =>
+      texts.map(() => new Float32Array([1, 0, 0]));
+    vi.mocked(loadClassifier).mockResolvedValueOnce(stubEmbed);
+
+    // Use a single non-matching rule whose title shares the "lease"
+    // keyword with the fixture paragraphs — deterministic emits 0,
+    // pre-filter passes, stub embedder returns similarity = 1.
+    const classifyRule: import('../rules/types').Rule = {
+      id: 'classify-only',
+      severity: 'low',
+      category: 'general',
+      title: 'Lease classification probe',
+      explanation: 'probe',
+      citation: null,
+      match: { type: 'regex', pattern: 'definitely_no_match_token_xyz' },
+    };
+    const audit = vi.fn(async () => undefined);
+    const { result } = renderHook(() => usePipeline({ audit, rules: [classifyRule] }));
+    const bytes = await makeBytes();
+    await act(async () => {
+      await result.current.upload(bytes, 'lease.pdf');
+    });
+    expect(result.current.status.kind).toBe('analyzed');
+    // At least one llm-classify audit entry should have fired (the
+    // stub embedder produces similarity = 1 for every candidate, so
+    // every pre-filter hit becomes a hybrid finding).
+    const llmCalls = audit.mock.calls.filter(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (c: any[]) => c[0]?.kind === 'llm-classify',
+    );
+    expect(llmCalls.length).toBeGreaterThan(0);
+    // Restore.
+    Object.defineProperty(window, 'location', {
+      value: new URL('http://localhost/'),
+      writable: true,
+    });
+  });
+
+  it('upload() falls back to deterministic findings when classifier load fails (no error surfaced)', async () => {
+    Object.defineProperty(window, 'location', {
+      value: new URL('http://localhost/?phase18=on'),
+      writable: true,
+    });
+    vi.mocked(loadClassifier).mockRejectedValueOnce(new Error('wasm boot failed'));
+
+    const audit = vi.fn(async () => undefined);
+    const { result } = renderHook(() => usePipeline({ audit }));
+    const bytes = await makeBytes();
+    await act(async () => {
+      await result.current.upload(bytes, 'lease.pdf');
+    });
+    // Status reaches 'analyzed' regardless — load failure is swallowed.
+    expect(result.current.status.kind).toBe('analyzed');
+    // No llm-classify audit entries (the classifier never ran).
+    const llmCalls = audit.mock.calls.filter(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (c: any[]) => c[0]?.kind === 'llm-classify',
+    );
+    expect(llmCalls).toHaveLength(0);
+    // Restore.
+    Object.defineProperty(window, 'location', {
+      value: new URL('http://localhost/'),
+      writable: true,
+    });
   });
 
   it('routes upload() through an injected pipelineClient (Phase 13 worker hook)', async () => {

--- a/app/src/App/usePipeline.ts
+++ b/app/src/App/usePipeline.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { type AnalysisResult } from '../ui/analyzeFile';
 import { runOcr } from '../ocr/runOcr';
 import { analyze } from '../rules/analyze';
-import { runHybridAnalyze, type EmbedFunction } from '../rules/hybridAnalyze';
+import { runClassifierPass, runHybridAnalyze, type EmbedFunction } from '../rules/hybridAnalyze';
 import { isPhase18Enabled } from '../llm/featureFlag';
 import { DEFAULT_MODEL_ID, loadClassifier } from '../llm/loadClassifier';
 import { RULE_PACK_V1 } from '../rules/packV1';
@@ -138,7 +138,37 @@ export function usePipeline(deps: UsePipelineDeps = {}): PipelineApi {
         // hand the worker (or inline pipeline) a dedicated copy and keep
         // the original for the viewer. The worker-backed client also
         // transfers the copy's buffer; the viewer's copy is untouched.
-        const result: AnalysisResult = await client.parseAndAnalyze(copyBytes(bytes), activeRules);
+        const baseResult: AnalysisResult = await client.parseAndAnalyze(
+          copyBytes(bytes),
+          activeRules,
+        );
+        // Phase 18 hybrid path on the upload flow (Wave 24-A): run the
+        // classifier pass on the main thread after the worker returns
+        // deterministic findings. Worker source stays untouched —
+        // transformers.js + WebGPU don't currently fit in the worker.
+        // When the flag is off OR the classifier files are missing OR
+        // transformers.js fails to bootstrap, this is a no-op and the
+        // upload path stays byte-identical to Wave 23.
+        let result = baseResult;
+        if (isPhase18Enabled()) {
+          const embedFn = await loadClassifierEmbedFn();
+          if (embedFn) {
+            const extras = await runClassifierPass({
+              doc: baseResult.doc,
+              rules: activeRules,
+              baseFindings: baseResult.findings,
+              embedFn,
+              ...(audit ? { audit } : {}),
+              modelId: DEFAULT_MODEL_ID,
+            });
+            if (extras.length > 0) {
+              result = {
+                doc: baseResult.doc,
+                findings: [...baseResult.findings, ...extras],
+              };
+            }
+          }
+        }
         const newId = await saveLease({
           name: fileName,
           doc: result.doc,
@@ -172,7 +202,7 @@ export function usePipeline(deps: UsePipelineDeps = {}): PipelineApi {
         setStatus({ kind: 'error', message: friendlyError(err) });
       }
     },
-    [onLibraryChange, activeRules, client],
+    [onLibraryChange, activeRules, client, audit],
   );
 
   const ocr = useCallback(

--- a/app/src/rules/hybridAnalyze.test.ts
+++ b/app/src/rules/hybridAnalyze.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { runHybridAnalyze, type EmbedFunction } from './hybridAnalyze';
+import { runClassifierPass, runHybridAnalyze, type EmbedFunction } from './hybridAnalyze';
 import type { LeaseDocument } from '../parser/types';
 import type { Rule } from './types';
 
@@ -281,6 +281,56 @@ describe('runHybridAnalyze', () => {
       threshold: 0.0001,
     });
     expect(findings).toHaveLength(0);
+  });
+
+  // Wave 24-A: runClassifierPass is the standalone classifier pass that
+  // the upload-path now calls after the Web Worker returns deterministic
+  // findings. It must return ONLY the delta (extras) and never re-emit
+  // findings against paragraphs already covered by `baseFindings`.
+  it('runClassifierPass: returns delta only when given pre-computed baseFindings', async () => {
+    const embedFn = vi.fn(makeStubEmbedder());
+    const d = doc(['The renewal clause grants additional renewal terms upon notice.']);
+    const extras = await runClassifierPass({
+      doc: d,
+      rules: [rule()],
+      baseFindings: [], // no deterministic findings yet
+      embedFn,
+      threshold: 0.3,
+    });
+    expect(extras).toHaveLength(1);
+    expect(extras[0]?.confidence).toBe(0.5);
+    expect(extras[0]?.paragraphIndex).toBe(0);
+  });
+
+  it('runClassifierPass: never duplicates findings against paragraphs already covered by baseFindings', async () => {
+    const embedFn = vi.fn(makeStubEmbedder());
+    const d = doc(['The renewal clause grants additional renewal terms upon notice.']);
+    // Pre-seed a deterministic finding on paragraph 0 — the classifier
+    // pass must skip it.
+    const extras = await runClassifierPass({
+      doc: d,
+      rules: [rule()],
+      baseFindings: [
+        {
+          ruleId: 'r1',
+          severity: 'medium',
+          category: 'general',
+          title: 'Auto-renewal clause',
+          explanation: 'preset',
+          citation: null,
+          page: 1,
+          paragraphIndex: 0,
+          snippet: '',
+          span: { start: 0, end: 0 },
+          confidence: 0.9,
+          negated: false,
+          rulePackVersion: '1',
+        },
+      ],
+      embedFn,
+      threshold: 0.3,
+    });
+    expect(extras).toEqual([]);
   });
 
   it('skips rules whose title has no 4+-char tokens (cheap pre-filter is empty)', async () => {

--- a/app/src/rules/hybridAnalyze.ts
+++ b/app/src/rules/hybridAnalyze.ts
@@ -54,6 +54,17 @@ export interface HybridAnalyzeOptions {
   modelId?: string;
 }
 
+export interface RunClassifierPassOptions {
+  doc: LeaseDocument;
+  rules: Rule[] | CompiledRule[];
+  baseFindings: Finding[];
+  embedFn: EmbedFunction;
+  threshold?: number;
+  maxLlmCalls?: number;
+  audit?: (entry: HybridAnalyzeAuditEntry) => Promise<void> | void;
+  modelId?: string;
+}
+
 const DEFAULT_THRESHOLD = 0.7;
 const DEFAULT_MAX_LLM_CALLS = 50;
 
@@ -63,14 +74,39 @@ const DEFAULT_MAX_LLM_CALLS = 50;
  */
 export async function runHybridAnalyze(opts: HybridAnalyzeOptions): Promise<Finding[]> {
   const { doc, rules, enabled, embedFn } = opts;
+  const baseFindings = analyze(doc, rules);
+  if (!enabled || embedFn === null) return baseFindings;
+  const extras = await runClassifierPass({
+    doc,
+    rules,
+    baseFindings,
+    embedFn,
+    ...(opts.threshold !== undefined ? { threshold: opts.threshold } : {}),
+    ...(opts.maxLlmCalls !== undefined ? { maxLlmCalls: opts.maxLlmCalls } : {}),
+    ...(opts.audit ? { audit: opts.audit } : {}),
+    ...(opts.modelId !== undefined ? { modelId: opts.modelId } : {}),
+  });
+  return [...baseFindings, ...extras];
+}
+
+/**
+ * Phase-18 classifier pass over a doc, returning ONLY the extras
+ * (hybrid findings) so the caller can concat them onto pre-computed
+ * `baseFindings`. Wave 24-A extracts this so the upload path can run
+ * the classifier after the worker returns deterministic findings,
+ * without re-running the regex pass on the main thread.
+ *
+ * The pass skips paragraphs that already have at least one entry in
+ * `baseFindings` (deterministic findings always win).
+ */
+export async function runClassifierPass(opts: RunClassifierPassOptions): Promise<Finding[]> {
+  const { doc, rules, baseFindings, embedFn } = opts;
   const threshold = opts.threshold ?? DEFAULT_THRESHOLD;
   const maxLlmCalls = opts.maxLlmCalls ?? DEFAULT_MAX_LLM_CALLS;
   const audit = opts.audit;
   const modelId = opts.modelId ?? 'unknown';
 
-  const baseFindings = analyze(doc, rules);
-
-  if (!enabled || embedFn === null || maxLlmCalls <= 0) return baseFindings;
+  if (maxLlmCalls <= 0) return [];
 
   // Index of paragraphs that already have at least one finding —
   // these are skipped on the classifier pass.
@@ -115,7 +151,7 @@ export async function runHybridAnalyze(opts: HybridAnalyzeOptions): Promise<Find
     if (work.length >= maxLlmCalls) break;
   }
 
-  if (work.length === 0) return baseFindings;
+  if (work.length === 0) return [];
 
   // Embed paragraphs and rule titles in two batched calls. De-dupe.
   const paraIdxs = Array.from(new Set(work.map((w) => w.pIdx)));
@@ -179,7 +215,7 @@ export async function runHybridAnalyze(opts: HybridAnalyzeOptions): Promise<Find
     }
   }
 
-  return [...baseFindings, ...extras];
+  return extras;
 }
 
 function cosine(a: Float32Array, b: Float32Array): number {


### PR DESCRIPTION
## Summary

Wave 24 Part A — extends Phase 18 to the **upload** flow (previously OCR-only).

- Extracts `runClassifierPass` from `runHybridAnalyze` so callers with pre-computed `baseFindings` (the worker-returned ones) can run only the classifier pass — no redundant `analyze()` re-run on the main thread.
- `runHybridAnalyze` becomes a thin wrapper; OCR-path behavior byte-identical.
- `usePipeline.upload` runs the pass after the worker returns, when Phase 18 is on AND the classifier loads. Flag off OR load failure → no behavior change vs. Wave 23.
- Worker source untouched (transformers.js + WebGPU don't currently fit there; Wave 25+ revisits if needed).

## Scope

| Cap | Used |
|-----|------|
| 2 src edits | ✅ `hybridAnalyze.ts` + `usePipeline.ts` |
| 2 test extensions | ✅ `hybridAnalyze.test.ts` (+2) + `usePipeline.test.ts` (+2) |
| 0 new files | ✅ |
| Worker source untouched | ✅ |
| Flag-off byte-identical | ✅ |

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test:coverage` — 1208 passed; branches 89.43% (≥ 88% floor)
- [x] `runClassifierPass` returns delta only; never duplicates against `baseFindings`
- [x] `upload()` flag-on success: stub `loadClassifier` → extras appended, audit fires
- [x] `upload()` flag-on load-fails: deterministic findings unchanged, no error surfaced
- [x] All 13 existing `runHybridAnalyze` cases still pass (wrapper bytes-equivalent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)