### PR TITLE
wave25-A: Phase 18 e2e smoke (re-scoped)

### DIFF
--- a/tests/e2e/phase18-smoke.spec.ts
+++ b/tests/e2e/phase18-smoke.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+// Wave 25 Part A — Phase 18 smoke. The hybrid classifier path is wired
+// into both OCR (Wave 23-B) and upload (Wave 24-A) pipelines, but the
+// classifier assets aren't dropped in CI (Wave 23-A's downloader is a
+// one-time manual step). The smoke contract here is narrow:
+//
+//   1. `?phase18=on` is recognized by the runtime feature flag and
+//      doesn't crash the app on boot.
+//   2. The sample-lease deterministic happy path still works with the
+//      flag on (i.e. enabling Phase 18 doesn't regress the existing
+//      regex pipeline when the classifier files are absent).
+//   3. NO hybrid badge renders on the deterministic findings — the
+//      classifier load fails cleanly (no assets) and the upload /
+//      OCR fallbacks (Wave 23-B / 24-A) keep the deterministic
+//      findings unchanged with no `evidence` payload.
+//
+// The real-model golden case (a paraphrased clause that ONLY the
+// classifier catches) lives in Wave 25 Part C behind a `RUN_REAL_MODEL`
+// env gate so it stays off PR CI until a nightly job is wired.
+
+test.describe('Phase 18 flag-on smoke', () => {
+  test('flag on + sample lease: deterministic findings render, no hybrid badge', async ({
+    page,
+  }) => {
+    await page.goto('/?phase18=on');
+
+    const skipTour = page.getByRole('button', { name: /skip onboarding tour/i });
+    await skipTour.click();
+
+    await page.getByRole('button', { name: /try a sample lease/i }).click();
+
+    const findings = page.getByRole('complementary', { name: /findings/i });
+    await expect(findings).toBeVisible();
+    const findingButtons = findings.locator('button.finding-btn');
+    await expect(findingButtons.first()).toBeVisible({ timeout: 15_000 });
+
+    // Hybrid badge is the Wave 24-B span with this aria-label prefix.
+    // Without classifier assets in CI, NO finding should carry one.
+    const hybridBadges = findings.locator(
+      '[aria-label^="Identified by on-device classifier"]',
+    );
+    await expect(hybridBadges).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Wave 25 Part A — re-scoped after preflight surfaced that Playwright is **already** fully scaffolded at the repo root (config, CI matrix across chromium/firefox/webkit, three existing specs in \`tests/e2e/\`). Per user direction, this PR ships the smaller scope: one new spec under the existing infrastructure.

## What this PR does

Adds \`tests/e2e/phase18-smoke.spec.ts\`. Pins three contracts:

1. \`?phase18=on\` is a recognized flag value (no boot crash).
2. Sample-lease deterministic happy path still renders findings when the flag is on.
3. No hybrid badge appears on those findings (classifier load fails cleanly without assets; Wave 23-B / 24-A fallbacks hold).

No new deps. No config changes. No production source changes.

## Out of scope (deferred per plan)

- The real-model golden case (a paraphrased clause that ONLY the classifier catches) → Wave 25 Part C, env-gated behind \`RUN_REAL_MODEL=1\`.

## Test plan

- [x] \`npx playwright test --project=chromium tests/e2e/phase18-smoke.spec.ts\` — green (734ms)
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean

## Pre-existing red

\`tests/e2e/save-and-library.spec.ts\` is failing on \`main\` as of this commit — verified by checking out main and running it. Not introduced by this PR. Worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)