### PR TITLE
wave31-A: hybrid demotion candidates

### DIFF
--- a/app/src/audit/hybridStats.test.ts
+++ b/app/src/audit/hybridStats.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeHybridStats } from './hybridStats';
+import { computeHybridStats, isDemotionCandidate, DEMOTION_MIN_FIRES, DEMOTION_MAX_PRECISION } from './hybridStats';
 import type { AuditEntry } from './auditLog';
 
 function entry(
@@ -116,5 +116,27 @@ describe('computeHybridStats', () => {
       'mu',
       'zeta',
     ]);
+  });
+});
+
+describe('isDemotionCandidate', () => {
+  it('returns false below the fires floor', () => {
+    expect(isDemotionCandidate({ ruleId: 'r', fires: 9, notRelevant: 9, precision: 0 })).toBe(false);
+  });
+  it('returns true at the fires floor with bad precision', () => {
+    expect(isDemotionCandidate({ ruleId: 'r', fires: 10, notRelevant: 4, precision: 0.6 })).toBe(true);
+  });
+  it('returns false above the floor with good precision', () => {
+    expect(isDemotionCandidate({ ruleId: 'r', fires: 20, notRelevant: 2, precision: 0.9 })).toBe(false);
+  });
+  it('treats the precision boundary as exclusive (< not <=)', () => {
+    expect(isDemotionCandidate({ ruleId: 'r', fires: 10, notRelevant: 3, precision: 0.7 })).toBe(false);
+  });
+  it('returns false when precision is null (no fires)', () => {
+    expect(isDemotionCandidate({ ruleId: 'r', fires: 0, notRelevant: 1, precision: null })).toBe(false);
+  });
+  it('exports the documented threshold values', () => {
+    expect(DEMOTION_MIN_FIRES).toBe(10);
+    expect(DEMOTION_MAX_PRECISION).toBe(0.70);
   });
 });

--- a/app/src/audit/hybridStats.ts
+++ b/app/src/audit/hybridStats.ts
@@ -65,3 +65,23 @@ export function computeHybridStats(entries: AuditEntry[]): HybridRuleStats[] {
   rows.sort((a, b) => (a.ruleId < b.ruleId ? -1 : a.ruleId > b.ruleId ? 1 : 0));
   return rows;
 }
+
+// ---------------------------------------------------------------------------
+// Demotion-candidate helpers (Wave 31-A)
+// ---------------------------------------------------------------------------
+
+/** Minimum number of fires before a rule is considered for demotion. */
+export const DEMOTION_MIN_FIRES = 10;
+
+/** Precision ceiling (exclusive) below which a rule is a demotion candidate. */
+export const DEMOTION_MAX_PRECISION = 0.70;
+
+/**
+ * Returns `true` when a rule has fired enough times to be statistically
+ * meaningful AND has poor precision — signalling that the `hybridAnchors`
+ * predicate is too loose. See Wave 31-A plan for action steps.
+ */
+export function isDemotionCandidate(stats: HybridRuleStats): boolean {
+  if (stats.precision === null) return false;
+  return stats.fires >= DEMOTION_MIN_FIRES && stats.precision < DEMOTION_MAX_PRECISION;
+}

--- a/app/src/ui/HybridPrecisionPanel.test.tsx
+++ b/app/src/ui/HybridPrecisionPanel.test.tsx
@@ -11,6 +11,18 @@ const populated: HybridRuleStats[] = [
   { ruleId: 'orphan', fires: 0, notRelevant: 1, precision: null },
 ];
 
+// Stats where no row meets demotion thresholds (all fires < 10 or precision >= 0.70)
+const noCandidates: HybridRuleStats[] = [
+  { ruleId: 'auto-renewal', fires: 12, notRelevant: 2, precision: 1 - 2 / 12 }, // 83% precision — good
+  { ruleId: 'late-fee-cap', fires: 9, notRelevant: 6, precision: 1 - 6 / 9 },   // only 9 fires — below floor
+];
+
+// Stats where one row is a demotion candidate (fires >= 10 AND precision < 0.70)
+const withCandidate: HybridRuleStats[] = [
+  { ruleId: 'auto-renewal', fires: 12, notRelevant: 2, precision: 1 - 2 / 12 }, // 83% precision — good
+  { ruleId: 'rule.indemnity', fires: 14, notRelevant: 5, precision: 0.643 },     // candidate
+];
+
 describe('HybridPrecisionPanel', () => {
   it('renders an empty state when stats is empty', () => {
     render(<HybridPrecisionPanel stats={[]} />);
@@ -53,6 +65,19 @@ describe('HybridPrecisionPanel', () => {
       'hybrid-precision-row-security-deposit', // 100%
       'hybrid-precision-row-orphan', // null → last
     ]);
+  });
+
+  it('renders the empty-state copy when no rules meet demotion thresholds', () => {
+    render(<HybridPrecisionPanel stats={noCandidates} />);
+    expect(screen.getByText(/No rules currently meet demotion thresholds/i)).toBeInTheDocument();
+    expect(screen.getByText(/≥10 fires AND <70% precision/)).toBeInTheDocument();
+  });
+
+  it('lists demotion candidates with rule id, fires, and precision', () => {
+    render(<HybridPrecisionPanel stats={withCandidate} />);
+    expect(screen.getByText(/Demotion candidates \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText(/rule\.indemnity — 14 fires, 64\.3%/)).toBeInTheDocument();
+    expect(screen.getByText(/remove `hybridAnchors`/)).toBeInTheDocument();
   });
 
   it('switches to fires-desc ordering on user request', async () => {

--- a/app/src/ui/HybridPrecisionPanel.tsx
+++ b/app/src/ui/HybridPrecisionPanel.tsx
@@ -7,7 +7,11 @@
 
 import { useState } from 'react';
 import type { AuditEntry } from '../audit/auditLog';
-import { computeHybridStats, type HybridRuleStats } from '../audit/hybridStats';
+import {
+  computeHybridStats,
+  isDemotionCandidate,
+  type HybridRuleStats,
+} from '../audit/hybridStats';
 import { Section } from './system/Section';
 import { EmptyState } from './system/EmptyState';
 
@@ -53,6 +57,8 @@ export function HybridPrecisionPanel({
     return ap - bp;
   });
 
+  const demotionCandidates = stats.filter(isDemotionCandidate);
+
   return (
     <Section label="hybrid precision" className="space-y-3 px-4 py-4">
       <h2 className="text-heading uppercase text-fg-muted">
@@ -62,6 +68,28 @@ export function HybridPrecisionPanel({
         Per-rule precision over hybrid (LLM-assisted) findings.
         Precision = 1 − (not-relevant ÷ fires).
       </p>
+
+      {demotionCandidates.length === 0 ? (
+        <p className="text-small text-fg-muted">
+          No rules currently meet demotion thresholds (≥10 fires AND &lt;70% precision). The panel will populate as users mark hybrid findings not-relevant.
+        </p>
+      ) : (
+        <div className="space-y-1">
+          <h3 className="text-small text-fg-muted font-sans">
+            Demotion candidates ({demotionCandidates.length})
+          </h3>
+          <ul className="text-small text-fg-body space-y-0.5">
+            {demotionCandidates.map((row) => (
+              <li key={row.ruleId} className="font-mono text-mono">
+                {row.ruleId} — {row.fires} fires, {((row.precision as number) * 100).toFixed(1)}%
+              </li>
+            ))}
+          </ul>
+          <p className="text-small text-fg-muted">
+            To demote: remove `hybridAnchors` from this rule in `app/src/rules/packV1.ts`.
+          </p>
+        </div>
+      )}
 
       <div role="group" aria-label="hybrid precision controls" className="flex flex-wrap gap-2">
         <label className="text-small text-fg-muted">


### PR DESCRIPTION
## Summary

Adds a read-only "demotion candidates" subsection above the existing
rules table in HybridPrecisionPanel. A rule is a candidate when it has
≥10 fires AND <70% precision in the hybrid-feedback audit stream
(thresholds exported from `hybridStats.ts` so the follow-up demotion
PR can reference the same numbers).

Empty state on fresh installs declares the thresholds inline; the
populated state lists candidates and points humans to
`app/src/rules/packV1.ts hybridAnchors` for the actual edit.

No buttons, no IDB writes, no new audit kinds. The panel surfaces
signal; demotion happens in a follow-up PR.

## Files

- `app/src/audit/hybridStats.ts` — `DEMOTION_MIN_FIRES`,
  `DEMOTION_MAX_PRECISION`, `isDemotionCandidate`.
- `app/src/audit/hybridStats.test.ts` — boundary cases (6 new tests).
- `app/src/ui/HybridPrecisionPanel.tsx` — empty / non-empty branches.
- `app/src/ui/HybridPrecisionPanel.test.tsx` — both branches covered.

## Test plan

- [x] `npm run typecheck` green
- [x] `npm run lint` green
- [x] `npm test` green (1374 passed)
- [ ] CI green before `gh pr ready`

🤖 Generated with [Claude Code](https://claude.com/claude-code)