### PR TITLE
wave29-B: hybrid quality (DRAFT — awaiting rule-id approval)

### DIFF
--- a/app/src/rules/hybridAnalyze.test.ts
+++ b/app/src/rules/hybridAnalyze.test.ts
@@ -345,4 +345,53 @@ describe('runHybridAnalyze', () => {
     expect(findings).toEqual([]);
     expect(embedFn).not.toHaveBeenCalled();
   });
+
+  // Wave 29 Part B (Phase 2): rules may declare `hybridAnchors`,
+  // additional substrings merged into the keyword pre-filter so a
+  // paragraph that doesn't share any title tokens can still qualify
+  // for the embedding pass when it contains a known anchor phrase.
+  it('hybridAnchors merge into pre-filter so an off-title paragraph qualifies', async () => {
+    const embedFn = vi.fn(makeStubEmbedder());
+    // Title-only tokens are {indemnification, landlord} — the test
+    // paragraph contains neither, but it does contain the anchor
+    // phrase "hold harmless". Without anchors the rule would be
+    // skipped; with anchors it should produce a hybrid finding.
+    const r = rule({
+      id: 'indemnification',
+      title: 'Indemnification of landlord',
+      match: { type: 'keywordProximity', keywords: ['xxxx', 'yyyy'], window: 40 },
+      hybridAnchors: ['hold harmless'],
+    });
+    const paragraphText =
+      'Tenant agrees to hold harmless the property owner from any third-party claims arising on the premises.';
+    const findings = await runHybridAnalyze({
+      doc: doc([paragraphText]),
+      rules: [r],
+      enabled: true,
+      embedFn,
+      threshold: 0.0,
+    });
+    expect(embedFn).toHaveBeenCalled();
+    expect(findings.length).toBe(1);
+    expect(findings[0]?.ruleId).toBe('indemnification');
+    expect(findings[0]?.confidence).toBe(0.5);
+
+    // Sanity: same paragraph + same rule WITHOUT anchors → no
+    // pre-filter overlap, no embed call, no finding.
+    const embedFn2 = vi.fn(makeStubEmbedder());
+    const rNoAnchors = rule({
+      id: 'indemnification',
+      title: 'Indemnification of landlord',
+      match: { type: 'keywordProximity', keywords: ['xxxx', 'yyyy'], window: 40 },
+    });
+    const findings2 = await runHybridAnalyze({
+      doc: doc([paragraphText]),
+      rules: [rNoAnchors],
+      enabled: true,
+      embedFn: embedFn2,
+      threshold: 0.0,
+    });
+    expect(embedFn2).not.toHaveBeenCalled();
+    expect(findings2).toEqual([]);
+  });
 });

--- a/app/src/rules/hybridAnalyze.ts
+++ b/app/src/rules/hybridAnalyze.ts
@@ -115,14 +115,25 @@ export async function runClassifierPass(opts: RunClassifierPassOptions): Promise
 
   // Pre-compute keyword sets for each rule (lowercased word set from
   // rule title). Rule title is the cheapest "anchor" we have without
-  // synthesizing prompts.
+  // synthesizing prompts. Wave 29 Part B (Phase 2): rules may also
+  // declare `hybridAnchors` — additional case-insensitive substrings
+  // (often multi-word phrases like "hold harmless") that should also
+  // qualify a paragraph for the classifier pass. Anchors are merged
+  // into the keyword set; the original title-derived tokens are kept.
   const rulesArr = rules as Rule[];
   const ruleKeywords = rulesArr.map((r) => {
     const tokens = r.title
       .toLowerCase()
       .split(/[^a-z0-9]+/)
       .filter((w) => w.length >= 4);
-    return new Set(tokens);
+    const set = new Set<string>(tokens);
+    if (r.hybridAnchors) {
+      for (const a of r.hybridAnchors) {
+        const trimmed = a.trim().toLowerCase();
+        if (trimmed.length > 0) set.add(trimmed);
+      }
+    }
+    return set;
   });
 
   // Build the work queue: (paragraphIndex, ruleIndex) pairs where the

--- a/app/src/rules/packV1.ts
+++ b/app/src/rules/packV1.ts
@@ -36,6 +36,7 @@ export const RULE_PACK_V1: Rule[] = [
       keywords: ['early', 'termination'],
       window: 40,
     },
+    hybridAnchors: ['buyout fee', 'lease break fee'],
   },
   {
     id: 'assignment-subletting',
@@ -54,6 +55,7 @@ export const RULE_PACK_V1: Rule[] = [
       keywords: ['sublet', 'consent'],
       window: 60,
     },
+    hybridAnchors: ['underlet', 'transfer this lease'],
   },
   {
     id: 'late-fees',
@@ -106,6 +108,7 @@ export const RULE_PACK_V1: Rule[] = [
       keywords: ['waive', 'jury'],
       window: 40,
     },
+    hybridAnchors: ['trial by jury'],
   },
   {
     id: 'arbitration',
@@ -124,6 +127,7 @@ export const RULE_PACK_V1: Rule[] = [
       pattern: '\\b(?:binding\\s+)?arbitration\\b',
       flags: 'i',
     },
+    hybridAnchors: ['JAMS', 'AAA', 'ADR'],
   },
   {
     id: 'indemnification',
@@ -142,6 +146,7 @@ export const RULE_PACK_V1: Rule[] = [
       keywords: ['indemnify', 'landlord'],
       window: 60,
     },
+    hybridAnchors: ['hold harmless', 'save harmless'],
   },
   {
     id: 'rent-escalation',
@@ -160,6 +165,7 @@ export const RULE_PACK_V1: Rule[] = [
       keywords: ['rent', 'increase'],
       window: 40,
     },
+    hybridAnchors: ['CPI', 'step-up', 'escalation'],
   },
   {
     id: 'personal-guaranty',
@@ -178,5 +184,6 @@ export const RULE_PACK_V1: Rule[] = [
       pattern: '\\bpersonal(?:ly)?\\s+guarant(?:y|ee|or)\\b',
       flags: 'i',
     },
+    hybridAnchors: ['personally liable'],
   },
 ];

--- a/app/src/rules/types.ts
+++ b/app/src/rules/types.ts
@@ -57,6 +57,19 @@ export interface Rule {
    * addition — purely additive.
    */
   suggestedEdit?: string;
+  /**
+   * Wave 29 Part B (Phase 2) — optional hybrid pre-filter anchors.
+   * The classifier pass uses the rule title to derive 4+-char keyword
+   * tokens for cheap pre-filtering before computing embedding similarity.
+   * For rules whose title doesn't capture common phrasings (e.g.
+   * "indemnification" doesn't include "hold harmless"), `hybridAnchors`
+   * supplies extra phrases that are MERGED INTO the keyword set so
+   * paragraphs containing those anchors are considered for the
+   * classifier pass. Anchors are matched as case-insensitive substrings
+   * of the paragraph text. Purely additive — rules without
+   * `hybridAnchors` keep current behavior.
+   */
+  hybridAnchors?: string[];
 }
 
 export interface Span {


### PR DESCRIPTION
## APPROVED — Phase 2 implementation

Phase 1 was approved on 2026-04-26 (option 2: add `hybridAnchors?:
string[]` and merge into the keyword pre-filter for 7 targeted rules).
Phase 2 implementation is pushed to this branch. CI/Mergify gate
remains open — this PR is **not** flipped to ready-for-review yet
(see Wave 28 CI discrepancy memo).

---

## Phase 2 changes

**Mechanism (additive, optional):**
- `app/src/rules/types.ts` — adds `hybridAnchors?: string[]` to `Rule`
- `app/src/rules/hybridAnalyze.ts` — when a rule supplies
  `hybridAnchors`, lowercased anchor strings are merged into that
  rule's keyword set used by the cheap pre-filter. The existing
  `lower.includes(kw)` substring check handles multi-word phrases
  unchanged. Rules without `hybridAnchors` keep current behavior.

**Anchors applied (per approved Phase 1 list, no deviations):**
| rule id | anchors |
|---|---|
| `indemnification` | `hold harmless`, `save harmless` |
| `assignment-subletting` | `underlet`, `transfer this lease` |
| `jury-waiver` | `trial by jury` |
| `personal-guaranty` | `personally liable` |
| `early-termination-fee` | `buyout fee`, `lease break fee` |
| `arbitration` | `JAMS`, `AAA`, `ADR` |
| `rent-escalation` | `CPI`, `step-up`, `escalation` |

**Tests:** one new unit test in `hybridAnalyze.test.ts` proves
anchor-merge: a paragraph with no title-token overlap qualifies via
the anchor; the same paragraph without anchors triggers no embed call.

**Skipped per plan:** e2e rebaseline — `tests/e2e/hybrid-golden.spec.ts`
asserts `evidence.modelId` presence, not a finding count, so there is
nothing to rebaseline.

**File caps:** 2 src files (types, hybridAnalyze) + 1 metadata-only
data file (packV1) + 1 test file. Within the ≤2 src + ≤1 test
envelope when packV1 is treated as data, as the plan anticipated.

## Local gate

```
cd app && npm run typecheck && npm run lint && npm test
```

All green: typecheck clean, lint clean, **169 test files, 1325 tests
passed, 1 todo** (15.62s). Logs: see commit `5967ae4`.

## Heartbeat

`.claude/agent-status/wave29-B.log` writes were sandbox-denied in
Phase 1; falling back to PR comments per the dispatch brief. Phase 2
ran in a single ~10-minute slice so no mid-run heartbeat was needed.

## Phase 1 archive

Phase 1 investigation findings (allowlist-mechanism analysis,
candidate-id rationale, plan-spec corrections) preserved below for
audit:

<details>
<summary>Phase 1 findings (collapsed)</summary>

The plan's reference to a "Wave 22-A allowlist" was a misnomer —
Wave 22-A shipped the `llm-classify` audit kind, not an allowlist.
No allowlist existed. `hybridAnalyze.ts` admitted any rule whose
title produced ≥1 keyword token of length ≥4. Recommended path
(approved): introduce per-rule `hybridAnchors?: string[]` merged
into the keyword pre-filter for variable-phrasing rules. The
real-model spec lives at `tests/e2e/hybrid-golden.spec.ts`, not
`app/e2e/golden-real-model.spec.ts` as the plan stated, and it
asserts `evidence.modelId` presence with no finding-count
baseline — so the planned e2e rebaseline was a no-op.

</details>
