### PR TITLE
wave25-B: click-to-explain affordance on hybrid badge

### DIFF
--- a/app/src/ui/FindingsPanel.test.tsx
+++ b/app/src/ui/FindingsPanel.test.tsx
@@ -93,6 +93,62 @@ describe('FindingsPanel', () => {
     expect(screen.queryByLabelText(/identified by on-device classifier/i)).not.toBeInTheDocument();
   });
 
+  // Wave 25-B: clicking the hybrid badge expands an inline detail panel
+  // that surfaces the modelId, similarity %, and threshold context. The
+  // disclosure pattern mirrors the existing "What this means" affordance
+  // (aria-expanded on the trigger; sibling content gates on it).
+  it('hybrid badge: clicking expands an inline detail panel with modelId + similarity', async () => {
+    render(
+      <FindingsPanel
+        findings={[
+          f({
+            ruleId: 'h',
+            title: 'Hybrid hit',
+            confidence: 0.5,
+            evidence: { modelId: 'Xenova/paraphrase-MiniLM-L3-v2', similarity: 0.83 },
+          }),
+        ]}
+        onSelect={() => {}}
+      />,
+    );
+    const badge = screen.getByRole('button', {
+      name: /identified by on-device classifier \(similarity 83%\)/i,
+    });
+    expect(badge).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('Xenova/paraphrase-MiniLM-L3-v2')).not.toBeInTheDocument();
+
+    await userEvent.click(badge);
+
+    expect(badge).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Xenova/paraphrase-MiniLM-L3-v2')).toBeInTheDocument();
+    expect(screen.getByText('83%')).toBeInTheDocument();
+    expect(screen.getByText(/above the 70% similarity floor/i)).toBeInTheDocument();
+  });
+
+  it('hybrid badge: clicking again collapses the detail panel', async () => {
+    render(
+      <FindingsPanel
+        findings={[
+          f({
+            ruleId: 'h',
+            title: 'Hybrid hit',
+            confidence: 0.5,
+            evidence: { modelId: 'Xenova/test-model', similarity: 0.71 },
+          }),
+        ]}
+        onSelect={() => {}}
+      />,
+    );
+    const badge = screen.getByRole('button', {
+      name: /identified by on-device classifier/i,
+    });
+    await userEvent.click(badge);
+    expect(badge).toHaveAttribute('aria-expanded', 'true');
+    await userEvent.click(badge);
+    expect(badge).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('Xenova/test-model')).not.toBeInTheDocument();
+  });
+
   it('filters findings by search query across title and explanation', async () => {
     const findings = [
       f({ ruleId: 'a', title: 'Arbitration clause', explanation: 'Disputes go to arbitrator.' }),

--- a/app/src/ui/FindingsPanel.tsx
+++ b/app/src/ui/FindingsPanel.tsx
@@ -205,6 +205,10 @@ export function FindingsPanel({
                         plain={plain}
                         isExplainerOpen={isOpen}
                         toggleExplainer={() => toggleInSet(openExplainers, key, setOpenExplainers)}
+                        isHybridDetailOpen={openExplainers.has(`${key}:hybrid`)}
+                        toggleHybridDetail={() =>
+                          toggleInSet(openExplainers, `${key}:hybrid`, setOpenExplainers)
+                        }
                         suggestedText={suggested}
                         onSelect={onSelect}
                         onApplySuggestion={onApplySuggestion}
@@ -269,6 +273,8 @@ interface VirtualFindingItemProps {
   plain: string | undefined;
   isExplainerOpen: boolean;
   toggleExplainer: () => void;
+  isHybridDetailOpen: boolean;
+  toggleHybridDetail: () => void;
   suggestedText: string | undefined;
   onSelect: (finding: Finding) => void;
   onApplySuggestion:
@@ -288,6 +294,8 @@ function VirtualFindingItem(props: VirtualFindingItemProps): JSX.Element {
     plain,
     isExplainerOpen,
     toggleExplainer,
+    isHybridDetailOpen,
+    toggleHybridDetail,
     suggestedText,
     onSelect,
     onApplySuggestion,
@@ -341,20 +349,6 @@ function VirtualFindingItem(props: VirtualFindingItemProps): JSX.Element {
                 deviates from verified pack
               </span>
             )}
-            {finding.evidence && (
-              <span
-                className="finding-llm-badge"
-                title={`On-device classifier (similarity ${Math.round(
-                  finding.evidence.similarity * 100,
-                )}%)`}
-                aria-label={`Identified by on-device classifier (similarity ${Math.round(
-                  finding.evidence.similarity * 100,
-                )}%)`}
-              >
-                {' '}
-                ~
-              </span>
-            )}
             <div>{finding.explanation}</div>
             {(definitions && definitions.length > 0) || (glossary && glossary.length > 0) ? (
               <small className="finding-snippet">
@@ -363,6 +357,34 @@ function VirtualFindingItem(props: VirtualFindingItemProps): JSX.Element {
             ) : null}
             <small>Page {finding.page}</small>
           </button>
+          {finding.evidence ? (
+            <div className="finding-llm-detail">
+              <button
+                type="button"
+                className="finding-llm-badge"
+                aria-expanded={isHybridDetailOpen}
+                aria-label={`Identified by on-device classifier (similarity ${Math.round(
+                  finding.evidence.similarity * 100,
+                )}%)`}
+                title={`On-device classifier (similarity ${Math.round(
+                  finding.evidence.similarity * 100,
+                )}%)`}
+                onClick={toggleHybridDetail}
+              >
+                ~
+              </button>
+              {isHybridDetailOpen ? (
+                <dl className="finding-llm-evidence">
+                  <dt>Model</dt>
+                  <dd>{finding.evidence.modelId}</dd>
+                  <dt>Similarity</dt>
+                  <dd>{Math.round(finding.evidence.similarity * 100)}%</dd>
+                  <dt>Threshold</dt>
+                  <dd>Above the 70% similarity floor</dd>
+                </dl>
+              ) : null}
+            </div>
+          ) : null}
           {plain ? (
             <div className="finding-plain-english">
               <button

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -158,11 +158,14 @@ New UI panels live in `src/ui/` and follow a four-file convention:
    free-form string. `llm-classify` fires once per Phase 18 hybrid
    finding (Wave 22-A); payload includes `{ ruleId, paragraphIndex,
    modelId, similarity }`.
-6. **Hybrid-finding badge** (Wave 24-B): `FindingsPanel` renders a
-   `finding-llm-badge` span next to the title for any finding carrying
-   `evidence: { modelId, similarity }`; the badge's `aria-label` exposes
-   the similarity percentage so screen readers convey provenance.
-   Deterministic findings render no badge.
+6. **Hybrid-finding badge** (Wave 24-B / 25-B): `FindingsPanel`
+   renders a `finding-llm-badge` button next to each finding carrying
+   `evidence: { modelId, similarity }`; the button's `aria-label`
+   exposes the similarity percentage so screen readers convey
+   provenance. Clicking the badge toggles an inline `<dl>` (modelId,
+   similarity %, threshold context) for users who want the raw
+   provenance — no new audit `kind`, no IDB writes, read-only over
+   `Finding.evidence`. Deterministic findings render no badge.
 
 ## Testing patterns
 


### PR DESCRIPTION
## Summary

Wave 25 Part B — promotes the Wave 24-B static badge to an interactive button that toggles an inline detail panel surfacing the \`Finding.evidence\` payload (modelId, similarity %, threshold context).

## What changed

- **Badge → button.** The Wave 24-B \`<span class="finding-llm-badge">\` is now a \`<button class="finding-llm-badge">\` with \`aria-expanded\` and a click handler. Had to move it OUT of the parent \`<button class="finding-btn">\` to avoid nested-button HTML — it now sits in a sibling \`<div class="finding-llm-detail">\` after the row button.
- **Disclosure block.** When expanded, renders an inline \`<dl>\` with: Model (\`evidence.modelId\`), Similarity (rounded %), Threshold ("Above the 70% similarity floor").
- **State reuse.** The existing \`openExplainers: Set<string>\` tracks the new disclosure with a \`:hybrid\` suffix so it's independent of the plain-English one.
- **Read-only.** No new audit \`kind\`, no IDB writes, no new product UI panel.

## Scope

| Cap | Used |
|-----|------|
| 1 src edit | ✅ \`FindingsPanel.tsx\` |
| 1 test extension | ✅ \`FindingsPanel.test.tsx\` (+2 cases; 2 prior cases adapted) |
| 1 CLAUDE.md line | ✅ Wave 24-B bullet rewritten |
| 0 new files | ✅ |

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test:coverage\` — 1212 passed; branches 89.64% (≥ 89 floor)
- [x] Click-to-expand: aria-expanded flips; modelId, similarity %, threshold copy visible
- [x] Click-to-collapse: aria-expanded flips back; content removed
- [x] Existing 22 FindingsPanel cases still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)