### PR TITLE
wave27-B: primary analyzed view (8 components)

### DIFF
--- a/app/src/index.css
+++ b/app/src/index.css
@@ -69,6 +69,10 @@
 
   /* Single shadow */
   --shadow-paper: 0 1px 0 rgba(42, 35, 22, 0.05);
+
+  /* PDF highlight overlay — semi-transparent by design; no opaque hex form exists */
+  --color-highlight: rgba(255, 235, 59, 0.35);
+  --color-highlight-border: rgba(255, 193, 7, 0.9);
 }
 
 /* Base */

--- a/app/src/ui/AnnotationsPanel.tsx
+++ b/app/src/ui/AnnotationsPanel.tsx
@@ -78,7 +78,7 @@ export function AnnotationsPanel({
                       aria-label="edit note text"
                       value={editing.text}
                       onChange={(e) => setEditing({ ...editing, text: e.target.value })}
-                      className="w-full border border-rule rounded bg-paper-raised px-2 py-1 text-body text-fg focus:outline focus:outline-2 focus:outline-ink"
+                      className="w-full border border-rule rounded-sm bg-paper-raised px-2 py-1 text-body text-fg focus:outline focus:outline-2 focus:outline-ink"
                     />
                   </label>
                   <div className="flex gap-2">

--- a/app/src/ui/AnnotationsPanel.tsx
+++ b/app/src/ui/AnnotationsPanel.tsx
@@ -1,5 +1,18 @@
 import { useState } from 'react';
 import type { Annotation } from '../annotations/annotations';
+import { Section } from './system/Section';
+import { Button } from './system/Button';
+import { Field } from './system/Field';
+
+// Aria/data inventory (preserved verbatim):
+//   aria-label="annotations" (section)
+//   aria-label="edit note" (form)
+//   aria-label="edit note text" (textarea)
+//   aria-label="edit note" (button)
+//   aria-label="delete note" (button)
+//   aria-label="add note" (form)
+//   aria-label="new note" (textarea)
+//   className="visually-hidden" (span) — handled by Field's label rendering
 
 interface AnnotationsPanelProps {
   leaseId: string;
@@ -22,10 +35,10 @@ export function AnnotationsPanel({
 
   if (paragraphIndex === null) {
     return (
-      <section aria-label="annotations">
-        <h2>Notes</h2>
-        <p>Click a finding to attach a note.</p>
-      </section>
+      <Section label="annotations">
+        <h3 className="text-heading uppercase text-fg-muted mb-3">Notes</h3>
+        <p className="text-body text-fg-faint">Click a finding to attach a note.</p>
+      </Section>
     );
   }
 
@@ -49,46 +62,55 @@ export function AnnotationsPanel({
   }
 
   return (
-    <section aria-label="annotations">
-      <h2>Notes</h2>
+    <Section label="annotations" className="space-y-3">
+      <h3 className="text-heading uppercase text-fg-muted mb-3">Notes</h3>
       {forParagraph.length === 0 ? (
-        <p>No notes yet for this paragraph.</p>
+        <p className="text-body text-fg-faint">No notes yet for this paragraph.</p>
       ) : (
-        <ul>
+        <ul className="space-y-2">
           {forParagraph.map((a) => (
-            <li key={a.id}>
+            <li key={a.id} className="bg-paper-sunken border border-rule rounded-sm p-3">
               {editing?.id === a.id ? (
-                <form onSubmit={onEditSubmit} aria-label="edit note">
+                <form onSubmit={onEditSubmit} aria-label="edit note" className="space-y-2">
                   <label>
                     <span className="visually-hidden">Edit note text</span>
                     <textarea
                       aria-label="edit note text"
                       value={editing.text}
                       onChange={(e) => setEditing({ ...editing, text: e.target.value })}
+                      className="w-full border border-rule rounded bg-paper-raised px-2 py-1 text-body text-fg focus:outline focus:outline-2 focus:outline-ink"
                     />
                   </label>
-                  <button type="submit">Save</button>
-                  <button type="button" onClick={() => setEditing(null)}>
-                    Cancel
-                  </button>
+                  <div className="flex gap-2">
+                    <Button type="submit" variant="subtle" size="sm">Save</Button>
+                    <Button type="button" variant="ghost" size="sm" onClick={() => setEditing(null)}>
+                      Cancel
+                    </Button>
+                  </div>
                 </form>
               ) : (
                 <>
-                  <p>{a.text}</p>
-                  <button
-                    type="button"
-                    aria-label="edit note"
-                    onClick={() => setEditing({ id: a.id, text: a.text })}
-                  >
-                    Edit
-                  </button>
-                  <button
-                    type="button"
-                    aria-label="delete note"
-                    onClick={() => onDelete(a.id)}
-                  >
-                    Delete
-                  </button>
+                  <p className="text-body text-fg-body mb-2">{a.text}</p>
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      aria-label="edit note"
+                      onClick={() => setEditing({ id: a.id, text: a.text })}
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      aria-label="delete note"
+                      onClick={() => onDelete(a.id)}
+                    >
+                      Delete
+                    </Button>
+                  </div>
                 </>
               )}
             </li>
@@ -96,18 +118,17 @@ export function AnnotationsPanel({
         </ul>
       )}
 
-      <form onSubmit={onSubmit} aria-label="add note">
-        <h3>Add note</h3>
-        <label>
-          Note
-          <textarea
-            aria-label="new note"
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-          />
-        </label>
-        <button type="submit">Add note</button>
+      <form onSubmit={onSubmit} aria-label="add note" className="space-y-2">
+        <h4 className="text-heading uppercase text-fg-muted">Add note</h4>
+        <Field
+          as="textarea"
+          label="Note"
+          aria-label="new note"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+        />
+        <Button type="submit" variant="subtle" size="sm">Add note</Button>
       </form>
-    </section>
+    </Section>
   );
 }

--- a/app/src/ui/AppCurrentPane.tsx
+++ b/app/src/ui/AppCurrentPane.tsx
@@ -13,7 +13,7 @@
 //   role="alert" (p)
 //   aria-label="selected finding" (article — now Card as="article")
 
-import type { Dispatch, SetStateAction } from 'react';
+import { useMemo, type Dispatch, type SetStateAction } from 'react';
 import type { OcrLanguage } from '../ocr/availableLanguages';
 import { FindingsPanel } from './FindingsPanel';
 import { PdfViewer } from './PdfViewer';
@@ -112,6 +112,7 @@ export function AppCurrentPane({
 }: AppCurrentPaneProps): JSX.Element {
   const { t } = useI18n();
   const ocr = needsOcr(status.result.doc);
+  const leaseFacts = useMemo(() => extractLeaseFacts(status.result.doc), [status]);
   return (
     <div className="results">
       <div className="results-actions flex flex-wrap gap-2 mb-3">
@@ -173,7 +174,7 @@ export function AppCurrentPane({
             setSelected(f);
             setSelectedPage(f.page);
           }}
-          definitions={extractLeaseFacts(status.result.doc).definitions}
+          definitions={leaseFacts.definitions}
           glossary={glossaryEntries}
           plainEnglishByRuleId={plainEnglishByRuleId}
           suggestedTextByRuleId={suggestedTextByRuleId}
@@ -233,7 +234,7 @@ export function AppCurrentPane({
         suggestedEdit={selected ? suggestedEditByRuleId[selected.ruleId] : undefined}
       />
       <TemplateMatchesPanel matches={matchTemplates(templates, status.result.doc)} />
-      <LeaseFactsPanel facts={extractLeaseFacts(status.result.doc)} />
+      <LeaseFactsPanel facts={leaseFacts} />
       <WorkflowPanel
         leaseName={status.fileName}
         findings={status.result.findings}

--- a/app/src/ui/AppCurrentPane.tsx
+++ b/app/src/ui/AppCurrentPane.tsx
@@ -7,6 +7,12 @@
 // `needsOcr` derivations into a dedicated hook) is a Wave 21
 // candidate.
 
+// Aria/data inventory (preserved verbatim):
+//   role="status" + className="ocr-banner" (div)
+//   aria-live="polite" + className="ocr-progress" (p)
+//   role="alert" (p)
+//   aria-label="selected finding" (article — now Card as="article")
+
 import type { Dispatch, SetStateAction } from 'react';
 import type { OcrLanguage } from '../ocr/availableLanguages';
 import { FindingsPanel } from './FindingsPanel';
@@ -23,6 +29,8 @@ import { matchTemplates } from '../templates/matchTemplates';
 import { buildSummary, copyToClipboard } from '../workflow/copySummary';
 import { exportFindingsAsHtml, downloadHandoffZip } from '../App/appHelpers';
 import { useI18n } from '../i18n/I18nContext';
+import { Card } from './system/Card';
+import { Button } from './system/Button';
 import type { Finding } from '../rules/types';
 import type { LeaseDocument } from '../parser/types';
 import type { ClauseTemplate } from '../templates/types';
@@ -106,12 +114,14 @@ export function AppCurrentPane({
   const ocr = needsOcr(status.result.doc);
   return (
     <div className="results">
-      <div className="results-actions">
-        <button type="button" onClick={onExportJson}>
+      <div className="results-actions flex flex-wrap gap-2 mb-3">
+        <Button type="button" variant="subtle" size="sm" onClick={onExportJson}>
           {t('findings.export.json')}
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
+          variant="subtle"
+          size="sm"
           onClick={() =>
             exportFindingsAsHtml({
               fileName: status.fileName,
@@ -121,23 +131,23 @@ export function AppCurrentPane({
           }
         >
           {t('findings.export.html')}
-        </button>
+        </Button>
         {hasSigningKey && (
-          <button type="button" onClick={onExportSignedJson}>
+          <Button type="button" variant="subtle" size="sm" onClick={onExportSignedJson}>
             {t('findings.export.signed')}
-          </button>
+          </Button>
         )}
       </div>
       {ocr.likelyScanned && (
-        <div role="status" className="ocr-banner">
-          <p>
+        <div role="status" className="ocr-banner bg-paper-sunken border border-rule rounded-sm p-3 mb-3 space-y-2">
+          <p className="text-body text-fg-body">
             This PDF looks scanned (avg {Math.round(ocr.avgCharsPerPage)} chars/page). Text
             extraction may be incomplete.
           </p>
           {status.bytes && ocrState.kind !== 'running' && (
-            <button type="button" onClick={onAttemptOcr}>
+            <Button type="button" variant="subtle" size="sm" onClick={onAttemptOcr}>
               Attempt OCR
-            </button>
+            </Button>
           )}
           <OcrLanguagePickerPanel
             available={ocrLanguages}
@@ -145,11 +155,15 @@ export function AppCurrentPane({
             onChange={setOcrLanguage}
           />
           {ocrState.kind === 'running' && (
-            <p aria-live="polite" className="ocr-progress">
+            <p aria-live="polite" className="ocr-progress text-body text-fg-body">
               Running OCR: {ocrState.stage} ({Math.round(ocrState.pct * 100)}%)
             </p>
           )}
-          {ocrState.kind === 'error' && <p role="alert">OCR failed: {ocrState.message}</p>}
+          {ocrState.kind === 'error' && (
+            <p role="alert" className="text-body text-severity-high">
+              OCR failed: {ocrState.message}
+            </p>
+          )}
         </div>
       )}
       <div className="split">
@@ -187,12 +201,14 @@ export function AppCurrentPane({
         />
       </div>
       {selected && (
-        <article aria-label="selected finding">
-          <h3>{selected.title}</h3>
-          <p>{selected.explanation}</p>
-          <blockquote>{selected.snippet}</blockquote>
-          <small>Page {selected.page}</small>
-        </article>
+        <Card as="article" aria-label="selected finding" className="p-4 space-y-2 my-3">
+          <h3 className="text-heading uppercase text-fg-muted">{selected.title}</h3>
+          <p className="text-body text-fg-body">{selected.explanation}</p>
+          <blockquote className="border-l-2 border-rule pl-3 font-mono text-mono text-fg-muted italic">
+            {selected.snippet}
+          </blockquote>
+          <span className="text-small text-fg-muted">Page {selected.page}</span>
+        </Card>
       )}
       <AnnotationsPanel
         leaseId={analyzedLeaseId ?? ''}

--- a/app/src/ui/AppHeader.tsx
+++ b/app/src/ui/AppHeader.tsx
@@ -1,5 +1,11 @@
 import { LocalePickerPanel } from './LocalePickerPanel';
 import { useI18n } from '../i18n/I18nContext';
+import { Button } from './system/Button';
+
+// Aria/data inventory (preserved verbatim):
+//   aria-label="upload lease" (input)
+//   role="group" + aria-label="view mode" (div)
+//   aria-pressed={...} on each view-mode button (3 buttons)
 
 export type AppViewMode = 'current' | 'portfolio' | 'redline';
 
@@ -20,62 +26,78 @@ export function AppHeader({
 }: AppHeaderProps): JSX.Element {
   const { t } = useI18n();
   return (
-    <header>
-      <h1>{t('app.title')}</h1>
-      <p>{t('app.tagline')}</p>
-      <LocalePickerPanel />
-      <details className="privacy">
-        <summary>{t('header.privacy.summary')}</summary>
-        <ul>
-          <li>The PDF is parsed entirely in your browser via pdf.js.</li>
-          <li>All storage is in IndexedDB on this device. No account, no sync.</li>
-          <li>
-            A strict Content-Security-Policy (<code>default-src &apos;self&apos;</code>) blocks this
-            page from loading scripts, fonts, or data from any other origin.
-          </li>
-          <li>LeaseGuard is not legal advice. Findings are heuristic pattern matches.</li>
-        </ul>
-      </details>
-      <label>
-        <span className="visually-hidden">Upload lease</span>
-        <input
-          type="file"
-          accept="application/pdf"
-          aria-label="upload lease"
-          onChange={async (e) => {
-            const file = e.target.files?.[0];
-            if (!file) return;
-            await onUpload(file);
-          }}
-        />
-      </label>
-      <button type="button" onClick={onTrySample}>
-        {t('header.trySample')}
-      </button>
-      <div role="group" aria-label="view mode" className="view-toggle">
-        <button
-          type="button"
-          aria-pressed={view === 'current'}
-          onClick={() => onViewChange('current')}
-        >
-          {t('header.view.current')}
-        </button>
-        <button
-          type="button"
-          aria-pressed={view === 'portfolio'}
-          onClick={() => onViewChange('portfolio')}
-        >
-          {t('header.view.portfolio')}
-        </button>
-        {showRedlineToggle && (
-          <button
+    <header className="bg-paper border-b border-rule px-4 py-3 space-y-2">
+      <div className="flex items-baseline gap-3">
+        <h1 className="text-display font-display text-fg">{t('app.title')}</h1>
+        <p className="text-small text-fg-muted">{t('app.tagline')}</p>
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <LocalePickerPanel />
+        <details className="privacy text-small text-fg-muted">
+          <summary className="cursor-pointer">{t('header.privacy.summary')}</summary>
+          <ul className="mt-1 ml-4 space-y-0.5 list-disc text-fg-faint">
+            <li>The PDF is parsed entirely in your browser via pdf.js.</li>
+            <li>All storage is in IndexedDB on this device. No account, no sync.</li>
+            <li>
+              A strict Content-Security-Policy (<code>default-src &apos;self&apos;</code>) blocks this
+              page from loading scripts, fonts, or data from any other origin.
+            </li>
+            <li>LeaseGuard is not legal advice. Findings are heuristic pattern matches.</li>
+          </ul>
+        </details>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <label className="inline-flex items-center gap-1 text-body text-fg-body cursor-pointer">
+          <span className="visually-hidden">Upload lease</span>
+          <input
+            type="file"
+            accept="application/pdf"
+            aria-label="upload lease"
+            className="text-small"
+            onChange={async (e) => {
+              const file = e.target.files?.[0];
+              if (!file) return;
+              await onUpload(file);
+            }}
+          />
+        </label>
+        <Button type="button" variant="default" size="sm" onClick={onTrySample}>
+          {t('header.trySample')}
+        </Button>
+        <div role="group" aria-label="view mode" className="view-toggle flex gap-1">
+          <Button
             type="button"
-            aria-pressed={view === 'redline'}
-            onClick={() => onViewChange('redline')}
+            variant="ghost"
+            size="sm"
+            pressed={view === 'current'}
+            aria-pressed={view === 'current'}
+            onClick={() => onViewChange('current')}
           >
-            {t('header.view.redline')}
-          </button>
-        )}
+            {t('header.view.current')}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            pressed={view === 'portfolio'}
+            aria-pressed={view === 'portfolio'}
+            onClick={() => onViewChange('portfolio')}
+          >
+            {t('header.view.portfolio')}
+          </Button>
+          {showRedlineToggle && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              pressed={view === 'redline'}
+              aria-pressed={view === 'redline'}
+              onClick={() => onViewChange('redline')}
+            >
+              {t('header.view.redline')}
+            </Button>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/app/src/ui/CounterOfferPanel.tsx
+++ b/app/src/ui/CounterOfferPanel.tsx
@@ -1,6 +1,17 @@
 import { useEffect, useState } from 'react';
 import type { CounterOffer } from '../negotiation/counterOffers';
 import type { Finding } from '../rules/types';
+import { Section } from './system/Section';
+import { Button } from './system/Button';
+import { Field } from './system/Field';
+
+// Aria/data inventory (preserved verbatim):
+//   aria-label="counter-offers" (section)
+//   aria-label="add counter-offer" (form)
+//   aria-label="new counter-offer name" (input)
+//   aria-label="new counter-offer text" (textarea)
+//   aria-label="Apply ${c.name}" (button)
+//   aria-label="Delete ${c.name}" (button)
 
 interface CounterOfferPanelProps {
   finding: Finding | null;
@@ -44,10 +55,10 @@ export function CounterOfferPanel({
 
   if (!finding) {
     return (
-      <section aria-label="counter-offers">
-        <h2>Counter-offers</h2>
-        <p>Select a finding to see or add counter-offers.</p>
-      </section>
+      <Section label="counter-offers">
+        <h3 className="text-heading uppercase text-fg-muted mb-3">Counter-offers</h3>
+        <p className="text-body text-fg-faint">Select a finding to see or add counter-offers.</p>
+      </Section>
     );
   }
 
@@ -65,59 +76,63 @@ export function CounterOfferPanel({
   }
 
   return (
-    <section aria-label="counter-offers">
-      <h2>Counter-offers</h2>
-      <p>For rule: {finding.title}</p>
+    <Section label="counter-offers" className="space-y-3">
+      <h3 className="text-heading uppercase text-fg-muted mb-3">Counter-offers</h3>
+      <p className="text-small text-fg-muted">For rule: {finding.title}</p>
       {forRule.length === 0 ? (
-        <p>No counter-offers saved for this rule.</p>
+        <p className="text-body text-fg-faint">No counter-offers saved for this rule.</p>
       ) : (
-        <ul>
+        <ul className="space-y-2">
           {forRule.map((c) => (
-            <li key={c.id}>
-              <strong>{c.name}</strong>
-              <p>{c.text}</p>
-              {onApply ? (
-                <button
+            <li key={c.id} className="bg-paper-sunken border border-rule rounded-sm p-3 space-y-2">
+              <span className="text-body text-fg-body font-sans font-semibold">{c.name}</span>
+              <p className="text-body text-fg-body">{c.text}</p>
+              <div className="flex gap-2">
+                {onApply ? (
+                  <Button
+                    type="button"
+                    variant="subtle"
+                    size="sm"
+                    aria-label={`Apply ${c.name}`}
+                    onClick={() => onApply(c)}
+                  >
+                    Apply
+                  </Button>
+                ) : null}
+                <Button
                   type="button"
-                  aria-label={`Apply ${c.name}`}
-                  onClick={() => onApply(c)}
+                  variant="ghost"
+                  size="sm"
+                  aria-label={`Delete ${c.name}`}
+                  onClick={() => onDelete(c.id)}
                 >
-                  Apply
-                </button>
-              ) : null}
-              <button
-                type="button"
-                aria-label={`Delete ${c.name}`}
-                onClick={() => onDelete(c.id)}
-              >
-                Delete
-              </button>
+                  Delete
+                </Button>
+              </div>
             </li>
           ))}
         </ul>
       )}
 
-      <form onSubmit={onSubmit} aria-label="add counter-offer">
-        <h3>Add counter-offer</h3>
-        <label>
-          Name
-          <input
-            type="text"
-            aria-label="new counter-offer name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-          />
-        </label>
-        <label>
-          Suggested replacement
-          <textarea
-            aria-label="new counter-offer text"
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-          />
-        </label>
-        <button type="submit">Add counter-offer</button>
+      <form onSubmit={onSubmit} aria-label="add counter-offer" className="space-y-2">
+        <h4 className="text-heading uppercase text-fg-muted">Add counter-offer</h4>
+        <Field
+          as="input"
+          label="Name"
+          type="text"
+          aria-label="new counter-offer name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <Field
+          as="textarea"
+          label="Suggested replacement"
+          aria-label="new counter-offer text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+        />
+        <Button type="submit" variant="subtle" size="sm">Add counter-offer</Button>
       </form>
-    </section>
+    </Section>
   );
 }

--- a/app/src/ui/FindingsPanel.tsx
+++ b/app/src/ui/FindingsPanel.tsx
@@ -395,6 +395,10 @@ function VirtualFindingItem(props: VirtualFindingItemProps): JSX.Element {
             </button>
             {finding.evidence ? (
               <div className="finding-llm-detail px-3 pb-2">
+                {/* LLM badge intentionally rendered as <button> (not <Badge>) because
+                    Wave 25-B made it the click-to-explain disclosure trigger — it
+                    toggles aria-expanded and reveals the model/similarity/threshold
+                    detail panel. <Badge> is a non-interactive <span>. */}
                 <button
                   type="button"
                   className="finding-llm-badge inline-flex items-center gap-1 text-small text-fg-muted border border-rule rounded-sm px-2 py-0.5 hover:bg-paper-sunken transition-colors"

--- a/app/src/ui/FindingsPanel.tsx
+++ b/app/src/ui/FindingsPanel.tsx
@@ -5,6 +5,25 @@ import type { DefinitionEntry } from '../facts/types';
 import type { GlossaryEntry } from '../glossary/loadGlossary';
 import { highlightDefinedTerms } from './highlightDefinedTerms';
 import { useInViewport } from './useInViewport';
+import { Button } from './system/Button';
+import { Card } from './system/Card';
+
+// Aria/data inventory (preserved verbatim):
+//   aria-label="findings" (aside)
+//   aria-label="search findings" (input)
+//   role="group" + aria-label="severity filters" (div)
+//   role="group" + aria-label="category filters" (div)
+//   aria-pressed + aria-label="severity ${sev}" (severity filter buttons)
+//   aria-pressed + aria-label="category ${cat}" (category filter buttons)
+//   aria-labelledby="findings-${sev}" (section)
+//   id="findings-${sev}" (h2)
+//   aria-expanded + aria-label="toggle ${sev}" (collapse button)
+//   data-finding-key (li and button — both)
+//   aria-expanded + aria-label="Identified by on-device classifier..." (llm badge button)
+//   aria-expanded + aria-label="what this means for ${finding.title}" (explainer button)
+//   aria-label="apply suggestion for ${finding.title}" (button)
+//   aria-label="promote to standard ${finding.title}" (button)
+//   aria-hidden="true" + data-finding-placeholder (placeholder div)
 
 const SEVERITY_ORDER: Severity[] = ['high', 'medium', 'low', 'info'];
 const SEVERITY_LABEL: Record<Severity, string> = {
@@ -94,8 +113,8 @@ export function FindingsPanel({
 
   if (findings.length === 0) {
     return (
-      <aside aria-label="findings">
-        <p>No findings yet. Upload a lease to analyze.</p>
+      <aside aria-label="findings" className="p-4">
+        <p className="text-body text-fg-faint">No findings yet. Upload a lease to analyze.</p>
       </aside>
     );
   }
@@ -126,8 +145,8 @@ export function FindingsPanel({
   }
 
   return (
-    <aside aria-label="findings">
-      <div className="controls">
+    <aside aria-label="findings" className="flex flex-col gap-2">
+      <div className="controls px-3 pt-3 space-y-2">
         <label>
           <span className="visually-hidden">Search findings</span>
           <input
@@ -136,57 +155,68 @@ export function FindingsPanel({
             placeholder="Search findings…"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
+            className="w-full border border-rule rounded-sm bg-paper-raised px-2 py-1 text-body text-fg focus:outline focus:outline-2 focus:outline-ink"
           />
         </label>
 
-        <div role="group" aria-label="severity filters">
+        <div role="group" aria-label="severity filters" className="flex flex-wrap gap-1">
           {SEVERITY_ORDER.map((sev) => (
-            <button
+            <Button
               key={sev}
               type="button"
+              variant="ghost"
+              size="sm"
+              pressed={!hiddenSeverities.has(sev)}
               aria-pressed={!hiddenSeverities.has(sev)}
               aria-label={`severity ${sev}`}
               onClick={() => toggleInSet(hiddenSeverities, sev, setHiddenSeverities)}
             >
               {SEVERITY_LABEL[sev]}
-            </button>
+            </Button>
           ))}
         </div>
 
-        <div role="group" aria-label="category filters">
+        <div role="group" aria-label="category filters" className="flex flex-wrap gap-1">
           {categories.map((cat) => (
-            <button
+            <Button
               key={cat}
               type="button"
+              variant="ghost"
+              size="sm"
+              pressed={!hiddenCategories.has(cat)}
               aria-pressed={!hiddenCategories.has(cat)}
               aria-label={`category ${cat}`}
               onClick={() => toggleInSet(hiddenCategories, cat, setHiddenCategories)}
             >
               {cat}
-            </button>
+            </Button>
           ))}
         </div>
       </div>
 
-      <div ref={listRef} onKeyDown={onListKeyDown}>
+      <div ref={listRef} onKeyDown={onListKeyDown} className="flex-1 overflow-y-auto px-3 pb-3 space-y-3">
         {SEVERITY_ORDER.map((sev) => {
           const group = bySeverity[sev];
           if (!group || group.length === 0) return null;
           const isCollapsed = collapsed.has(sev);
           return (
             <section key={sev} aria-labelledby={`findings-${sev}`}>
-              <h2 id={`findings-${sev}`}>
+              <h2 id={`findings-${sev}`} className="mb-1">
                 <button
                   type="button"
                   aria-expanded={!isCollapsed}
                   aria-label={`toggle ${sev}`}
                   onClick={() => toggleInSet(collapsed, sev, setCollapsed)}
+                  className="flex w-full items-center justify-between text-heading uppercase font-sans text-fg-muted py-1 hover:text-fg transition-colors"
                 >
-                  {SEVERITY_LABEL[sev]} ({group.length})
+                  <span>
+                    {SEVERITY_LABEL[sev]} ({group.length})
+                  </span>
+                  <span aria-hidden="true">{isCollapsed ? '▸' : '▾'}</span>
                 </button>
               </h2>
               {!isCollapsed && (
-                <ul>
+                <ul className="space-y-2">
                   {group.map((finding) => {
                     const key = findingKey(finding);
                     const plain = plainEnglishByRuleId?.[finding.ruleId];
@@ -330,93 +360,112 @@ function VirtualFindingItem(props: VirtualFindingItemProps): JSX.Element {
   return (
     <li ref={liRef} data-finding-key={key}>
       {inView ? (
-        <div ref={fullRef}>
-          <button
-            type="button"
-            className="finding-btn"
-            data-finding-key={key}
-            ref={btnRef}
-            onClick={() => onSelect(finding)}
-          >
-            <strong>{finding.title}</strong>
-            {finding.negated && <span aria-label="negated"> (possibly not applicable)</span>}
-            {finding.deviation && (
-              <span
-                className="finding-deviation-badge"
-                aria-label="Deviates from verified baseline"
-              >
-                {' '}
-                deviates from verified pack
+        <Card accent={finding.severity as Severity} className="overflow-hidden">
+          <div ref={fullRef}>
+            <button
+              type="button"
+              className="finding-btn w-full text-left p-3 space-y-1"
+              data-finding-key={key}
+              ref={btnRef}
+              onClick={() => onSelect(finding)}
+            >
+              <span className="font-sans text-body text-fg-body font-semibold">
+                {finding.title}
               </span>
-            )}
-            <div>{finding.explanation}</div>
-            {(definitions && definitions.length > 0) || (glossary && glossary.length > 0) ? (
-              <small className="finding-snippet">
-                {highlightDefinedTerms(finding.snippet, definitions ?? [], glossary)}
-              </small>
-            ) : null}
-            <small>Page {finding.page}</small>
-          </button>
-          {finding.evidence ? (
-            <div className="finding-llm-detail">
-              <button
-                type="button"
-                className="finding-llm-badge"
-                aria-expanded={isHybridDetailOpen}
-                aria-label={`Identified by on-device classifier (similarity ${Math.round(
-                  finding.evidence.similarity * 100,
-                )}%)`}
-                title={`On-device classifier (similarity ${Math.round(
-                  finding.evidence.similarity * 100,
-                )}%)`}
-                onClick={toggleHybridDetail}
-              >
-                ~
-              </button>
-              {isHybridDetailOpen ? (
-                <dl className="finding-llm-evidence">
-                  <dt>Model</dt>
-                  <dd>{finding.evidence.modelId}</dd>
-                  <dt>Similarity</dt>
-                  <dd>{Math.round(finding.evidence.similarity * 100)}%</dd>
-                  <dt>Threshold</dt>
-                  <dd>Above the 70% similarity floor</dd>
-                </dl>
+              {finding.negated && (
+                <span aria-label="negated" className="text-small text-fg-muted ml-1">
+                  {' '}(possibly not applicable)
+                </span>
+              )}
+              {finding.deviation && (
+                <span
+                  className="finding-deviation-badge text-small text-fg-muted ml-1"
+                  aria-label="Deviates from verified baseline"
+                >
+                  {' '}deviates from verified pack
+                </span>
+              )}
+              <div className="text-body text-fg-body">{finding.explanation}</div>
+              {(definitions && definitions.length > 0) || (glossary && glossary.length > 0) ? (
+                <span className="finding-snippet block font-mono text-mono text-fg-muted">
+                  {highlightDefinedTerms(finding.snippet, definitions ?? [], glossary)}
+                </span>
               ) : null}
-            </div>
-          ) : null}
-          {plain ? (
-            <div className="finding-plain-english">
-              <button
-                type="button"
-                aria-expanded={isExplainerOpen}
-                aria-label={`what this means for ${finding.title}`}
-                onClick={toggleExplainer}
-              >
-                What this means
-              </button>
-              {isExplainerOpen ? <p>{plain}</p> : null}
-            </div>
-          ) : null}
-          {onApplySuggestion && suggestedText ? (
-            <button
-              type="button"
-              aria-label={`apply suggestion for ${finding.title}`}
-              onClick={() => onApplySuggestion(finding, finding.paragraphIndex, suggestedText)}
-            >
-              Apply suggestion
+              <span className="text-small text-fg-muted">Page {finding.page}</span>
             </button>
-          ) : null}
-          {onPromoteToStandard && leaseId !== undefined ? (
-            <button
-              type="button"
-              aria-label={`promote to standard ${finding.title}`}
-              onClick={() => onPromoteToStandard(leaseId, finding.paragraphIndex)}
-            >
-              Promote to standard
-            </button>
-          ) : null}
-        </div>
+            {finding.evidence ? (
+              <div className="finding-llm-detail px-3 pb-2">
+                <button
+                  type="button"
+                  className="finding-llm-badge inline-flex items-center gap-1 text-small text-fg-muted border border-rule rounded-sm px-2 py-0.5 hover:bg-paper-sunken transition-colors"
+                  aria-expanded={isHybridDetailOpen}
+                  aria-label={`Identified by on-device classifier (similarity ${Math.round(
+                    finding.evidence.similarity * 100,
+                  )}%)`}
+                  title={`On-device classifier (similarity ${Math.round(
+                    finding.evidence.similarity * 100,
+                  )}%)`}
+                  onClick={toggleHybridDetail}
+                >
+                  ~
+                </button>
+                {isHybridDetailOpen ? (
+                  <dl className="finding-llm-evidence mt-2 space-y-1 text-small text-fg-body">
+                    <dt className="text-fg-muted">Model</dt>
+                    <dd className="font-mono text-mono ml-2">{finding.evidence.modelId}</dd>
+                    <dt className="text-fg-muted">Similarity</dt>
+                    <dd className="ml-2">{Math.round(finding.evidence.similarity * 100)}%</dd>
+                    <dt className="text-fg-muted">Threshold</dt>
+                    <dd className="ml-2">Above the 70% similarity floor</dd>
+                  </dl>
+                ) : null}
+              </div>
+            ) : null}
+            {plain ? (
+              <div className="finding-plain-english px-3 pb-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  aria-expanded={isExplainerOpen}
+                  aria-label={`what this means for ${finding.title}`}
+                  onClick={toggleExplainer}
+                >
+                  What this means
+                </Button>
+                {isExplainerOpen ? (
+                  <p className="mt-1 text-body text-fg-body">{plain}</p>
+                ) : null}
+              </div>
+            ) : null}
+            {(onApplySuggestion && suggestedText) || (onPromoteToStandard && leaseId !== undefined) ? (
+              <div className="flex gap-2 px-3 pb-3">
+                {onApplySuggestion && suggestedText ? (
+                  <Button
+                    type="button"
+                    variant="subtle"
+                    size="sm"
+                    aria-label={`apply suggestion for ${finding.title}`}
+                    onClick={() => onApplySuggestion(finding, finding.paragraphIndex, suggestedText)}
+                  >
+                    Apply suggestion
+                  </Button>
+                ) : null}
+                {onPromoteToStandard && leaseId !== undefined ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    aria-label={`promote to standard ${finding.title}`}
+                    onClick={() => onPromoteToStandard(leaseId, finding.paragraphIndex)}
+                  >
+                    Promote to standard
+                  </Button>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        </Card>
       ) : (
         <div
           aria-hidden="true"

--- a/app/src/ui/LeaseFactsPanel.tsx
+++ b/app/src/ui/LeaseFactsPanel.tsx
@@ -5,6 +5,13 @@ import type {
   MoneyValue,
   RentSchedulePeriod,
 } from '../facts/types';
+import { Section } from './system/Section';
+
+// Aria/data inventory (preserved verbatim):
+//   aria-label="lease facts" (section)
+//   aria-label="rent schedule" (table)
+//   scope="col" (th headers), scope="row" (th row headers)
+//   className="visually-hidden" (caption)
 
 interface LeaseFactsPanelProps {
   facts: LeaseFacts;
@@ -25,19 +32,19 @@ export function LeaseFactsPanel({ facts }: LeaseFactsPanelProps): JSX.Element {
 
   if (isEmpty) {
     return (
-      <section aria-label="lease facts">
-        <h2>Lease facts</h2>
-        <p>No structured facts detected in this lease.</p>
-      </section>
+      <Section label="lease facts">
+        <h3 className="text-heading uppercase text-fg-muted mb-3">Lease facts</h3>
+        <p className="text-body text-fg-faint">No structured facts detected in this lease.</p>
+      </Section>
     );
   }
 
   return (
-    <section aria-label="lease facts">
-      <h2>Lease facts</h2>
-      <table>
+    <Section label="lease facts" className="space-y-4">
+      <h3 className="text-heading uppercase text-fg-muted mb-3">Lease facts</h3>
+      <table className="w-full text-body text-fg-body">
         <caption className="visually-hidden">Key lease facts</caption>
-        <tbody>
+        <tbody className="divide-y divide-rule">
           <FactRow label="Base rent" value={formatMoney(facts.baseRent)} />
           <FactRow label="Security deposit" value={formatMoney(facts.securityDeposit)} />
           <FactRow label="Term" value={formatMonths(facts.termMonths)} />
@@ -49,8 +56,10 @@ export function LeaseFactsPanel({ facts }: LeaseFactsPanelProps): JSX.Element {
 
       {facts.definitions.length > 0 && (
         <div>
-          <h3>Definitions ({facts.definitions.length})</h3>
-          <dl>
+          <h4 className="text-heading uppercase text-fg-muted mb-2">
+            Definitions ({facts.definitions.length})
+          </h4>
+          <dl className="space-y-2">
             {facts.definitions.map((d) => (
               <DefinitionRow key={`${d.term}-${d.paragraphIndex}`} entry={d} />
             ))}
@@ -60,8 +69,10 @@ export function LeaseFactsPanel({ facts }: LeaseFactsPanelProps): JSX.Element {
 
       {facts.crossReferences.length > 0 && (
         <div>
-          <h3>Cross-references ({facts.crossReferences.length})</h3>
-          <ul>
+          <h4 className="text-heading uppercase text-fg-muted mb-2">
+            Cross-references ({facts.crossReferences.length})
+          </h4>
+          <ul className="space-y-1 text-body text-fg-body">
             {facts.crossReferences.map((r) => (
               <CrossRefRow key={`${r.target}-${r.paragraphIndex}-${r.page}`} entry={r} />
             ))}
@@ -71,17 +82,19 @@ export function LeaseFactsPanel({ facts }: LeaseFactsPanelProps): JSX.Element {
 
       {rentSchedule.length > 0 && (
         <div>
-          <h3>Rent schedule ({rentSchedule.length})</h3>
-          <table aria-label="rent schedule">
+          <h4 className="text-heading uppercase text-fg-muted mb-2">
+            Rent schedule ({rentSchedule.length})
+          </h4>
+          <table aria-label="rent schedule" className="w-full text-body text-fg-body">
             <thead>
-              <tr>
-                <th scope="col">From</th>
-                <th scope="col">To</th>
-                <th scope="col">Amount</th>
-                <th scope="col">Escalator</th>
+              <tr className="border-b border-rule">
+                <th scope="col" className="py-1 pr-3 text-left text-small text-fg-muted font-sans">From</th>
+                <th scope="col" className="py-1 pr-3 text-left text-small text-fg-muted font-sans">To</th>
+                <th scope="col" className="py-1 pr-3 text-left text-small text-fg-muted font-sans">Amount</th>
+                <th scope="col" className="py-1 text-left text-small text-fg-muted font-sans">Escalator</th>
               </tr>
             </thead>
-            <tbody>
+            <tbody className="divide-y divide-rule">
               {rentSchedule.map((period, i) => (
                 <RentScheduleRow key={`${period.from}-${period.to}-${i}`} period={period} />
               ))}
@@ -89,17 +102,17 @@ export function LeaseFactsPanel({ facts }: LeaseFactsPanelProps): JSX.Element {
           </table>
         </div>
       )}
-    </section>
+    </Section>
   );
 }
 
 function RentScheduleRow({ period }: { period: RentSchedulePeriod }): JSX.Element {
   return (
     <tr>
-      <td>{period.from}</td>
-      <td>{period.to}</td>
-      <td>{formatAmount(period.amount)}</td>
-      <td>{period.escalator !== undefined ? `${period.escalator}%` : '—'}</td>
+      <td className="py-1 pr-3">{period.from}</td>
+      <td className="py-1 pr-3">{period.to}</td>
+      <td className="py-1 pr-3">{formatAmount(period.amount)}</td>
+      <td className="py-1">{period.escalator !== undefined ? `${period.escalator}%` : '—'}</td>
     </tr>
   );
 }
@@ -116,8 +129,8 @@ interface FactRowProps {
 function FactRow({ label, value }: FactRowProps): JSX.Element {
   return (
     <tr>
-      <th scope="row">{label}</th>
-      <td>{value}</td>
+      <th scope="row" className="py-1 pr-4 text-left text-small text-fg-muted font-sans w-40">{label}</th>
+      <td className="py-1 text-body text-fg-body font-sans">{value}</td>
     </tr>
   );
 }
@@ -125,9 +138,9 @@ function FactRow({ label, value }: FactRowProps): JSX.Element {
 function DefinitionRow({ entry }: { entry: DefinitionEntry }): JSX.Element {
   return (
     <>
-      <dt>{entry.term}</dt>
-      <dd>
-        {entry.definition} <small>(p. {entry.page})</small>
+      <dt className="font-sans text-body text-fg-body font-semibold">{entry.term}</dt>
+      <dd className="font-sans text-body text-fg-body ml-4">
+        {entry.definition} <span className="text-small text-fg-muted">(p. {entry.page})</span>
       </dd>
     </>
   );
@@ -136,7 +149,8 @@ function DefinitionRow({ entry }: { entry: DefinitionEntry }): JSX.Element {
 function CrossRefRow({ entry }: { entry: CrossReference }): JSX.Element {
   return (
     <li>
-      <strong>{entry.text}</strong> <small>(p. {entry.page})</small>
+      <span className="font-sans text-body text-fg-body font-semibold">{entry.text}</span>{' '}
+      <span className="text-small text-fg-muted">(p. {entry.page})</span>
     </li>
   );
 }

--- a/app/src/ui/PdfViewer.tsx
+++ b/app/src/ui/PdfViewer.tsx
@@ -94,8 +94,8 @@ export function PdfViewer({
       top: `${top}px`,
       width: `${width}px`,
       height: `${height}px`,
-      background: 'rgba(255, 235, 59, 0.35)',
-      border: '1px solid rgba(255, 193, 7, 0.9)',
+      background: 'var(--color-highlight)',
+      border: '1px solid var(--color-highlight-border)',
       pointerEvents: 'none',
     };
   }

--- a/app/src/ui/PdfViewer.tsx
+++ b/app/src/ui/PdfViewer.tsx
@@ -102,6 +102,7 @@ export function PdfViewer({
 
   return (
     <section aria-label="pdf viewer" className="pdf-viewer">
+      <div className="pdf-viewer-legacy">
       {Array.from({ length: pageCount }, (_, i) => {
         const pageNum = i + 1;
         const overlay = highlight?.page === pageNum ? highlight : null;
@@ -125,6 +126,7 @@ export function PdfViewer({
           </div>
         );
       })}
+      </div>
     </section>
   );
 }

--- a/app/src/ui/TemplateMatchesPanel.tsx
+++ b/app/src/ui/TemplateMatchesPanel.tsx
@@ -1,5 +1,13 @@
 import type { ClauseTemplateMatch } from '../templates/types';
 import { classifyMatch } from './templateMatch';
+import { Section } from './system/Section';
+import { Card } from './system/Card';
+import { Badge } from './system/Badge';
+
+// Aria/data inventory (preserved verbatim):
+//   aria-label="template matches" (section)
+//   aria-label="template status ${badge}" (span)
+//   data-badge={badge} (span)
 
 interface TemplateMatchesPanelProps {
   matches: ClauseTemplateMatch[];
@@ -14,35 +22,43 @@ export function TemplateMatchesPanel({
 }: TemplateMatchesPanelProps): JSX.Element {
   if (matches.length === 0) {
     return (
-      <section aria-label="template matches">
-        <h2>Template matches</h2>
-        <p>No clause templates to compare against.</p>
-      </section>
+      <Section label="template matches">
+        <h3 className="text-heading uppercase text-fg-muted mb-3">Template matches</h3>
+        <p className="text-body text-fg-faint">No clause templates to compare against.</p>
+      </Section>
     );
   }
   return (
-    <section aria-label="template matches">
-      <h2>Template matches</h2>
-      <ul>
+    <Section label="template matches" className="space-y-2">
+      <h3 className="text-heading uppercase text-fg-muted mb-3">Template matches</h3>
+      <ul className="space-y-2">
         {matches.map((m) => {
           const badge = classifyMatch(m.bestScore, matchedThreshold, weakThreshold);
           return (
             <li key={m.templateId}>
-              <strong>{m.templateName}</strong>{' '}
-              <span aria-label={`template status ${badge}`} data-badge={badge}>
-                {badge}
-              </span>{' '}
-              <small>score {m.bestScore.toFixed(2)}</small>
-              {m.matchedSnippet && m.matchedPage !== null && (
-                <>
-                  <blockquote>{m.matchedSnippet}</blockquote>
-                  <small>Page {m.matchedPage}</small>
-                </>
-              )}
+              <Card className="p-3 space-y-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-body text-fg-body font-sans font-semibold">{m.templateName}</span>
+                  <span aria-label={`template status ${badge}`} data-badge={badge}>
+                    <Badge variant="outline">{badge}</Badge>
+                  </span>
+                  <span className="text-mono font-mono text-fg-muted">
+                    score {m.bestScore.toFixed(2)}
+                  </span>
+                </div>
+                {m.matchedSnippet && m.matchedPage !== null && (
+                  <div>
+                    <blockquote className="border-l-2 border-rule pl-3 font-mono text-mono text-fg-muted italic">
+                      {m.matchedSnippet}
+                    </blockquote>
+                    <span className="text-small text-fg-muted">Page {m.matchedPage}</span>
+                  </div>
+                )}
+              </Card>
             </li>
           );
         })}
       </ul>
-    </section>
+    </Section>
   );
 }

--- a/app/src/ui/WorkflowPanel.tsx
+++ b/app/src/ui/WorkflowPanel.tsx
@@ -1,5 +1,12 @@
 import { useState } from 'react';
 import type { Finding } from '../rules/types';
+import { Section } from './system/Section';
+import { Button } from './system/Button';
+
+// Aria/data inventory (preserved verbatim):
+//   aria-label="workflow" (aside — now Section)
+//   role="group" + aria-label="workflow actions" (div)
+//   role="status" + aria-live="polite" (p)
 
 export interface WorkflowPanelProps {
   leaseName: string;
@@ -26,32 +33,34 @@ export function WorkflowPanel(props: WorkflowPanelProps): JSX.Element {
   }
 
   return (
-    <aside aria-label="workflow" className="workflow-panel">
-      <h2>Workflow</h2>
-      <p className="lease-name">
+    <Section label="workflow" className="workflow-panel space-y-3">
+      <h3 className="text-heading uppercase text-fg-muted mb-1">Workflow</h3>
+      <p className="lease-name text-body text-fg-body">
         <strong>{leaseName}</strong> · {findings.length} finding
         {findings.length === 1 ? '' : 's'}
       </p>
-      <div className="actions" role="group" aria-label="workflow actions">
-        <button type="button" onClick={onBuildIcs}>
+      <div className="actions flex flex-wrap gap-2" role="group" aria-label="workflow actions">
+        <Button type="button" variant="subtle" size="sm" onClick={onBuildIcs}>
           Download .ics
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
+          variant="subtle"
+          size="sm"
           onClick={handleCopy}
           disabled={copyStatus === 'copying'}
         >
           Copy summary
-        </button>
-        <button type="button" onClick={onDownloadHandoff}>
+        </Button>
+        <Button type="button" variant="subtle" size="sm" onClick={onDownloadHandoff}>
           Download handoff ZIP
-        </button>
+        </Button>
       </div>
-      <p className="status" role="status" aria-live="polite">
+      <p className="status text-small text-fg-muted" role="status" aria-live="polite">
         {copyStatus === 'copied' && 'Copied!'}
         {copyStatus === 'copying' && 'Copying…'}
         {copyStatus === 'failed' && 'Copy failed.'}
       </p>
-    </aside>
+    </Section>
   );
 }


### PR DESCRIPTION
## Summary

Wave 27 Part B — rewrites the 8 primary-analyzed-view components to use the Part A primitives (Button, Card, Badge, Section, Field) and Tailwind utilities. **Zero churn** on \`role\` / \`aria-label\` / \`aria-expanded\` / \`aria-pressed\` / \`data-finding-key\` / \`data-*\` / \`id\` (verified by spec reviewer with mechanical attribute-diffs per file).

Plan: \`docs/plans/wave27-design-pass.md\` §"Part B".
Builds on Part A: PR #109 (substrate, tokens, primitives).

## Components rewritten (8 + 1 wrapper)

- \`AppHeader\` — view-mode toggles via \`Button pressed\`
- \`FindingsPanel\` — largest single-file diff. Severity filter pills, category pills, \`Card accent={severity}\` per finding row, severity-group sections, hybrid-LLM badge stays as \`<button>\` (Wave 25-B click-to-explain disclosure; new code comment explains why it's not \`<Badge>\`)
- \`AppCurrentPane\` — SelectedFinding article via \`<Card as="article" aria-label="selected finding">\`; \`useMemo\` added to deduplicate the \`extractLeaseFacts(...)\` call that was running twice per render
- \`AnnotationsPanel\` / \`CounterOfferPanel\` — \`Section\` + \`Field\` + \`Button\`
- \`TemplateMatchesPanel\` — \`Section\` + \`Card\` rows
- \`LeaseFactsPanel\` — \`Section\` + utility-styled definition list
- \`WorkflowPanel\` — \`Section\`-wrapped, three workflow buttons (download .ics / copy summary / download handoff ZIP) as \`Button\`
- \`PdfViewer\` — root wrapped in \`<div class="pdf-viewer-legacy">\` so Part A's scoped legacy cascade applies

## Process (subagent-driven)

Implementer → spec reviewer (✅ SPEC_COMPLIANT) → code quality reviewer (3 IMPORTANT + 2 MINOR) → polish commit:

- Hardcoded rgba in \`PdfViewer\` overlay → \`var(--color-highlight)\` + \`var(--color-highlight-border)\` tokens added to \`@theme\`
- LLM badge \`<button>\` justified with code comment (Wave 25-B contract)
- \`AnnotationsPanel\` textarea \`rounded\` → \`rounded-sm\` (editorial sharp-corner system)
- \`AppCurrentPane\` double \`extractLeaseFacts\` → memoized once

Deferred: FindingsPanel split (~500 LOC) — not blocking.

## Gates

| Gate | Result |
|---|---|
| typecheck | ✅ |
| lint | ✅ |
| test:coverage | 1266 tests passed; **branches 89.79%** (≥ 89 floor) |
| build | ✅ |
| check:budget | ✅ |
| check:csp | ✅ |
| Playwright e2e | **6 passed + 1 skipped** (all 6 active specs green) |
| vitest-axe | clean across the suite |

🤖 Generated with [Claude Code](https://claude.com/claude-code)