### PR TITLE
fix(e2e): save-and-library spec — filename + virtualized-row drift

### DIFF
--- a/tests/e2e/save-and-library.spec.ts
+++ b/tests/e2e/save-and-library.spec.ts
@@ -18,13 +18,23 @@ test.describe('LeaseGuard library flow', () => {
     await expect(findingButtons.first()).toBeVisible({ timeout: 15_000 });
 
     // usePipeline auto-saves analyzed leases. The library row's "open" button
-    // surfaces with the file name aria-label, e.g. "open sample.pdf".
-    const openSample = page.getByRole('button', { name: /open sample\.pdf/i });
+    // surfaces with the file name aria-label, e.g. "Open Sample lease.pdf".
+    // (The sample-lease handler in useAppCallbacks names the synthesized
+    // file "Sample lease.pdf", not "sample.pdf" — the spec drifted from
+    // the source.)
+    const openSample = page.getByRole('button', { name: /open sample lease\.pdf/i });
     await expect(openSample).toBeVisible({ timeout: 10_000 });
 
     // Reopen the saved record. Findings panel stays populated (the saved
-    // record carries findings, not just bytes).
+    // record carries findings, not just bytes). The "Open" button lives
+    // at the bottom of the page, so after the click we're scrolled past
+    // the FindingsPanel — which is virtualized (Phase 13's
+    // VirtualFindingItem swaps offscreen rows for placeholders). Assert
+    // on the severity-group heading instead, which is always rendered
+    // and includes the finding count.
     await openSample.click();
-    await expect(findingButtons.first()).toBeVisible({ timeout: 10_000 });
+    // The h2 wraps a button whose aria-label is "toggle high" — match by
+    // visible text instead, which carries the rendered count "High (N)".
+    await expect(findings.getByText(/^High \(\d+\)$/)).toBeVisible({ timeout: 10_000 });
   });
 });


### PR DESCRIPTION
## Summary

\`tests/e2e/save-and-library.spec.ts\` has been red on \`main\` since shortly after it was added in Wave 16-B. Two stale assumptions, both surfaced when Wave 25's preflight ran the e2e suite end-to-end:

1. **Sample filename drift.** The handler in \`useAppCallbacks\` synthesizes the sample as \`"Sample lease.pdf"\` (with space + word "lease"); the spec was looking for \`/open sample\\.pdf/i\` — never matched. Updated regex to \`/open sample lease\\.pdf/i\`.

2. **Virtualization regression.** Phase 13's \`VirtualFindingItem\` renders a placeholder for any finding row outside the viewport. Clicking the library "Open" button (at the bottom of the page) scrolls the FindingsPanel out of view, so post-click there's no \`.finding-btn\` element. Switched the post-open assertion to the severity-group's visible "High (N)" text, which the panel always renders.

## Test plan

- [x] \`npx playwright test --project=chromium tests/e2e/save-and-library.spec.ts\` — green (587ms)
- [x] Full chromium e2e (3 specs) green in 3.3s
- [x] Pre-existing \`golden.spec.ts\` and \`a11y.spec.ts\` unchanged, still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)