### PR TITLE
wave28-F: WCAG 2.1 AA fix-as-found sweep

### DIFF
--- a/app/src/ui/__tests__/accordion.a11y.test.tsx
+++ b/app/src/ui/__tests__/accordion.a11y.test.tsx
@@ -1,0 +1,119 @@
+// Wave 28 Part F — axe-core sweep across the bottom-pane accordion.
+//
+// Per plan §5 Part F.3 / F.4: every SectionGroup disclosure must satisfy
+// aria-expanded / aria-controls pairing in BOTH expanded and collapsed
+// states. Round-2 deviation: all three groups ship default-OPEN, so we
+// also need to verify the collapsed state by toggling.
+import { describe, it, expect, vi } from 'vitest';
+import type { ComponentProps } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AppLibraryAndPacksPane } from '../AppLibraryAndPacksPane';
+import { I18nProvider } from '../../i18n/I18nProvider';
+import { expectAxeClean } from '../../test/axe';
+
+function renderPane(over: Partial<ComponentProps<typeof AppLibraryAndPacksPane>> = {}) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fakePacks: any = {
+    installedPacks: [],
+    enabledPacks: new Set(),
+    importPackFile: vi.fn(async () => undefined),
+    togglePack: vi.fn(),
+    deletePack: vi.fn(),
+    packSignatureStatus: {},
+    activeRules: [],
+    selectedJurisdictions: [],
+    setSelectedJurisdictions: vi.fn(),
+    severityOverrides: {},
+    setSeverityOverride: vi.fn(),
+    existingRuleIds: [],
+    saveCustomRule: vi.fn(),
+    comparePackFile: vi.fn(async () => undefined),
+    packDiff: null,
+    bulkImportFiles: vi.fn(async () => ({ summary: [], total: 0 })),
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fakeSigning: any = { publicKey: null, createKey: vi.fn(), exportKeyToClipboard: vi.fn() };
+  const props: ComponentProps<typeof AppLibraryAndPacksPane> = {
+    library: [],
+    standardId: null,
+    templates: [],
+    packs: fakePacks,
+    marketplace: undefined,
+    jurisdictionOptions: [],
+    severityOverridesPanelRows: [],
+    severityOverridesPanelMap: {},
+    severityOverridesPanelOnChange: vi.fn(),
+    customRuleBuilderDoc: null,
+    auditEntries: [],
+    auditVerification: null,
+    signingKey: fakeSigning,
+    comparison: null,
+    onOpenLibrary: vi.fn(),
+    onDeleteLibrary: vi.fn(),
+    onSetStandard: vi.fn(),
+    onRenameLibrary: vi.fn(),
+    onCompare: vi.fn(),
+    onSaveTemplate: vi.fn(),
+    onUpdateTemplate: vi.fn(),
+    onDeleteTemplate: vi.fn(),
+    onRefreshAuditLog: vi.fn(),
+    onVerifyAuditChain: vi.fn(),
+    onDownloadAuditLog: vi.fn(),
+    ...over,
+  };
+  return render(
+    <I18nProvider>
+      <AppLibraryAndPacksPane {...props} />
+    </I18nProvider>,
+  );
+}
+
+describe('Accordion axe-core sweep (Wave 28 Part F)', () => {
+  it('all three SectionGroups expanded — zero axe violations', async () => {
+    const { container } = renderPane();
+    // sanity — confirm all open
+    expect(screen.getByRole('button', { name: /this lease/i })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    await expectAxeClean(container);
+  });
+
+  it('library + governance collapsed — zero axe violations (covers Round-2 deferred default-closed state)', async () => {
+    const { container } = renderPane();
+    await userEvent.click(screen.getByRole('button', { name: /^library$/i }));
+    await userEvent.click(screen.getByRole('button', { name: /governance/i }));
+    expect(screen.getByRole('button', { name: /^library$/i })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    expect(screen.getByRole('button', { name: /governance/i })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    await expectAxeClean(container);
+  });
+
+  it('every SectionGroup header carries paired aria-expanded + aria-controls', () => {
+    renderPane();
+    const headers = [
+      screen.getByRole('button', { name: /this lease/i }),
+      screen.getByRole('button', { name: /^library$/i }),
+      screen.getByRole('button', { name: /governance/i }),
+    ];
+    for (const h of headers) {
+      expect(h).toHaveAttribute('aria-expanded');
+      const controls = h.getAttribute('aria-controls');
+      expect(controls, `aria-controls missing on ${h.textContent}`).toBeTruthy();
+      // The disclosure panel must exist with the matching id and be
+      // labelled by the header. (Wave 28 Part F dropped role="region"
+      // from the panel to avoid landmark-unique collisions with
+      // descendant <Section> landmarks; the disclosure pattern itself
+      // stays intact.)
+      const panel = document.getElementById(controls!);
+      expect(panel, `panel #${controls} missing for header ${h.textContent}`).not.toBeNull();
+      expect(panel).toHaveAttribute('aria-labelledby', h.id);
+    }
+  });
+});

--- a/app/src/ui/__tests__/severity-table.a11y.test.tsx
+++ b/app/src/ui/__tests__/severity-table.a11y.test.tsx
@@ -1,0 +1,49 @@
+// Wave 28 Part F — axe-core sweep across SeverityOverridesPanel.
+//
+// Per plan §5 Part F.3 / F.6: re-verifies that Round-2's badge fix
+// (dark fg + tinted bg + low-alpha border) holds against axe color
+// contrast, and that the table semantics (scope=col headers, label/select
+// pairing, action button labels) survive.
+import { describe, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { SeverityOverridesPanel } from '../SeverityOverridesPanel';
+import { expectAxeClean } from '../../test/axe';
+
+const RULES = [
+  { id: 'r-info', title: 'Info rule', severity: 'info' as const },
+  { id: 'r-warn', title: 'Warn rule', severity: 'warn' as const },
+  { id: 'r-error', title: 'Error rule', severity: 'error' as const },
+];
+
+describe('SeverityOverridesPanel a11y (Wave 28 Part F)', () => {
+  it('empty branch — zero axe violations', async () => {
+    const { container } = render(
+      <SeverityOverridesPanel rules={[]} overrides={{}} onChange={() => {}} />,
+    );
+    await expectAxeClean(container);
+  });
+
+  it('populated table with all severity badges — zero axe violations', async () => {
+    const { container } = render(
+      <SeverityOverridesPanel
+        rules={RULES}
+        overrides={{ 'r-warn': 'error' }}
+        onChange={() => {}}
+      />,
+    );
+    await expectAxeClean(container);
+  });
+
+  it('with scope toggle column — zero axe violations', async () => {
+    const { container } = render(
+      <SeverityOverridesPanel
+        rules={RULES}
+        overrides={{ 'r-warn': 'error' }}
+        onChange={() => {}}
+        portfolioOverrides={{ 'r-error': 'info' }}
+        onScopeChange={() => {}}
+      />,
+    );
+    await expectAxeClean(container);
+  });
+});

--- a/app/src/ui/system/SectionGroup.tsx
+++ b/app/src/ui/system/SectionGroup.tsx
@@ -64,12 +64,16 @@ export function SectionGroup({
       {/*
         Wave 28 Part C bugfix: aria-labelledby now points to the disclosure
         button (which carries the title) rather than the panel's own id.
-        Self-referencing aria-labelledby caused the region's accessible name
-        to equal its full text content, which collided with descendant
-        labels (`getByLabelText` matched both the real <label> and this
-        wrapper).
+        Wave 28 Part F (a11y sweep): dropped `role="region"` on the panel —
+        the disclosure pattern (button[aria-expanded][aria-controls] +
+        panel[hidden]) is sufficient for AT. Promoting the panel to a
+        landmark region collided with descendant Section landmarks
+        (e.g. LibraryPanel's `<section aria-label="library">` matches the
+        outer "Library" disclosure's accessible name → axe
+        landmark-unique violation). aria-labelledby is retained so
+        readers still announce the group title when focus enters.
       */}
-      <div id={panelId} role="region" aria-labelledby={headerId} hidden={!open} className={open ? bodyPad : ''}>
+      <div id={panelId} aria-labelledby={headerId} hidden={!open} className={open ? bodyPad : ''}>
         {open && children}
       </div>
     </Card>


### PR DESCRIPTION
## Summary

Fix-as-found WCAG 2.1 AA sweep across the Wave 28 surfaces (SectionGroup,
bottom-pane accordion, severity table, button/panel polish, viewer span
highlights). Per plan §5 Part F.

## Fixes (1-liner each)

- **landmark-unique** — `SectionGroup` panel dropped `role="region"`; the disclosure pattern (`button[aria-expanded][aria-controls]` + `panel[hidden]` + `aria-labelledby`) is sufficient for AT, and the role was colliding with descendant `<Section>` landmarks (e.g. LibraryPanel's `<section aria-label=\"library\">` matched the outer \"Library\" disclosure's accessible name).

## Audit checklist (F.1 → F.12)

- F.1 Tab order — flows header → tab bar → main pane → bottom-pane groups (in DOM order, no traps).
- F.2 `:focus-visible` ring — verified `--ring` token + `focus-visible:focus-ring` utility wired on `SectionGroup` headers and all `Button` variants. Confirmed via `app/src/index.css` `@utility focus-ring` + `Button.tsx`/`SectionGroup.tsx` class lists.
- F.3 axe scans — added `accordion.a11y.test.tsx` (3 cases: expanded / collapsed / aria-pairing) and `severity-table.a11y.test.tsx` (3 cases: empty / populated / scope-toggle). All zero-violation after the landmark-unique fix.
- F.4 `aria-expanded` / `aria-controls` paired on every SectionGroup instance — asserted in the new accordion test (loops all three headers, looks up panel by id).
- F.5 Tab bar — uses `role=\"group\"` + `aria-label=\"view mode\"` + `aria-pressed` toggle buttons (Wave 27-B pattern). Valid WAI-ARIA toggle-button pattern; not restructured per scope cap.
- F.6 Color contrast — Round-2 severity-badge fix (dark `--color-fg` + tinted bg via `color-mix` + low-alpha border) re-verified by `severity-table.a11y.test.tsx`. Zero axe contrast violations.
- F.7 Tap targets — `Button` size `sm` is `h-7 px-2` (~28px); `md` is `h-9 px-3` (~36px). Both under the 44×44 mobile guideline. Surfacing for Wave 29 (would require restructure / new size token, out of cap).
- F.8 Screen-reader walk — skipped (no SR available in headless env).
- F.9 Fixes shipped as separate commits.
- F.10 Lighthouse — `npm run lhci` errored: \`sh: lhci: command not found\` in this env (lighthouse-ci not installed). Per brief contingency, fell back to axe-core sweep. Baseline lhci score not captured.
- F.11 Local CI — `npm run typecheck && npm run lint && npm run test:coverage` all green (169 files, 1324 passed + 1 todo). `npx playwright test --project=chromium` → 6 passed + 1 skipped. ✓
- F.12 Before / after a11y scores — see F.10 (lhci unavailable). axe before: 1 violation (landmark-unique on bottom-pane-library-panel). axe after: 0 violations.

## Deviations from cap

- 0 new src files (cap: 0). ✓
- 2 new test files (cap: ≤2). ✓
- 1 modified src file (cap: ≤8): `app/src/ui/system/SectionGroup.tsx`. ✓
- Zero churn on `data-finding-key`, `data-span-highlight`, or any e2e-queried `data-*`. ✓

## Punted to Wave 29

- F.7 tap-target sizes (Button `sm`/`md` both <44px). Requires new size token / Tailwind config — exceeds restructure cap.
- F.5 view-mode could move from `role=group + aria-pressed` to `role=tablist + role=tab + aria-selected` for stronger semantics — JSX restructure, deferred.
- Lighthouse baseline (lhci binary not installed in this env).
- Default-closed for `library` and `governance` accordion groups (already deferred from Wave 28 Part C).

## Test plan

- [x] `npm run typecheck` green
- [x] `npm run lint` green
- [x] `npm run test:coverage` green (169 files, 1324 passed + 1 todo)
- [x] `npx playwright test --project=chromium` → 6 passed + 1 skipped
- [x] All 9 `*.a11y.test.*` tests zero-violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)