### PR TITLE
wave24-B: hybrid-finding UI badge

### DIFF
--- a/app/src/ui/FindingsPanel.test.tsx
+++ b/app/src/ui/FindingsPanel.test.tsx
@@ -61,6 +61,38 @@ describe('FindingsPanel', () => {
     expect(screen.getByText(/not applicable/i)).toBeInTheDocument();
   });
 
+  // Wave 24-B: hybrid findings (those with `evidence` from the Phase 18
+  // classifier pass) render a small badge whose aria-label conveys the
+  // model's similarity score for screen readers. Deterministic findings
+  // render no badge.
+  it('renders a hybrid badge with similarity percentage on findings carrying evidence', () => {
+    render(
+      <FindingsPanel
+        findings={[
+          f({
+            ruleId: 'h',
+            title: 'Hybrid hit',
+            confidence: 0.5,
+            evidence: { modelId: 'Xenova/test-model', similarity: 0.83 },
+          }),
+        ]}
+        onSelect={() => {}}
+      />,
+    );
+    const badge = screen.getByLabelText(/identified by on-device classifier \(similarity 83%\)/i);
+    expect(badge).toBeInTheDocument();
+  });
+
+  it('renders no hybrid badge on deterministic findings (no evidence)', () => {
+    render(
+      <FindingsPanel
+        findings={[f({ ruleId: 'd', title: 'Deterministic hit' })]}
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.queryByLabelText(/identified by on-device classifier/i)).not.toBeInTheDocument();
+  });
+
   it('filters findings by search query across title and explanation', async () => {
     const findings = [
       f({ ruleId: 'a', title: 'Arbitration clause', explanation: 'Disputes go to arbitrator.' }),
@@ -156,9 +188,7 @@ describe('FindingsPanel', () => {
   it('omits the "What this means" disclosure when plainEnglish is absent', () => {
     const finding = f({ ruleId: 'no-pe', title: 'No PE' });
     render(<FindingsPanel findings={[finding]} onSelect={() => {}} />);
-    expect(
-      screen.queryByRole('button', { name: /what this means/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /what this means/i })).not.toBeInTheDocument();
   });
 
   it('omits the "What this means" disclosure when the map has no entry for this rule', () => {
@@ -170,9 +200,7 @@ describe('FindingsPanel', () => {
         plainEnglishByRuleId={{ 'other-rule': 'not this one' }}
       />,
     );
-    expect(
-      screen.queryByRole('button', { name: /what this means/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /what this means/i })).not.toBeInTheDocument();
   });
 
   // Phase 14 — hover glossary on snippets.
@@ -187,11 +215,7 @@ describe('FindingsPanel', () => {
       { term: 'Premises', definition: 'the leased building.', page: 1, paragraphIndex: 0 },
     ];
     const { container } = render(
-      <FindingsPanel
-        findings={[finding]}
-        onSelect={() => {}}
-        definitions={definitions}
-      />,
+      <FindingsPanel findings={[finding]} onSelect={() => {}} definitions={definitions} />,
     );
     const dfn = container.querySelector('dfn');
     expect(dfn).not.toBeNull();
@@ -205,9 +229,7 @@ describe('FindingsPanel', () => {
       title: 'No glossary',
       snippet: 'The Premises shall be delivered on time.',
     });
-    const { container } = render(
-      <FindingsPanel findings={[finding]} onSelect={() => {}} />,
-    );
+    const { container } = render(<FindingsPanel findings={[finding]} onSelect={() => {}} />);
     expect(container.querySelector('dfn')).toBeNull();
   });
 
@@ -249,9 +271,7 @@ describe('FindingsPanel', () => {
         suggestedTextByRuleId={{ nobtn: 'Suggested.' }}
       />,
     );
-    expect(
-      screen.queryByRole('button', { name: /apply suggestion/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /apply suggestion/i })).not.toBeInTheDocument();
   });
 
   it('omits "Apply suggestion" when the rule id has no suggested text', () => {
@@ -264,9 +284,7 @@ describe('FindingsPanel', () => {
         onApplySuggestion={() => {}}
       />,
     );
-    expect(
-      screen.queryByRole('button', { name: /apply suggestion/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /apply suggestion/i })).not.toBeInTheDocument();
   });
 
   it('"Apply suggestion" invokes the callback with finding, paragraphIndex, and suggested text', async () => {
@@ -284,9 +302,7 @@ describe('FindingsPanel', () => {
         onApplySuggestion={onApplySuggestion}
       />,
     );
-    await userEvent.click(
-      screen.getByRole('button', { name: /apply suggestion for apply me/i }),
-    );
+    await userEvent.click(screen.getByRole('button', { name: /apply suggestion for apply me/i }));
     expect(onApplySuggestion).toHaveBeenCalledWith(finding, 4, 'Suggested replacement.');
   });
 
@@ -348,9 +364,7 @@ describe('FindingsPanel', () => {
           f({ ruleId: 'b', severity: 'high', title: 'Second finding' }),
           f({ ruleId: 'c', severity: 'high', title: 'Third finding' }),
         ];
-        const { container } = render(
-          <FindingsPanel findings={findings} onSelect={() => {}} />,
-        );
+        const { container } = render(<FindingsPanel findings={findings} onSelect={() => {}} />);
 
         // Before any intersection event, all three are "off viewport" in
         // the observer-present branch — they should appear as placeholders
@@ -390,9 +404,7 @@ describe('FindingsPanel', () => {
             span: { start: i, end: i + 5 },
           }),
         );
-        const { container } = render(
-          <FindingsPanel findings={findings} onSelect={() => {}} />,
-        );
+        const { container } = render(<FindingsPanel findings={findings} onSelect={() => {}} />);
         // With no intersections reported yet, every row is a placeholder.
         const fullButtons = container.querySelectorAll('button.finding-btn');
         expect(fullButtons.length).toBeLessThan(100);

--- a/app/src/ui/FindingsPanel.tsx
+++ b/app/src/ui/FindingsPanel.tsx
@@ -49,11 +49,7 @@ interface FindingsPanelProps {
    * finding that invokes this with the finding, its paragraphIndex, and
    * the suggested text. Wiring into redline storage is App's job.
    */
-  onApplySuggestion?: (
-    finding: Finding,
-    paragraphIndex: number,
-    suggestedText: string,
-  ) => void;
+  onApplySuggestion?: (finding: Finding, paragraphIndex: number, suggestedText: string) => void;
   /**
    * Wave 10 Part C — optional "Promote to standard" callback. When defined
    * (and `leaseId` is supplied), each finding renders a button that
@@ -208,9 +204,7 @@ export function FindingsPanel({
                         glossary={glossary}
                         plain={plain}
                         isExplainerOpen={isOpen}
-                        toggleExplainer={() =>
-                          toggleInSet(openExplainers, key, setOpenExplainers)
-                        }
+                        toggleExplainer={() => toggleInSet(openExplainers, key, setOpenExplainers)}
                         suggestedText={suggested}
                         onSelect={onSelect}
                         onApplySuggestion={onApplySuggestion}
@@ -254,9 +248,7 @@ export function FindingsPanel({
     // effect inside VirtualFindingItem will claim focus when the button
     // appears.
     pendingFocusRef.current = nextKey;
-    const li = root.querySelector<HTMLLIElement>(
-      `li[data-finding-key="${cssEscape(nextKey)}"]`,
-    );
+    const li = root.querySelector<HTMLLIElement>(`li[data-finding-key="${cssEscape(nextKey)}"]`);
     if (li && typeof li.scrollIntoView === 'function') {
       li.scrollIntoView({ block: 'nearest' });
     }
@@ -282,9 +274,7 @@ interface VirtualFindingItemProps {
   onApplySuggestion:
     | ((finding: Finding, paragraphIndex: number, suggestedText: string) => void)
     | undefined;
-  onPromoteToStandard:
-    | ((leaseId: string, paragraphIndex: number) => void)
-    | undefined;
+  onPromoteToStandard: ((leaseId: string, paragraphIndex: number) => void) | undefined;
   leaseId: string | undefined;
   pendingFocusRef: { current: string | null };
 }
@@ -341,9 +331,7 @@ function VirtualFindingItem(props: VirtualFindingItemProps): JSX.Element {
             onClick={() => onSelect(finding)}
           >
             <strong>{finding.title}</strong>
-            {finding.negated && (
-              <span aria-label="negated"> (possibly not applicable)</span>
-            )}
+            {finding.negated && <span aria-label="negated"> (possibly not applicable)</span>}
             {finding.deviation && (
               <span
                 className="finding-deviation-badge"
@@ -353,15 +341,24 @@ function VirtualFindingItem(props: VirtualFindingItemProps): JSX.Element {
                 deviates from verified pack
               </span>
             )}
+            {finding.evidence && (
+              <span
+                className="finding-llm-badge"
+                title={`On-device classifier (similarity ${Math.round(
+                  finding.evidence.similarity * 100,
+                )}%)`}
+                aria-label={`Identified by on-device classifier (similarity ${Math.round(
+                  finding.evidence.similarity * 100,
+                )}%)`}
+              >
+                {' '}
+                ~
+              </span>
+            )}
             <div>{finding.explanation}</div>
-            {(definitions && definitions.length > 0) ||
-            (glossary && glossary.length > 0) ? (
+            {(definitions && definitions.length > 0) || (glossary && glossary.length > 0) ? (
               <small className="finding-snippet">
-                {highlightDefinedTerms(
-                  finding.snippet,
-                  definitions ?? [],
-                  glossary,
-                )}
+                {highlightDefinedTerms(finding.snippet, definitions ?? [], glossary)}
               </small>
             ) : null}
             <small>Page {finding.page}</small>
@@ -383,9 +380,7 @@ function VirtualFindingItem(props: VirtualFindingItemProps): JSX.Element {
             <button
               type="button"
               aria-label={`apply suggestion for ${finding.title}`}
-              onClick={() =>
-                onApplySuggestion(finding, finding.paragraphIndex, suggestedText)
-              }
+              onClick={() => onApplySuggestion(finding, finding.paragraphIndex, suggestedText)}
             >
               Apply suggestion
             </button>
@@ -394,9 +389,7 @@ function VirtualFindingItem(props: VirtualFindingItemProps): JSX.Element {
             <button
               type="button"
               aria-label={`promote to standard ${finding.title}`}
-              onClick={() =>
-                onPromoteToStandard(leaseId, finding.paragraphIndex)
-              }
+              onClick={() => onPromoteToStandard(leaseId, finding.paragraphIndex)}
             >
               Promote to standard
             </button>
@@ -413,11 +406,7 @@ function VirtualFindingItem(props: VirtualFindingItemProps): JSX.Element {
   );
 }
 
-function toggleInSet<T>(
-  current: Set<T>,
-  value: T,
-  setter: (s: Set<T>) => void,
-): void {
+function toggleInSet<T>(current: Set<T>, value: T, setter: (s: Set<T>) => void): void {
   const next = new Set(current);
   if (next.has(value)) next.delete(value);
   else next.add(value);

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -158,6 +158,11 @@ New UI panels live in `src/ui/` and follow a four-file convention:
    free-form string. `llm-classify` fires once per Phase 18 hybrid
    finding (Wave 22-A); payload includes `{ ruleId, paragraphIndex,
    modelId, similarity }`.
+6. **Hybrid-finding badge** (Wave 24-B): `FindingsPanel` renders a
+   `finding-llm-badge` span next to the title for any finding carrying
+   `evidence: { modelId, similarity }`; the badge's `aria-label` exposes
+   the similarity percentage so screen readers convey provenance.
+   Deterministic findings render no badge.
 
 ## Testing patterns
 


### PR DESCRIPTION
## Summary

Wave 24 Part B — small UI cue on findings emitted by the Phase 18 classifier pass.

- Findings carrying `evidence: { modelId, similarity }` (Wave 23-C) render a `finding-llm-badge` span next to the title; deterministic findings render no badge.
- Visible glyph: `~`. Tooltip + `aria-label` both expose the rounded similarity percentage so screen readers convey provenance.
- Single src edit (`FindingsPanel.tsx`); no new files, no new ARIA roles, no i18n, no schema change.

## Scope

| Cap | Used |
|-----|------|
| 1 src edit | ✅ `FindingsPanel.tsx` |
| 1 test extension | ✅ `FindingsPanel.test.tsx` (+2 cases) |
| 1 CLAUDE.md line | ✅ panel-convention bullet under §Adding a panel |
| 0 new files | ✅ |

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` — 1210 passed
- [x] Hybrid finding (with evidence) → badge rendered with similarity 83%
- [x] Deterministic finding (no evidence) → no badge
- [x] All 22 prior FindingsPanel tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)