### PR TITLE
wave28-D: component polish

### DIFF
--- a/app/src/ui/FindingsPanel.badge.test.tsx
+++ b/app/src/ui/FindingsPanel.badge.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FindingsPanel } from './FindingsPanel';
+import type { Finding } from '../rules/types';
+
+// Wave 28-D — hybrid finding badge polish:
+//   - aria-pressed reflects toggled state
+//   - focus-visible:focus-ring class present (for the design-system
+//     focus halo).
+
+function f(over: Partial<Finding>): Finding {
+  return {
+    ruleId: 'rule',
+    severity: 'medium',
+    category: 'general',
+    title: 'Some finding',
+    explanation: 'explanation',
+    citation: null,
+    page: 1,
+    paragraphIndex: 0,
+    snippet: 'snippet',
+    span: { start: 0, end: 7 },
+    confidence: 0.9,
+    negated: false,
+    rulePackVersion: '1.0.0',
+    evidence: { modelId: 'classifier-x', similarity: 0.82 },
+    ...over,
+  };
+}
+
+describe('FindingsPanel — hybrid badge (Wave 28-D)', () => {
+  it('renders the hybrid badge with aria-pressed=false initially', () => {
+    render(<FindingsPanel findings={[f({})]} onSelect={() => {}} />);
+    const badge = screen.getByRole('button', {
+      name: /identified by on-device classifier/i,
+    });
+    expect(badge).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('toggles aria-pressed=true after click', async () => {
+    render(<FindingsPanel findings={[f({})]} onSelect={() => {}} />);
+    const badge = screen.getByRole('button', {
+      name: /identified by on-device classifier/i,
+    });
+    await userEvent.click(badge);
+    expect(badge).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('applies the focus-ring utility for keyboard focus', () => {
+    render(<FindingsPanel findings={[f({})]} onSelect={() => {}} />);
+    const badge = screen.getByRole('button', {
+      name: /identified by on-device classifier/i,
+    });
+    expect(badge.className).toMatch(/focus-visible:focus-ring/);
+  });
+});

--- a/app/src/ui/FindingsPanel.tsx
+++ b/app/src/ui/FindingsPanel.tsx
@@ -401,8 +401,9 @@ function VirtualFindingItem(props: VirtualFindingItemProps): JSX.Element {
                     detail panel. <Badge> is a non-interactive <span>. */}
                 <button
                   type="button"
-                  className="finding-llm-badge inline-flex items-center gap-1 text-small text-fg-muted border border-rule rounded-sm px-2 py-0.5 hover:bg-paper-sunken transition-colors"
+                  className="finding-llm-badge inline-flex items-center gap-1 text-small text-fg-muted border border-rule rounded-sm px-2 py-0.5 hover:bg-[var(--state-hover)] active:bg-[var(--state-active)] transition-colors focus-visible:focus-ring"
                   aria-expanded={isHybridDetailOpen}
+                  aria-pressed={isHybridDetailOpen}
                   aria-label={`Identified by on-device classifier (similarity ${Math.round(
                     finding.evidence.similarity * 100,
                   )}%)`}

--- a/app/src/ui/JurisdictionPickerPanel.tsx
+++ b/app/src/ui/JurisdictionPickerPanel.tsx
@@ -9,6 +9,7 @@
 import type { ChangeEvent } from 'react';
 import { Section } from './system/Section';
 import { Button } from './system/Button';
+import { EmptyState } from './system/EmptyState';
 
 interface JurisdictionPickerPanelProps {
   /** Jurisdiction codes available to pick from (e.g. `"US-CA"`). */
@@ -47,9 +48,10 @@ export function JurisdictionPickerPanel({
     return (
       <Section label="jurisdictions" className="space-y-2 px-4 py-4">
         <h2 className="text-heading uppercase text-fg-muted">Jurisdictions</h2>
-        <p className="text-body text-fg-muted">
-          <em>No jurisdictions available.</em>
-        </p>
+        <EmptyState
+          title="No jurisdictions available."
+          description="All rules will run regardless of regional tags."
+        />
       </Section>
     );
   }

--- a/app/src/ui/LibraryPanel.test.tsx
+++ b/app/src/ui/LibraryPanel.test.tsx
@@ -35,8 +35,8 @@ describe('LibraryPanel', () => {
     expect(screen.getByText('Two.pdf')).toBeInTheDocument();
   });
 
-  it('shows an empty-state message when list is empty', () => {
-    render(
+  it('shows an empty-state message when list is empty (Wave 28-D EmptyState)', () => {
+    const { container } = render(
       <LibraryPanel
         leases={[]}
         standardId={null}
@@ -47,6 +47,9 @@ describe('LibraryPanel', () => {
       />,
     );
     expect(screen.getByText(/no saved leases/i)).toBeInTheDocument();
+    // Wave 28-D: the empty branch now uses the EmptyState primitive,
+    // which renders a description slot via [data-empty-description].
+    expect(container.querySelector('[data-empty-description]')).not.toBeNull();
   });
 
   it('fires onOpen with the lease id', async () => {

--- a/app/src/ui/LibraryPanel.tsx
+++ b/app/src/ui/LibraryPanel.tsx
@@ -10,6 +10,7 @@
 import type { LeaseMetadata } from '../storage/storage';
 import { Section } from './system/Section';
 import { Button } from './system/Button';
+import { EmptyState } from './system/EmptyState';
 
 interface LibraryPanelProps {
   leases: LeaseMetadata[];
@@ -32,7 +33,10 @@ export function LibraryPanel({
     return (
       <Section label="library" className="space-y-2 px-4 py-4">
         <h2 className="text-heading uppercase text-fg-muted">My Leases</h2>
-        <p className="text-body text-fg-muted">No saved leases yet.</p>
+        <EmptyState
+          title="No saved leases yet."
+          description="Upload a lease PDF to add it to your library."
+        />
       </Section>
     );
   }

--- a/app/src/ui/SeverityOverridesPanel.test.tsx
+++ b/app/src/ui/SeverityOverridesPanel.test.tsx
@@ -107,6 +107,26 @@ describe('SeverityOverridesPanel', () => {
     ).toBeDisabled();
   });
 
+  it('uses scope="col" on every header cell (Wave 28-D a11y)', () => {
+    const { container } = render(
+      <SeverityOverridesPanel rules={RULES} overrides={{}} onChange={() => {}} />,
+    );
+    const headers = container.querySelectorAll('thead th');
+    expect(headers.length).toBeGreaterThan(0);
+    for (const th of headers) {
+      expect(th.getAttribute('scope')).toBe('col');
+    }
+  });
+
+  it('renders a severity badge with token-colored class in the Built-in column (Wave 28-D)', () => {
+    const { container } = render(
+      <SeverityOverridesPanel rules={RULES} overrides={{}} onChange={() => {}} />,
+    );
+    const badges = container.querySelectorAll('[data-severity-badge]');
+    // One per rule row.
+    expect(badges.length).toBe(RULES.length);
+  });
+
   it('renders without crashing when overrides reference unknown ids', () => {
     // Stale entries from uninstalled packs should not blow up the panel.
     render(

--- a/app/src/ui/SeverityOverridesPanel.tsx
+++ b/app/src/ui/SeverityOverridesPanel.tsx
@@ -38,6 +38,16 @@ const SEVERITY_LABEL: Record<OverrideSeverity, string> = {
   error: 'Error',
 };
 
+// Tinted background + dark fg (--color-fg) so contrast clears WCAG AA
+// (4.5:1 for body text). Severity hue lives in the bg + a left border
+// rather than the text color, since the warm severity tokens don't
+// pass against cream as foregrounds at body sizes.
+const SEVERITY_BADGE_CLASS: Record<OverrideSeverity, string> = {
+  info: 'bg-[color-mix(in_srgb,var(--color-severity-info)_22%,var(--color-paper-raised))] text-fg border border-severity-info/40',
+  warn: 'bg-[color-mix(in_srgb,var(--color-severity-medium)_22%,var(--color-paper-raised))] text-fg border border-severity-medium/40',
+  error: 'bg-[color-mix(in_srgb,var(--color-severity-high)_22%,var(--color-paper-raised))] text-fg border border-severity-high/40',
+};
+
 const CLEAR_VALUE = '__clear__';
 
 function isOverrideSeverity(v: string): v is OverrideSeverity {
@@ -78,15 +88,15 @@ export function SeverityOverridesPanel({
   return (
     <Section label="severity overrides" className="space-y-3 px-4 py-4">
       <h2 className="text-heading uppercase text-fg-muted">Severity overrides</h2>
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto max-h-[24rem] relative">
         <table className="w-full text-small text-fg-body border-collapse">
-          <thead>
+          <thead className="sticky top-0 z-10 bg-paper-raised">
             <tr className="border-b border-rule">
-              <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">Rule</th>
-              <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">Built-in</th>
-              <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">Override</th>
-              {showScopeToggle ? <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">Scope</th> : null}
-              <th scope="col" className="text-left py-1 text-fg-muted font-sans">
+              <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans bg-paper-raised">Rule</th>
+              <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans bg-paper-raised">Built-in</th>
+              <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans bg-paper-raised">Override</th>
+              {showScopeToggle ? <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans bg-paper-raised">Scope</th> : null}
+              <th scope="col" className="text-left py-1 text-fg-muted font-sans bg-paper-raised">
                 <span className="sr-only">Actions</span>
               </th>
             </tr>
@@ -97,14 +107,21 @@ export function SeverityOverridesPanel({
               const hasOverride = current !== undefined;
               const value: string = current ?? CLEAR_VALUE;
               return (
-                <tr key={r.id} className="even:bg-paper-sunken border-b border-rule-subtle">
+                <tr key={r.id} className="even:bg-paper-sunken hover:bg-[var(--state-hover)] border-b border-rule-subtle transition-colors">
                   <td className="py-2 pr-3 align-top">
                     <strong className="text-body text-fg-body font-sans">{r.title}</strong>
                     <div>
                       <small className="font-mono text-mono text-fg-body">{r.id}</small>
                     </div>
                   </td>
-                  <td className="py-2 pr-3 align-top">{SEVERITY_LABEL[r.severity]}</td>
+                  <td className="py-2 pr-3 align-top">
+                    <span
+                      data-severity-badge={r.severity}
+                      className={`inline-flex items-center rounded-full px-2 py-0.5 text-small font-sans ${SEVERITY_BADGE_CLASS[r.severity]}`}
+                    >
+                      {SEVERITY_LABEL[r.severity]}
+                    </span>
+                  </td>
                   <td className="py-2 pr-3 align-top">
                     <label className="flex flex-col gap-1">
                       <span className="sr-only">

--- a/app/src/ui/TemplatesPanel.tsx
+++ b/app/src/ui/TemplatesPanel.tsx
@@ -15,6 +15,7 @@ import type { ClauseTemplate } from '../templates/types';
 import { Section } from './system/Section';
 import { Button } from './system/Button';
 import { Field } from './system/Field';
+import { EmptyState } from './system/EmptyState';
 
 interface TemplatesPanelProps {
   templates: ClauseTemplate[];
@@ -57,7 +58,10 @@ export function TemplatesPanel({
     <Section label="clause templates" className="space-y-4 px-4 py-4">
       <h2 className="text-heading uppercase text-fg-muted">Clause templates</h2>
       {templates.length === 0 ? (
-        <p className="text-body text-fg-muted">No clause templates saved yet.</p>
+        <EmptyState
+          title="No clause templates saved yet."
+          description="Add a template below to reuse standard clauses across leases."
+        />
       ) : (
         <ul className="space-y-2">
           {templates.map((t) => (

--- a/app/src/ui/__tests__/empty-states.test.tsx
+++ b/app/src/ui/__tests__/empty-states.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LibraryPanel } from '../LibraryPanel';
+import { TemplatesPanel } from '../TemplatesPanel';
+import { JurisdictionPickerPanel } from '../JurisdictionPickerPanel';
+
+// Wave 28-D smoke test: every empty-state branch renders the
+// EmptyState primitive (data-empty-description present) without
+// errors. Keeps the polish wired even if individual panels mutate.
+
+const noop = (): void => {};
+
+describe('empty states (Wave 28-D)', () => {
+  it('LibraryPanel empty branch uses EmptyState', () => {
+    const { container } = render(
+      <LibraryPanel
+        leases={[]}
+        standardId={null}
+        onOpen={noop}
+        onDelete={noop}
+        onSetStandard={noop}
+        onRename={noop}
+      />,
+    );
+    expect(screen.getByText(/no saved leases/i)).toBeInTheDocument();
+    expect(container.querySelector('[data-empty-description]')).not.toBeNull();
+  });
+
+  it('TemplatesPanel empty branch uses EmptyState', () => {
+    const { container } = render(
+      <TemplatesPanel
+        templates={[]}
+        onSave={noop}
+        onUpdate={noop}
+        onDelete={noop}
+      />,
+    );
+    expect(screen.getByText(/no clause templates saved yet/i)).toBeInTheDocument();
+    expect(container.querySelector('[data-empty-description]')).not.toBeNull();
+  });
+
+  it('JurisdictionPickerPanel empty-available branch uses EmptyState', () => {
+    const { container } = render(
+      <JurisdictionPickerPanel
+        available={[]}
+        selected={[]}
+        onChange={noop}
+      />,
+    );
+    expect(screen.getByText(/no jurisdictions available/i)).toBeInTheDocument();
+    expect(container.querySelector('[data-empty-description]')).not.toBeNull();
+  });
+});

--- a/app/src/ui/system/Button.tsx
+++ b/app/src/ui/system/Button.tsx
@@ -18,13 +18,16 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 const VARIANT: Record<Variant, string> = {
   default:
     'bg-ink text-paper hover:bg-ink/90 active:bg-ink/80 ' +
-    'focus-visible:outline focus-visible:outline-2 focus-visible:outline-ink',
+    'focus-visible:outline focus-visible:outline-2 focus-visible:outline-ink ' +
+    'focus-visible:focus-ring',
   ghost:
-    'bg-transparent text-fg-body hover:bg-paper-sunken ' +
-    'focus-visible:outline focus-visible:outline-2 focus-visible:outline-ink',
+    'bg-transparent text-fg-body hover:bg-[var(--state-hover)] active:bg-[var(--state-active)] ' +
+    'focus-visible:outline focus-visible:outline-2 focus-visible:outline-ink ' +
+    'focus-visible:focus-ring',
   subtle:
-    'bg-paper-sunken text-fg-body border border-rule hover:bg-paper-raised ' +
-    'focus-visible:outline focus-visible:outline-2 focus-visible:outline-ink',
+    'bg-paper-sunken text-fg-body border border-rule hover:bg-[var(--state-hover)] active:bg-[var(--state-active)] ' +
+    'focus-visible:outline focus-visible:outline-2 focus-visible:outline-ink ' +
+    'focus-visible:focus-ring',
 };
 const SIZE: Record<Size, string> = {
   sm: 'h-7 px-2 text-small rounded-sm',


### PR DESCRIPTION
## Summary

Wave 28 Part D — component polish per [docs/plans/wave28-design-pass-finish-and-a11y.md §5 Part D](../blob/main/docs/plans/wave28-design-pass-finish-and-a11y.md#part-d--component-polish-severity-table-findings-badge-empty-states-hoveractive).

- **SeverityOverridesPanel**: sticky `<thead>`, row hover via `--state-hover`, severity-tinted badges (dark fg + tinted bg + low-alpha border so they clear WCAG AA 4.5:1).
- **FindingsPanel**: hybrid `finding-llm-badge` gains `aria-pressed`, uses `--state-hover` / `--state-active`, and applies `focus-visible:focus-ring`.
- **LibraryPanel / TemplatesPanel / JurisdictionPickerPanel**: empty branches now render the `<EmptyState />` primitive (title + description). Visible copy preserved so existing e2e / unit assertions keep passing.
- **Button**: every variant wires `--state-hover` / `--state-active` + the `focus-visible:focus-ring` utility — polish cascades to every clickable surface, no behavioral change.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npm run test:coverage` — 165 files / 1305 tests pass; All files 97.40% / 89.89% / 93.80% / 97.40%; Button + EmptyState at 100%.
- [x] `npx playwright test --project=chromium` — 6 passed + 1 skipped (hybrid-golden gated, as expected).
- [x] No new audit kinds, no new deps, no `data-finding-key` / `aria-label` / `role` churn touched by the e2e specs.

## Caps

| Spec | Cap | Used |
|------|-----|------|
| New src | ≤ 1 | 0 (only one new test under `__tests__/`) |
| New tests | ≤ 4 | 2 (`FindingsPanel.badge.test.tsx`, `__tests__/empty-states.test.tsx`) |
| Modified src | ≤ 6 | 6 (`SeverityOverridesPanel.tsx`, `FindingsPanel.tsx`, `LibraryPanel.tsx`, `TemplatesPanel.tsx`, `JurisdictionPickerPanel.tsx`, `system/Button.tsx`) |

Stories were not modified — the polish lives on the components themselves and the existing stories continue to render through them; `TemplatesPanel` has no existing story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)