### PR TITLE
wave28-B: design-system primitives (SectionGroup, EmptyState, focus-ring)

### DIFF
--- a/app/src/index.css
+++ b/app/src/index.css
@@ -73,6 +73,23 @@
   /* PDF highlight overlay — semi-transparent by design; no opaque hex form exists */
   --color-highlight: rgba(255, 235, 59, 0.35);
   --color-highlight-border: rgba(255, 193, 7, 0.9);
+
+  /* Wave 28 — interactive state + focus-ring tokens.
+     Ring is a darker mustard tuned against the cream paper background;
+     ring-offset matches the paper so the halo reads cleanly. Hover /
+     active are warm low-opacity washes that harmonize with the
+     terracotta/mustard severity palette. */
+  --ring: #b8862c;
+  --ring-offset: #faf6ee;
+  --state-hover: rgba(184, 134, 44, 0.08);
+  --state-active: rgba(184, 134, 44, 0.16);
+}
+
+/* Focus-ring utility — applied via `focus-visible:focus-ring` on
+   interactive surfaces. Pulled out as a utility so primitives don't
+   each duplicate the ring math. */
+@utility focus-ring {
+  @apply outline-none ring-2 ring-[var(--ring)] ring-offset-2 ring-offset-[var(--ring-offset)];
 }
 
 /* Base */

--- a/app/src/ui/system/EmptyState.stories.tsx
+++ b/app/src/ui/system/EmptyState.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { EmptyState } from './EmptyState';
+
+const meta: Meta<typeof EmptyState> = {
+  title: 'System/EmptyState',
+  component: EmptyState,
+};
+export default meta;
+type Story = StoryObj<typeof EmptyState>;
+
+const FolderIcon = (
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    width="32"
+    height="32"
+  >
+    <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
+  </svg>
+);
+
+export const TitleOnly: Story = {
+  args: { title: 'No leases yet' },
+};
+
+export const WithDescription: Story = {
+  args: {
+    title: 'No clause templates saved yet',
+    description: 'Save a snippet from a lease to build your reusable clause library.',
+  },
+};
+
+export const WithIconAndAction: Story = {
+  args: {
+    title: 'No leases yet',
+    description: 'Drop a PDF here or use the Upload button above to get started.',
+    icon: FolderIcon,
+    action: (
+      <button
+        type="button"
+        className="border border-rule rounded-sm bg-paper-raised px-3 py-1 text-body font-sans text-fg hover:bg-[var(--state-hover)] active:bg-[var(--state-active)] focus-visible:focus-ring"
+      >
+        Upload a lease
+      </button>
+    ),
+  },
+};

--- a/app/src/ui/system/EmptyState.test.tsx
+++ b/app/src/ui/system/EmptyState.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { expectAxeClean } from '../../test/axe';
+import { EmptyState } from './EmptyState';
+
+describe('EmptyState', () => {
+  it('renders the title', () => {
+    render(<EmptyState title="No leases yet" />);
+    expect(screen.getByText('No leases yet')).toBeInTheDocument();
+  });
+
+  it('renders the description when provided', () => {
+    render(
+      <EmptyState
+        title="No clause templates saved yet"
+        description="Save snippets from a lease to build a library."
+      />,
+    );
+    expect(
+      screen.getByText('Save snippets from a lease to build a library.'),
+    ).toBeInTheDocument();
+  });
+
+  it('omits the description when not provided', () => {
+    const { container } = render(<EmptyState title="Nothing here" />);
+    expect(container.querySelector('[data-empty-description]')).toBeNull();
+  });
+
+  it('renders the action when provided', () => {
+    render(
+      <EmptyState
+        title="No leases yet"
+        action={<button type="button">Upload a lease</button>}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /upload a lease/i })).toBeInTheDocument();
+  });
+
+  it('omits the action region when not provided', () => {
+    const { container } = render(<EmptyState title="Nothing here" />);
+    expect(container.querySelector('[data-empty-action]')).toBeNull();
+  });
+
+  it('renders the icon slot when provided', () => {
+    render(
+      <EmptyState
+        title="Nothing here"
+        icon={<svg data-testid="glyph" aria-hidden="true" />}
+      />,
+    );
+    expect(screen.getByTestId('glyph')).toBeInTheDocument();
+  });
+
+  it('omits the icon wrapper when icon is not provided', () => {
+    const { container } = render(<EmptyState title="Nothing here" />);
+    expect(container.querySelector('[data-empty-icon]')).toBeNull();
+  });
+
+  it('has no a11y violations with all slots populated', async () => {
+    const { container } = render(
+      <EmptyState
+        title="No leases yet"
+        description="Drop a PDF here to get started."
+        icon={<svg aria-hidden="true" width="32" height="32" />}
+        action={<button type="button">Upload</button>}
+      />,
+    );
+    await expectAxeClean(container);
+  });
+
+  it('has no a11y violations with title only', async () => {
+    const { container } = render(<EmptyState title="Nothing here" />);
+    await expectAxeClean(container);
+  });
+});

--- a/app/src/ui/system/EmptyState.tsx
+++ b/app/src/ui/system/EmptyState.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react';
+
+export interface EmptyStateProps {
+  title: string;
+  description?: string;
+  /**
+   * Lucide-style glyph as inline SVG. We do NOT pull in lucide-react;
+   * pass the SVG element directly. Rendered at 32px and aria-hidden by
+   * convention (caller controls).
+   */
+  icon?: ReactNode;
+  action?: ReactNode;
+}
+
+/**
+ * Centered empty-state placeholder used by panels with no rows.
+ * Uses the muted-foreground tokens; icon slot is rendered at 32 px.
+ */
+export function EmptyState({
+  title,
+  description,
+  icon,
+  action,
+}: EmptyStateProps): JSX.Element {
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 py-8 px-4 text-center text-fg-muted">
+      {icon && (
+        <div data-empty-icon className="mb-1 h-8 w-8 text-fg-faint">
+          {icon}
+        </div>
+      )}
+      <p className="text-body font-sans text-fg m-0">{title}</p>
+      {description && (
+        <p
+          data-empty-description
+          className="text-small font-sans text-fg-muted m-0 max-w-prose"
+        >
+          {description}
+        </p>
+      )}
+      {action && (
+        <div data-empty-action className="mt-3">
+          {action}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/ui/system/SectionGroup.stories.tsx
+++ b/app/src/ui/system/SectionGroup.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { SectionGroup } from './SectionGroup';
+import { EmptyState } from './EmptyState';
+
+const meta: Meta<typeof SectionGroup> = {
+  title: 'System/SectionGroup',
+  component: SectionGroup,
+};
+export default meta;
+type Story = StoryObj<typeof SectionGroup>;
+
+export const OpenWithCount: Story = {
+  args: {
+    id: 'this-lease',
+    title: 'This lease',
+    count: 8,
+    defaultOpen: true,
+    children: (
+      <div className="text-body font-sans text-fg-body">
+        Lease facts, annotations, and export controls live here.
+      </div>
+    ),
+  },
+};
+
+export const CollapsedNoCount: Story = {
+  args: {
+    id: 'governance',
+    title: 'Governance',
+    defaultOpen: false,
+    children: <div>Hidden by default</div>,
+  },
+};
+
+export const Compact: Story = {
+  args: {
+    id: 'library',
+    title: 'Library',
+    count: '3 pending',
+    defaultOpen: true,
+    density: 'compact',
+    children: <div>Compact density example</div>,
+  },
+};
+
+export const WithEmptyStateInside: Story = {
+  args: {
+    id: 'library',
+    title: 'Library',
+    count: 0,
+    defaultOpen: true,
+    children: (
+      <EmptyState
+        title="No leases yet"
+        description="Drop a PDF here or use the Upload button above to get started."
+      />
+    ),
+  },
+};

--- a/app/src/ui/system/SectionGroup.test.tsx
+++ b/app/src/ui/system/SectionGroup.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expectAxeClean } from '../../test/axe';
+import { SectionGroup } from './SectionGroup';
+
+describe('SectionGroup', () => {
+  it('renders title and children when defaultOpen is true', () => {
+    render(
+      <SectionGroup id="grp" title="This Lease" defaultOpen>
+        <p>inner content</p>
+      </SectionGroup>,
+    );
+    expect(screen.getByRole('button', { name: /this lease/i })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByText('inner content')).toBeInTheDocument();
+  });
+
+  it('hides children when defaultOpen is false', () => {
+    render(
+      <SectionGroup id="grp" title="Library" defaultOpen={false}>
+        <p>hidden body</p>
+      </SectionGroup>,
+    );
+    expect(screen.getByRole('button', { name: /library/i })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    expect(screen.queryByText('hidden body')).toBeNull();
+  });
+
+  it('toggles aria-expanded on click', async () => {
+    render(
+      <SectionGroup id="grp" title="Governance" defaultOpen={false}>
+        <p>secret</p>
+      </SectionGroup>,
+    );
+    const toggle = screen.getByRole('button', { name: /governance/i });
+    await userEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('secret')).toBeInTheDocument();
+    await userEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('secret')).toBeNull();
+  });
+
+  it('renders numeric count badge', () => {
+    render(
+      <SectionGroup id="grp" title="Library" count={8}>
+        <p>x</p>
+      </SectionGroup>,
+    );
+    expect(screen.getByText('8')).toBeInTheDocument();
+  });
+
+  it('renders string count badge', () => {
+    render(
+      <SectionGroup id="grp" title="Library" count="3 pending">
+        <p>x</p>
+      </SectionGroup>,
+    );
+    expect(screen.getByText('3 pending')).toBeInTheDocument();
+  });
+
+  it('omits the count badge when count is undefined', () => {
+    const { container } = render(
+      <SectionGroup id="grp" title="Library">
+        <p>x</p>
+      </SectionGroup>,
+    );
+    expect(container.querySelector('[data-section-count]')).toBeNull();
+  });
+
+  it('uses compact density when requested', () => {
+    const { container } = render(
+      <SectionGroup id="grp" title="Library" density="compact">
+        <p>x</p>
+      </SectionGroup>,
+    );
+    expect(container.querySelector('[data-density="compact"]')).not.toBeNull();
+  });
+
+  it('defaults to comfortable density', () => {
+    const { container } = render(
+      <SectionGroup id="grp" title="Library">
+        <p>x</p>
+      </SectionGroup>,
+    );
+    expect(container.querySelector('[data-density="comfortable"]')).not.toBeNull();
+  });
+
+  it('wires aria-controls to the panel id derived from id', () => {
+    render(
+      <SectionGroup id="lib" title="Library">
+        <p>body</p>
+      </SectionGroup>,
+    );
+    const toggle = screen.getByRole('button', { name: /library/i });
+    const controlsId = toggle.getAttribute('aria-controls');
+    expect(controlsId).toBeTruthy();
+    expect(document.getElementById(controlsId as string)).not.toBeNull();
+  });
+
+  it('has no a11y violations when expanded', async () => {
+    const { container } = render(
+      <SectionGroup id="grp" title="This Lease" defaultOpen>
+        <p>inner</p>
+      </SectionGroup>,
+    );
+    await expectAxeClean(container);
+  });
+
+  it('has no a11y violations when collapsed', async () => {
+    const { container } = render(
+      <SectionGroup id="grp" title="This Lease" defaultOpen={false}>
+        <p>hidden</p>
+      </SectionGroup>,
+    );
+    await expectAxeClean(container);
+  });
+});

--- a/app/src/ui/system/SectionGroup.tsx
+++ b/app/src/ui/system/SectionGroup.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { Card } from './Card';
+
+export interface SectionGroupProps {
+  /** Heading shown in the group header. */
+  title: string;
+  /** Optional badge after the title (e.g., "8 leases", "3 pending"). */
+  count?: number | string;
+  /** Whether the group is open by default. State is in-memory only. */
+  defaultOpen?: boolean;
+  /** Visual density. "comfortable" (default) or "compact". */
+  density?: 'comfortable' | 'compact';
+  /** Stable id used for the disclosure region's aria controls. */
+  id: string;
+  children: ReactNode;
+}
+
+/**
+ * Collapsible group container with a header, optional count badge, and
+ * disclosure affordance. State is in-memory only (per Wave 28 §1.2).
+ */
+export function SectionGroup({
+  title,
+  count,
+  defaultOpen = false,
+  density = 'comfortable',
+  id,
+  children,
+}: SectionGroupProps): JSX.Element {
+  const [open, setOpen] = useState(defaultOpen);
+  const panelId = `${id}-panel`;
+  const headerPad = density === 'compact' ? 'px-3 py-2' : 'px-4 py-3';
+  const bodyPad = density === 'compact' ? 'px-3 pb-3' : 'px-4 pb-4';
+
+  return (
+    <Card data-density={density} className="overflow-hidden">
+      <h3 className="m-0">
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-controls={panelId}
+          onClick={() => setOpen((v) => !v)}
+          className={`flex w-full items-center justify-between gap-3 text-heading uppercase font-sans text-fg-muted hover:bg-[var(--state-hover)] active:bg-[var(--state-active)] focus-visible:focus-ring ${headerPad}`}
+        >
+          <span className="flex items-center gap-2">
+            <span aria-hidden="true" className="inline-block w-3">
+              {open ? '▾' : '▸'}
+            </span>
+            <span>{title}</span>
+            {count !== undefined && (
+              <span
+                data-section-count
+                className="inline-flex items-center rounded-full border border-rule px-2 py-0.5 text-small font-sans text-fg-muted bg-paper-sunken"
+              >
+                {count}
+              </span>
+            )}
+          </span>
+        </button>
+      </h3>
+      <div id={panelId} role="region" aria-labelledby={panelId} hidden={!open} className={open ? bodyPad : ''}>
+        {open && children}
+      </div>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

Round-1 Track 2 of Wave 28. Adds two new design-system primitives and the focus-ring tokens that Parts C, D, and F depend on.

- **`SectionGroup`** — collapsible group container with title, optional count badge, `defaultOpen`, `density` (`comfortable` | `compact`), stable `id` for aria-controls. Rendered as a `Card` with a disclosure button + `aria-expanded` / `aria-controls` wired to the body region. State is in-memory only per plan §1.2.
- **`EmptyState`** — centered placeholder with `title`, optional `description`, `icon` (inline SVG slot — no lucide-react dep), and `action` slot. Used by Part D in `LibraryPanel`, `TemplatesPanel`, `JurisdictionPickerPanel`.
- **Tokens + utility** in `app/src/index.css`: `--ring` (mustard `#b8862c`), `--ring-offset` (paper `#faf6ee`), `--state-hover` / `--state-active` (mustard washes). Adds `@utility focus-ring` per plan §5 Part B.8 so primitives can `focus-visible:focus-ring` without duplicating ring math.

Stories cover the matrix called out in plan B.9 (open/collapsed/compact/empty-state-inside; title-only/with-description/with-icon-and-action).

Plan: `docs/plans/wave28-design-pass-finish-and-a11y.md` §5 Part B.

## Coverage

Both new primitives at 100% lines / 100% branches / 100% functions. Above the ≥ 95% lines / ≥ 90% branches gate.

```
SectionGroup.tsx |     100 |      100 |     100 |     100
EmptyState.tsx   |     100 |      100 |     100 |     100
```

Full suite: 162 files / 1286 tests pass; typecheck + lint clean.

## File-touch boundary

Inside cap (≤ 4 new src + ≤ 4 new tests + ≤ 1 modified src):

- New: `SectionGroup.{tsx,test.tsx,stories.tsx}`, `EmptyState.{tsx,test.tsx,stories.tsx}` (4 src + 2 tests).
- Modified: `app/src/index.css` only.

Zero changes outside `app/src/ui/system/` and `app/src/index.css`.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npm run test:coverage` — green; new primitives at 100/100/100
- [ ] Storybook sanity walk (CI-only verification — run locally via `npm run storybook`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)