### PR TITLE
docs(post-wave28): mark span-bbox shipped; note WCAG pass

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -173,18 +173,13 @@ Local-only, CSP-compatible.
       `definitions` prop is supplied.
 - [ ] Golden tests: a commercial lease fixture exercising table +
       definitions + references simultaneously.
-- [ ] **Per-span bbox on `Finding`** so the PDF viewer can highlight the
-      exact matched substring instead of the whole paragraph. Today
-      `Finding.span` is `{start, end}` char offsets into
-      `paragraph.text`; mapping that back to a canvas bbox requires
-      walking the paragraph's `PageText.items[]` (each item has
-      x/y/width/height). Plan: extend `Finding` with a derived
-      `spanBbox: BoundingBox` populated by the rules engine when the
-      span maps cleanly to one or more text items, and consumed by
-      `PdfViewer.tsx` (multiple rects when the span straddles items).
-      Out of scope for Wave 15-C (shipped clipping + reduced-motion
-      only); track as a dedicated follow-up wave because it touches
-      parser → rules → ui in lockstep.
+- [x] **Per-span bbox highlighting.** Shipped in Wave 28-A + 28-E.
+      Parser now attaches `Paragraph.lines: LineSpan[]` (each line
+      keeps its char-offset range + bbox); `PdfViewer` renders one
+      highlight rect per overlapping line via `computeSpanRects`,
+      with paragraph-bbox fallback for legacy persisted leases.
+      Non-breaking — `lines` is optional; legacy leases get the
+      Wave 15-C paragraph-rect highlight until re-parsed.
 
 ## Phase 9 — Negotiation support
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -181,13 +181,9 @@ New UI panels live in `src/ui/` and follow a four-file convention:
 
 ## Deferred / explicitly out of scope
 
-- Span-level highlight bbox computation. Wave 15-C shipped viewport
-  clipping + `prefers-reduced-motion` opt-out on the existing paragraph
-  bbox; per-span bbox highlighting is tracked as a planned follow-up
-  wave because `Finding.span` is `{start, end}` char offsets, not a
-  bbox — the parser needs to attach a per-span bounding box first.
-  See the BACKLOG row under Phase 8.
-- Full WCAG 2.1 AA audit.
+- Full WCAG 2.1 AA audit. (Wave 28-F shipped a fix-as-found pass:
+  axe-core scans on accordion + severity table, `landmark-unique`
+  fix in `SectionGroup`. A full external AA audit remains deferred.)
 - Tauri desktop wrapper (stub dir exists; no code).
 - Cloud sync / accounts / telemetry.
 - Pre-commit hooks via `lint-staged` (CI is authoritative).


### PR DESCRIPTION
## Summary

- Mark per-span bbox highlighting (Phase 8 follow-up) as shipped — Wave 28-A + 28-E delivered it via `Paragraph.lines: LineSpan[]` + `computeSpanRects` with paragraph-bbox fallback for legacy persisted leases.
- Note in \`docs/CLAUDE.md\` that Wave 28-F shipped a fix-as-found WCAG pass; full external AA audit remains deferred.

## Test plan

- [ ] BACKLOG Phase 8 row reads as ✅ shipped with the new file references (`Paragraph.lines`, `computeSpanRects`).
- [ ] CLAUDE.md "Deferred / explicitly out of scope" no longer lists span-level highlight bbox; WCAG entry now references Wave 28-F.

🤖 Generated with [Claude Code](https://claude.com/claude-code)