### PR TITLE
wave24-C: defensive-guard cleanup + branch threshold 88 → 89

### DIFF
--- a/app/src/rules/hybridAnalyze.ts
+++ b/app/src/rules/hybridAnalyze.ts
@@ -132,8 +132,9 @@ export async function runClassifierPass(opts: RunClassifierPassOptions): Promise
   const work: Work[] = [];
   for (let pIdx = 0; pIdx < doc.paragraphs.length; pIdx++) {
     if (flagged.has(pIdx)) continue;
-    const para = doc.paragraphs[pIdx];
-    if (!para) continue;
+    // pIdx < doc.paragraphs.length, so the indexed access is always
+    // defined; the `!` strips a TypeScript-narrowing branch.
+    const para = doc.paragraphs[pIdx]!;
     const lower = para.text.toLowerCase();
     for (let rIdx = 0; rIdx < rulesArr.length; rIdx++) {
       const kws = ruleKeywords[rIdx];
@@ -156,8 +157,11 @@ export async function runClassifierPass(opts: RunClassifierPassOptions): Promise
   // Embed paragraphs and rule titles in two batched calls. De-dupe.
   const paraIdxs = Array.from(new Set(work.map((w) => w.pIdx)));
   const ruleIdxs = Array.from(new Set(work.map((w) => w.rIdx)));
-  const paraTexts = paraIdxs.map((i) => doc.paragraphs[i]?.text ?? '');
-  const ruleTexts = ruleIdxs.map((i) => rulesArr[i]?.title ?? '');
+  // paraIdxs / ruleIdxs come from `work` items pushed only when the
+  // outer loops asserted the index was in bounds against the same
+  // arrays — the indexed accesses can't return undefined.
+  const paraTexts = paraIdxs.map((i) => doc.paragraphs[i]!.text);
+  const ruleTexts = ruleIdxs.map((i) => rulesArr[i]!.title);
 
   const [paraVecs, ruleVecs] = await Promise.all([embedFn(paraTexts), embedFn(ruleTexts)]);
 
@@ -179,9 +183,11 @@ export async function runClassifierPass(opts: RunClassifierPassOptions): Promise
     if (!pv || !rv) continue;
     const sim = cosine(pv, rv);
     if (sim < threshold) continue;
-    const rule = rulesArr[w.rIdx];
-    const para = doc.paragraphs[w.pIdx];
-    if (!rule || !para) continue;
+    // w.rIdx / w.pIdx were both bounds-checked against rulesArr /
+    // doc.paragraphs when `work` was populated, so the lookups always
+    // yield defined values here — strip the TS-narrowing branches.
+    const rule = rulesArr[w.rIdx]!;
+    const para = doc.paragraphs[w.pIdx]!;
     extras.push({
       ruleId: rule.id,
       severity: rule.severity,
@@ -225,8 +231,11 @@ function cosine(a: Float32Array, b: Float32Array): number {
   let na = 0;
   let nb = 0;
   for (let i = 0; i < n; i++) {
-    const av = a[i] ?? 0;
-    const bv = b[i] ?? 0;
+    // i < n = min(a.length, b.length), so both indexed accesses are
+    // in-bounds and Float32Array always returns a number — drop the
+    // `?? 0` defaults that v8 was counting as branches.
+    const av = a[i]!;
+    const bv = b[i]!;
     dot += av * bv;
     na += av * av;
     nb += bv * bv;

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -67,16 +67,15 @@ export default defineConfig({
         'src/worker/leaseWorker.ts',
       ],
       thresholds: {
-        // Raised 2026-04-25 after Wave 16 Part A test additions
-        // (appHelpers, useVersionHistory, clauseClusters edge cases).
-        // Actuals sit at 96.63 / 88.31 / 93.03 / 96.63; the +1 branch
-        // bump (87 → 88) is the honest ceiling without (a) decomposing
-        // App.tsx (38 missed branches; tracked as a Wave 17 candidate)
-        // and (b) reducing v8's defensive-guard noise from
-        // `noUncheckedIndexedAccess` (`?? 0` / `?? ''` paths it counts
-        // as branches but that runtime cannot reach).
+        // Raised 2026-04-26 (Wave 24-C) after surgical removal of
+        // unreachable defensive guards in `hybridAnalyze.ts` (loop-
+        // bounded indexed accesses no longer pay v8's `?? 0` / `?? ''`
+        // branch tax). Actuals sit at 97.27 / 89.61 / 93.71 / 97.27;
+        // the +1 branch bump (88 → 89) is the honest ceiling absent
+        // either (a) decomposing App.tsx further or (b) another guard
+        // sweep on remaining `noUncheckedIndexedAccess` artifacts.
         statements: 95,
-        branches: 88,
+        branches: 89,
         functions: 91,
         lines: 95,
       },

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -89,19 +89,21 @@ which is also directly covered.
 ## Coverage thresholds
 
 Defined in `app/vite.config.ts` under `test.coverage.thresholds`.
-Current floors: **stmt 95 / branch 88 / func 91 / line 95**. Actuals
-as of 2026-04-25: 96.63 / 88.31 / 93.03 / 96.63. Floors leave ~1.5
-points of headroom on stmt/line and func, ~0.3 on branch — branch is
-the tight one because the two structural ceilings on the codebase
-keep it sticky:
+Current floors: **stmt 95 / branch 89 / func 91 / line 95**. Actuals
+as of 2026-04-26 (post-Wave-24-C): 97.27 / 89.61 / 93.71 / 97.27.
+Floors leave ~2 points of headroom on stmt/line, ~2.7 on func, ~0.6
+on branch — branch is the tight one because the two structural
+ceilings on the codebase keep it sticky:
 
-- `App.tsx` is 1007 lines with 38 missed branches; raising branch
-  coverage past ~89 means decomposing it (tracked as a Wave 17
-  candidate, not a Wave 16 task).
+- `App.tsx` decomposition (Waves 17–21) trimmed it 1007 → 541 lines;
+  remaining branch headroom now comes from continued extraction OR
+  from the next surgical guard sweep.
 - `noUncheckedIndexedAccess` produces `?? 0` / `?? ''` defensive
   guards that v8 counts as branches but that runtime cannot reach.
-  These show up across the parser / matchers / diff code as
-  permanently uncovered branches.
+  Wave 24-C dropped the unreachable subset in `hybridAnalyze.ts`
+  (loop-bounded indexed accesses); these still show up across the
+  parser / matchers / diff code and remain permanently uncovered
+  branches there.
 
 Raise floors in lock-step with actuals; never set a floor you don't
 already have headroom on.


### PR DESCRIPTION
## Summary

Wave 24 Part C — surgical removal of unreachable TypeScript-narrowing guards in `hybridAnalyze.ts`, then the contingent branch-threshold bump.

Each removal sits on a loop-bounded index against the same array it indexes — v8 was counting them as branches but runtime cannot reach them. Other guards (e.g. around external `embedFn` returns) ARE reachable on adversarial inputs and were left intact.

## Removed guards

| Site | Removed | Why unreachable |
|---|---|---|
| L136 | `if (!para) continue;` | `pIdx < doc.paragraphs.length` |
| L159–160 | `?.text ?? ''` / `?.title ?? ''` | indices come from `work` (already in-bounds) |
| L184 | `if (!rule || !para) continue;` | same `work` indices |
| L228–229 | `?? 0` in cosine | `i < min(a.length, b.length)` on `Float32Array` |

## Coverage

- Pre-cleanup actual: branches **89.43%**
- Post-cleanup actual: branches **89.61%** (clears the plan's 89.5% buffer)
- Floor bumped: `vite.config.ts` `branches: 88` → `89`
- TESTING.md actuals refreshed

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (no `@typescript-eslint/no-non-null-assertion` violations)
- [x] `npm run test:coverage` — 1210 passed; branches above new 89 floor
- [x] All 16 hybridAnalyze tests still pass (no behavior change)
- [x] Each removed guard has a written rationale (commit body + inline comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)