### PR TITLE
wave25-C: real-model golden e2e (env-gated)

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -171,6 +171,31 @@ smoke test (chrome-devtools MCP) when the behavior is any of:
 One browser walk per release is plenty; the smoke test's job is to
 catch jsdom-shaped blind spots, not replace the unit suite.
 
+## End-to-end (Playwright)
+
+Specs live in `tests/e2e/`; `playwright.config.ts` at the repo root
+boots the production preview (`app/dist/`) on port 4173. CI runs
+the matrix across chromium / firefox / webkit on every PR.
+
+The Phase 18 real-model golden case (`tests/e2e/hybrid-golden.spec.ts`)
+is gated behind `RUN_REAL_MODEL=1` so it stays off PR CI. To run
+locally:
+
+```bash
+cd app
+npm run build:classifier-assets   # one-time, drops weights into public/classifier
+npm run build
+cd ..
+RUN_REAL_MODEL=1 npx playwright test --project=chromium tests/e2e/hybrid-golden.spec.ts
+```
+
+**Known gap (Wave 26 fix):** the spec currently fails even with
+assets present, because `loadClassifier.ts` doesn't configure
+`@xenova/transformers`'s local-model path — the runtime falls back
+to fetching from huggingface.co and the upload path silently
+degrades to deterministic-only. The spec is shipped now to document
+the contract; the loader fix unsticks it without spec edits.
+
 ## Run commands
 
 ```bash

--- a/tests/e2e/hybrid-golden.spec.ts
+++ b/tests/e2e/hybrid-golden.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Wave 25 Part C — real-model golden case.
+//
+// Env-gated behind RUN_REAL_MODEL=1 so it stays off PR CI until Wave 26
+// wires a nightly job. The contract:
+//
+//   1. Phase 18 flag on (`?phase18=on`).
+//   2. Classifier asset bundle present at `app/dist/classifier/` (the
+//      one-time output of `npm run build:classifier-assets` from
+//      Wave 23-A).
+//   3. Sample lease analyzed. At least one finding carries
+//      `evidence.modelId === 'Xenova/paraphrase-MiniLM-L3-v2'` —
+//      proving the classifier ran end-to-end (asset fetch → ONNX
+//      runtime boot → embedding → cosine sim → Finding emission).
+//   4. Clicking the badge (Wave 25-B affordance) reveals the modelId
+//      in the inline `<dl>`.
+//   5. Zero CSP violations in the page console.
+//
+// Locally:
+//
+//   cd app && npm run build:classifier-assets   # one-time
+//   cd app && npm run build
+//   RUN_REAL_MODEL=1 npx playwright test --project=chromium tests/e2e/hybrid-golden.spec.ts
+//
+// Without `RUN_REAL_MODEL=1`, the spec is skipped entirely.
+//
+// KNOWN GAP (Wave 26): this spec currently FAILS even with assets
+// present, because `loadClassifier.ts` doesn't configure
+// `@xenova/transformers`'s `env.localModelPath` / `env.allowRemoteModels`
+// — the runtime falls back to fetching from huggingface.co (which the
+// upload-path then catches and silently degrades to deterministic-only,
+// so no `llm-classify` audit entries fire and no hybrid badges render).
+// Wave 25 Part C ships the spec as-is so the contract is documented
+// and discoverable; Wave 26 fixes the loader and the spec will start
+// passing without any spec edits.
+
+const RUN_REAL_MODEL = process.env.RUN_REAL_MODEL === '1';
+
+test.describe('Phase 18 real-model golden', () => {
+  test.skip(!RUN_REAL_MODEL, 'set RUN_REAL_MODEL=1 to run the real classifier locally');
+
+  test('flag on + classifier assets present: hybrid finding rendered with badge + modelId', async ({
+    page,
+  }) => {
+    // Pre-flight: fail fast with an actionable message if the classifier
+    // bundle wasn't dropped, rather than mid-test on a 404.
+    const assetsDir = resolve(process.cwd(), 'app', 'dist', 'classifier');
+    expect(
+      existsSync(assetsDir),
+      'classifier assets missing — run `cd app && npm run build:classifier-assets && npm run build` first',
+    ).toBe(true);
+
+    // Capture CSP violations as they fire — the assertion at the end
+    // catches any that surfaced during model boot.
+    const cspViolations: string[] = [];
+    page.on('console', (msg) => {
+      const text = msg.text();
+      if (/Content Security Policy/i.test(text) || /CSP/i.test(text)) {
+        cspViolations.push(text);
+      }
+    });
+
+    await page.goto('/?phase18=on');
+    await page.getByRole('button', { name: /skip onboarding tour/i }).click();
+    await page.getByRole('button', { name: /try a sample lease/i }).click();
+
+    const findings = page.getByRole('complementary', { name: /findings/i });
+    await expect(findings).toBeVisible();
+    // Deterministic findings appear first; classifier pass runs after
+    // and re-renders. Give it generous time — model boot + embedding
+    // can take several seconds on first load.
+    const hybridBadges = findings.locator(
+      'button.finding-llm-badge[aria-label*="on-device classifier"]',
+    );
+    await expect(hybridBadges.first()).toBeVisible({ timeout: 60_000 });
+
+    // Click the first hybrid badge → inline detail panel surfaces the
+    // modelId. The Wave 25-B affordance renders `<dl>` with `<dd>`
+    // containing the literal model id string.
+    await hybridBadges.first().click();
+    await expect(findings.getByText('Xenova/paraphrase-MiniLM-L3-v2')).toBeVisible();
+
+    expect(cspViolations, `CSP violations during real-model run:\n${cspViolations.join('\n')}`)
+      .toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Wave 25 Part C — adds \`tests/e2e/hybrid-golden.spec.ts\`. Skipped by default; runs only when \`RUN_REAL_MODEL=1\`, matching the plan's contract that the heavier case stays off PR CI until Wave 26 wires a nightly job.

## What the spec asserts

Full Phase 18 chain on the upload path:

1. \`?phase18=on\` recognized
2. Sample lease analyzed
3. At least one finding carries a hybrid badge
4. Clicking the badge surfaces \`Xenova/paraphrase-MiniLM-L3-v2\` (Wave 25-B affordance)
5. Zero CSP violations on the page console

Includes a fail-fast pre-flight that flags missing classifier assets with an actionable hint instead of timing out mid-run on a 404.

## ⚠️ KNOWN GAP discovered while verifying locally (Wave 26 fix)

The spec currently fails even with assets present, because \`loadClassifier.ts\` doesn't tell \`@xenova/transformers\` where to find local model files (no \`env.localModelPath\` / \`env.allowRemoteModels\` config). The runtime falls back to fetching from huggingface.co; the upload path catches the failure and silently degrades to deterministic-only — no \`llm-classify\` audit entries fire and no hybrid badges render.

Per the plan's "0 src changes" cap on Part C, the loader fix rolls to Wave 26. The spec is shipped now so the contract is discoverable; when the loader is fixed the spec passes without any spec edits.

Documented inline in the spec header and in TESTING.md's new "End-to-end (Playwright)" section.

## Scope

| Cap | Used |
|-----|------|
| 1 new e2e file | ✅ \`tests/e2e/hybrid-golden.spec.ts\` |
| 1 doc paragraph | ✅ TESTING.md "End-to-end (Playwright)" section |
| 0 src changes | ✅ |
| Env-gated | ✅ \`RUN_REAL_MODEL=1\` required to un-skip |

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] Default Playwright run (no \`RUN_REAL_MODEL\`) — spec skipped
- [x] Full chromium e2e: 4 passed, 1 skipped
- [x] \`RUN_REAL_MODEL=1\` run — spec executes; fails as documented (Wave 26 loader gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)