### PR TITLE
wave28-A: span-bbox parser foundation

### DIFF
--- a/app/src/parser/lineSpans.test.ts
+++ b/app/src/parser/lineSpans.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { findLinesForSpan } from './lineSpans';
+import type { BoundingBox, LineSpan } from './types';
+
+function bbox(yTop: number, yBottom: number): BoundingBox {
+  return { page: 1, xLeft: 72, xRight: 540, yTop, yBottom };
+}
+
+const lines: LineSpan[] = [
+  { start: 0, end: 10, bbox: bbox(700, 690) }, // "First line"
+  { start: 11, end: 22, bbox: bbox(685, 675) }, // "Second line"
+  { start: 23, end: 33, bbox: bbox(670, 660) }, // "Third line"
+];
+
+describe('findLinesForSpan', () => {
+  it('returns the single line containing a span fully within one line', () => {
+    const result = findLinesForSpan(lines, 2, 7);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.start).toBe(0);
+    expect(result[0]!.end).toBe(10);
+  });
+
+  it('returns both lines for a span crossing two lines, in document order', () => {
+    const result = findLinesForSpan(lines, 5, 15);
+    expect(result).toHaveLength(2);
+    expect(result[0]!.start).toBe(0);
+    expect(result[1]!.start).toBe(11);
+  });
+
+  it('returns three lines for a span spanning all three lines', () => {
+    const result = findLinesForSpan(lines, 5, 30);
+    expect(result).toHaveLength(3);
+    expect(result.map((l) => l.start)).toEqual([0, 11, 23]);
+  });
+
+  it('returns [] for a span fully outside any line (after end)', () => {
+    const result = findLinesForSpan(lines, 100, 110);
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] for an empty lines array', () => {
+    const result = findLinesForSpan([], 0, 10);
+    expect(result).toEqual([]);
+  });
+
+  it('treats line.end as exclusive (span starting exactly at line.end skips that line)', () => {
+    const result = findLinesForSpan(lines, 10, 11);
+    // span [10,11) — line0 is [0,10) (exclusive end), line1 is [11,22) — neither overlaps [10,11)
+    expect(result).toEqual([]);
+  });
+
+  it('includes a line where span starts exactly at line.start', () => {
+    const result = findLinesForSpan(lines, 11, 12);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.start).toBe(11);
+  });
+
+  it('returns [] for a zero-width span', () => {
+    const result = findLinesForSpan(lines, 5, 5);
+    expect(result).toEqual([]);
+  });
+});

--- a/app/src/parser/lineSpans.ts
+++ b/app/src/parser/lineSpans.ts
@@ -1,0 +1,17 @@
+import type { LineSpan } from './types';
+
+/**
+ * Return the lines whose char range [start,end) overlaps the given span [spanStart,spanEnd).
+ * Both endpoints treated as exclusive on the right. Result preserves input order.
+ *
+ * Used by Part E (span-level viewer highlighting): given a finding's char offsets
+ * within a Paragraph.text, locate the LineSpans whose bboxes should be highlighted.
+ */
+export function findLinesForSpan(
+  lines: LineSpan[],
+  spanStart: number,
+  spanEnd: number,
+): LineSpan[] {
+  if (spanEnd <= spanStart) return [];
+  return lines.filter((line) => line.start < spanEnd && line.end > spanStart);
+}

--- a/app/src/parser/paragraphs.test.ts
+++ b/app/src/parser/paragraphs.test.ts
@@ -59,6 +59,50 @@ describe('reconstructParagraphs', () => {
     expect(bbox!.yBottom).toBeLessThanOrEqual(685);
   });
 
+  it('attaches per-line spans whose char ranges sum to paragraph length', () => {
+    const pages = [page([item('First line of body', 700), item('second line here', 685)])];
+    const paras = reconstructParagraphs(pages);
+    expect(paras).toHaveLength(1);
+    const p = at(paras, 0);
+    expect(p.lines).toBeDefined();
+    expect(p.lines!.length).toBe(2);
+    // First line covers [0, "First line of body".length)
+    expect(p.lines![0]!.start).toBe(0);
+    expect(p.lines![0]!.end).toBe('First line of body'.length);
+    // Last line ends exactly at paragraph text length
+    expect(p.lines![p.lines!.length - 1]!.end).toBe(p.text.length);
+    // Each line's bbox is on the same page
+    for (const line of p.lines!) {
+      expect(line.bbox.page).toBe(p.page);
+    }
+  });
+
+  it('attaches a single line span for an unmerged paragraph', () => {
+    const pages = [page([item('Lonely paragraph.', 700)])];
+    const paras = reconstructParagraphs(pages);
+    const p = at(paras, 0);
+    expect(p.lines).toBeDefined();
+    expect(p.lines!.length).toBe(1);
+    expect(p.lines![0]!.start).toBe(0);
+    expect(p.lines![0]!.end).toBe(p.text.length);
+  });
+
+  it('preserves correct line offsets across hyphen-repaired joins', () => {
+    const pages = [page([item('exam-', 700), item('ple word', 685)])];
+    const paras = reconstructParagraphs(pages);
+    const p = at(paras, 0);
+    expect(p.text).toBe('example word');
+    expect(p.lines).toBeDefined();
+    expect(p.lines!.length).toBe(2);
+    // First line "exam-" → after repair, prior text becomes "exam" (len 4),
+    // so the second line starts at offset 4 with no separator.
+    expect(p.lines![0]!.start).toBe(0);
+    // Hyphen-repair drops the trailing '-' so first line's end shrinks to "exam".length.
+    expect(p.lines![0]!.end).toBe(4);
+    expect(p.lines![1]!.start).toBe(4);
+    expect(p.lines![1]!.end).toBe(p.text.length);
+  });
+
   it('strips repeating page-header lines', () => {
     const makePage = (n: number): PageText =>
       page(

--- a/app/src/parser/paragraphs.ts
+++ b/app/src/parser/paragraphs.ts
@@ -1,4 +1,4 @@
-import type { BoundingBox, PageText, Paragraph, TextItem } from './types';
+import type { BoundingBox, LineSpan, PageText, Paragraph, TextItem } from './types';
 
 interface Line {
   page: number;
@@ -84,6 +84,7 @@ interface Building {
   lastFont: number;
   lastY: number;
   bbox: BoundingBox;
+  lines: LineSpan[];
 }
 
 function mergeLinesIntoParagraphs(lines: Line[]): Paragraph[] {
@@ -98,24 +99,52 @@ function mergeLinesIntoParagraphs(lines: Line[]): Paragraph[] {
       current.lastY - line.y <= line.fontSize * PARAGRAPH_GAP_RATIO;
 
     if (shouldContinue && current) {
-      current.text = joinWithHyphenRepair(current.text, line.text);
+      const joined = joinWithHyphenRepair(current.text, line.text);
+      const hyphenRepaired = joined.length < current.text.length + line.text.length;
+      if (hyphenRepaired) {
+        // Hyphen-repair dropped the trailing '-' from prior text. Shrink the
+        // last line span's end by 1 so it reflects the post-repair paragraph text.
+        const lastIdx = current.lines.length - 1;
+        const last = current.lines[lastIdx]!;
+        current.lines[lastIdx] = { start: last.start, end: last.end - 1, bbox: last.bbox };
+      }
+      const start = hyphenRepaired ? current.text.length - 1 : current.text.length + 1;
+      const end = joined.length;
+      current.text = joined;
       current.lastFont = line.fontSize;
       current.lastY = line.y;
       current.bbox = extendBbox(current.bbox, line.bbox);
+      current.lines.push({ start, end, bbox: line.bbox });
     } else {
-      if (current) paragraphs.push({ page: current.page, text: current.text, bbox: current.bbox });
+      if (current) {
+        paragraphs.push({
+          page: current.page,
+          text: current.text,
+          bbox: current.bbox,
+          lines: current.lines,
+        });
+      }
       current = {
         page: line.page,
         text: line.text,
         lastFont: line.fontSize,
         lastY: line.y,
         bbox: line.bbox,
+        lines: [{ start: 0, end: line.text.length, bbox: line.bbox }],
       };
     }
   }
-  if (current) paragraphs.push({ page: current.page, text: current.text, bbox: current.bbox });
+  if (current) {
+    paragraphs.push({
+      page: current.page,
+      text: current.text,
+      bbox: current.bbox,
+      lines: current.lines,
+    });
+  }
   return paragraphs;
 }
+
 
 function extendBbox(a: BoundingBox, b: BoundingBox): BoundingBox {
   return {

--- a/app/src/parser/parseLease.ts
+++ b/app/src/parser/parseLease.ts
@@ -5,6 +5,9 @@ import type { LeaseDocument } from './types';
 
 export async function parseLease(bytes: Uint8Array): Promise<LeaseDocument> {
   const pages = await extractPages(bytes);
+  // Each Paragraph carries optional `lines: LineSpan[]` (Wave 28 / Part A).
+  // LineSpan is plain data (numbers + nested BoundingBox object) and is
+  // structured-clone-safe across the worker boundary — no serializer needed.
   const paragraphs = reconstructParagraphs(pages);
   const sections = detectSections(paragraphs);
   const raw = paragraphs.map((p) => p.text).join('\n\n');

--- a/app/src/parser/types.ts
+++ b/app/src/parser/types.ts
@@ -22,10 +22,22 @@ export interface BoundingBox {
   yBottom: number;
 }
 
+export interface LineSpan {
+  /** char offset within the parent Paragraph.text where this line begins */
+  start: number;
+  /** char offset within the parent Paragraph.text where this line ends (exclusive) */
+  end: number;
+  /** PDF-page bbox in PDF user-space units (same coordinate system as Paragraph.bbox) */
+  bbox: BoundingBox;
+}
+
 export interface Paragraph {
   text: string;
   page: number;
   bbox?: BoundingBox;
+  /** Wave 28: per-line spans for span-level highlight. Optional — legacy
+   *  paragraphs lack this and the viewer falls back to paragraph bbox. */
+  lines?: LineSpan[];
 }
 
 export interface Section {


### PR DESCRIPTION
## Summary

Wave 28 Part A — additive parser foundation for span-level viewer
highlighting. See [plan §5 Part A](../blob/main/docs/plans/wave28-design-pass-finish-and-a11y.md).

- Add `LineSpan` type + optional `Paragraph.lines` (additive, structured-clone safe).
- `paragraphs.ts` accumulates per-line char ranges + bboxes during merge,
  shrinking the prior span's `end` by 1 on hyphen-repair so offsets stay
  aligned with the final paragraph text.
- New pure helper `findLinesForSpan(lines, start, end): LineSpan[]` for Part E.
- Zero changes outside `app/src/parser/` (no UI / no viewer / no storage).

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npm test -- parser` — 42 tests, all green (8 new lineSpans + 3 new paragraphs)
- [x] `npm test -- App.panels` — 26 tests green (worker round-trip, structured-clone confirms)
- [x] `npm test` (full suite) — 1277 / 1278 passing (1 pre-existing todo)
- [x] `npm run test:coverage` — All files 97.38% lines / 89.84% branches (no regression)

## Caps

- 2 new src files (lineSpans.ts, lineSpans.test.ts) — at cap
- 3 modified src files (types.ts, paragraphs.ts, parseLease.ts) — at cap
- 1 modified test file (paragraphs.test.ts) — under cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)