### PR TITLE
wave26-B: npm audit triage + tech-debt verification

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -696,6 +696,22 @@ Things worth a deliberate decision before they surprise us.
       current audit pass. Quarterly (next 2026-07-25) and annual (next
       2027-04-25) human review cadences documented in
       `docs/SECURITY.md` §4 (2026-04-25).
+- [x] **npm audit standing decisions** — `app/` reports 4 critical
+      (`protobufjs <7.5.5` via `@xenova/transformers`) + 9 moderate
+      (`esbuild`/`vite` chain). Both audited in Wave 26-B and
+      consciously deferred: the critical never reaches the
+      vulnerable `protobufjs.parse()` (Phase 18 only uses
+      `transformers.pipeline()`); the moderate is dev-server-only
+      and the auditor's fix needs vite@8 (Wave 27 candidate).
+      Decisions + revisit triggers documented in `docs/SECURITY.md`
+      §7 (2026-04-26). Re-run `cd app && npm audit` quarterly.
+- [ ] **Vite 7-or-8 upgrade** (Wave 27 candidate) — clears the
+      moderate dev-time esbuild chain. Pre-flight: storybook 8 +
+      `vite-plugin-pwa` compatibility check; coverage threshold
+      revalidation; Workbox precache size verification.
+- [ ] **`@xenova/transformers` upstream bump watch** — when
+      transformers ships with `protobufjs >= 7.5.5`, take the
+      bump and retire `SECURITY.md` §7.1's "accept risk" line.
 
 ## Explicitly out of scope
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -358,3 +358,71 @@ This is the policy companion to the operational rules in
 bump versions; this section says **what compatibility guarantee** the
 signed-export bump implies. They must move together: a `v2` envelope
 PR must update both files in the same change.
+
+## 7. npm audit standing decisions
+
+`npm audit` (in `app/`) reports a small standing set of advisories
+that we've audited and consciously chosen to defer rather than take
+the breaking-change "fix" the auditor proposes. Each entry below
+includes the advisory, what we use the affected code for, why the
+fix is worse than the risk, and the trigger that flips the decision.
+
+Re-run `cd app && npm audit` quarterly (and on every Wave-N start)
+to verify nothing new has crept in.
+
+### 7.1 `protobufjs <7.5.5` — Arbitrary code execution in `parse()`
+
+**Path:** `@xenova/transformers` → `onnxruntime-web` → `onnx-proto` →
+`protobufjs`. Severity: **critical** at the advisory level.
+
+**What we use the dependency for:** Phase 18 hybrid classifier —
+loads a quantized MiniLM-L3 model and produces sentence embeddings
+for paragraph-vs-rule-title cosine similarity. The classifier path
+calls `transformers.pipeline('feature-extraction', ...)`, which
+internally uses ONNX Runtime Web; the path **never** invokes
+`protobufjs.parse()` (the API the advisory targets). Our model file
+ships pre-built and same-origin (Wave 25 fix); the protobuf code is
+only on the model-loading path and operates on bytes we shipped.
+
+**Why we don't take the auditor's fix:** `npm audit fix --force`
+proposes `@xenova/transformers@2.0.1`, which **removes** the model
+class we use. Effectively a Phase 18 rollback.
+
+**Decision (2026-04-26, Wave 26-B):** accept. Re-evaluate when
+`@xenova/transformers` ships an upstream release with `protobufjs
+>= 7.5.5`. Recheck quarterly.
+
+### 7.2 `esbuild <=0.24.2` — dev-server cross-origin reads
+
+**Path:** dev-time tooling — `vite` (5.x) → `esbuild`; also reached
+via `vitest`, `@vitest/coverage-v8`, `vite-node`, `vite-plugin-pwa`.
+Severity: **moderate** at the advisory level.
+
+**What we use the dependency for:** local dev server + the test
+runner's transform pipeline. The advisory affects esbuild's dev
+server; production builds (`npm run build`) emit static assets and
+don't ship esbuild. Risk surface is local-dev only.
+
+**Why we don't take the auditor's fix:** `npm audit fix --force`
+proposes `vite@8.0.10`, a 3-major-version bump. Storybook 8 + the
+current `vite-plugin-pwa` version need a compatibility audit before
+that lands.
+
+**Decision (2026-04-26, Wave 26-B):** accept dev-only risk. The
+**vite 7-or-8 upgrade** is queued as a Wave 27 candidate with
+explicit pre-flight (storybook + vite-plugin-pwa compatibility,
+coverage-threshold revalidation). Re-evaluate after vite-plugin-pwa
+ships a vite-7-compatible release.
+
+### 7.3 Other advisories
+
+The remaining moderate advisories at audit time are transitive
+consequences of 7.2 (the esbuild → vite chain pulls in the same
+advisory through `vite-node`, `vitest`, `@vitest/coverage-v8`,
+`vite-plugin-pwa`). They clear together when 7.2 clears.
+
+### 7.4 What the root `package.json` looks like
+
+The repo-root `package.json` (Playwright runner + husky + lint-staged
+only) reports **0 vulnerabilities**. The advisories above are
+scoped entirely to `app/`.


### PR DESCRIPTION
## Summary

Wave 26 Part B — documents-only PR. Triages \`npm audit\` findings in \`app/\`, records explicit accept-risk decisions with revisit triggers, updates the backlog, verifies the \`TODO\` sweep stays at zero. **No source changes**, no dep upgrades, no threshold changes.

## SECURITY.md gains a new §7 — npm audit standing decisions

Each entry covers: dep path, what we use the code for, why the auditor's "fix" is worse than the risk, the trigger that flips the decision.

| Advisory | Severity | Decision | Re-evaluate when |
|----------|---------:|----------|------------------|
| \`protobufjs <7.5.5\` (via \`@xenova/transformers\`) | critical | **Accept** — Phase 18 only calls \`transformers.pipeline()\`, never the vulnerable \`protobufjs.parse()\` API. \`--force\` fix downgrades transformers to 2.0.1 (removes our model class). | transformers ships with \`protobufjs >= 7.5.5\` |
| \`esbuild <=0.24.2\` (via vite/vitest/etc.) | moderate | **Accept dev-only risk**. Production builds don't ship esbuild. \`--force\` fix needs vite@8 (3-major bump). | Wave 27 vite-upgrade lands with storybook/vite-plugin-pwa compat audit |

Re-run \`cd app && npm audit\` quarterly (and on every Wave-N start).

## BACKLOG.md additions

- **§Risk register: npm audit standing decisions** — closed, points to SECURITY.md §7.
- **§Risk register: Vite 7-or-8 upgrade** — open, Wave 27 candidate with pre-flight contract.
- **§Risk register: \`@xenova/transformers\` upstream bump watch** — open, retire SECURITY.md §7.1 when upstream ships the fix.

## What got skipped (per plan)

- **Tech-debt refactor on \`appHelpers.ts\`** — plan said "IFF Part A surfaces unreachable guards there". Part A's audit found the gap is testability (needs top-level \`vi.mock\`), not unreachability. No guards to remove → no refactor.
- **Non-breaking dep bumps** — \`npm outdated\` reports \`wanted == current\` for every dep. Everything is a major-version bump → own wave.

## Verifications

- \`grep -rEn "TODO|FIXME|XXX|HACK" app/src --include='*.ts' --include='*.tsx'\` → **0 hits** (held from plan-time baseline through Part A).
- \`npm run typecheck\` clean.
- No source changes → no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)