### PR TITLE
wave31-C: coverage push

### DIFF
--- a/app/src/App/useReviewMode.test.ts
+++ b/app/src/App/useReviewMode.test.ts
@@ -39,4 +39,19 @@ describe('useReviewMode', () => {
     });
     expect(result.current.mode.active).toBe(false);
   });
+
+  it('returns a safe inactive fallback when used outside the provider', () => {
+    // Exercises the provider-absent branch — panels that call useReviewMode
+    // without a wrapping ReviewModeProvider must get mode.active===false
+    // rather than throwing, so isolated panel tests don't need the provider.
+    const { result } = renderHook(() => useReviewMode());
+    expect(result.current.mode.active).toBe(false);
+    // enter/exit are no-ops outside the provider — calling them must not throw.
+    expect(() => {
+      act(() => {
+        result.current.enter({ archiveId: 'x', expiresAt: '2099-01-01T00:00:00Z' });
+        result.current.exit();
+      });
+    }).not.toThrow();
+  });
 });

--- a/app/src/glossary/loadGlossary.test.ts
+++ b/app/src/glossary/loadGlossary.test.ts
@@ -144,4 +144,76 @@ describe('loadGlossary', () => {
     const g = await loadGlossary();
     expect(g.entries).toEqual([]);
   });
+
+  it('returns empty glossary when the top-level payload is not an object (e.g. array)', async () => {
+    // Exercises the !isRecord(raw) branch — a non-null non-object response
+    // (like a bare array) must not crash the validator.
+    stubFetch(async () => new Response(JSON.stringify([1, 2, 3]), { status: 200 }));
+    const g = await loadGlossary();
+    expect(g.entries).toEqual([]);
+  });
+
+  it('returns empty glossary when the schema version number is wrong', async () => {
+    // Exercises the raw.version !== 1 branch — a future schema bump should
+    // be silently ignored rather than crashing the consumer.
+    stubFetch(
+      async () =>
+        new Response(
+          JSON.stringify({ schema: 'leaseguard.glossary.v1', version: 2, entries: [] }),
+          { status: 200 },
+        ),
+    );
+    const g = await loadGlossary();
+    expect(g.entries).toEqual([]);
+  });
+
+  it('returns empty glossary when entries is not an array', async () => {
+    // Exercises the !Array.isArray(raw.entries) branch — a payload where
+    // entries is an object or null must not partially populate the glossary.
+    stubFetch(
+      async () =>
+        new Response(
+          JSON.stringify({ schema: 'leaseguard.glossary.v1', version: 1, entries: {} }),
+          { status: 200 },
+        ),
+    );
+    const g = await loadGlossary();
+    expect(g.entries).toEqual([]);
+  });
+
+  it('returns empty glossary when an entry is a non-object (e.g. string)', async () => {
+    // Exercises the !isRecord(e) per-entry guard — ensures a corrupted
+    // entry (bare string) does not bypass structural validation.
+    stubFetch(
+      async () =>
+        new Response(
+          JSON.stringify({
+            schema: 'leaseguard.glossary.v1',
+            version: 1,
+            entries: ['not-an-object'],
+          }),
+          { status: 200 },
+        ),
+    );
+    const g = await loadGlossary();
+    expect(g.entries).toEqual([]);
+  });
+
+  it('returns empty glossary when sources is present but not an array', async () => {
+    // Exercises the !Array.isArray(e.sources) branch — a sources field that
+    // is a plain string (not an array) must invalidate the whole glossary.
+    stubFetch(
+      async () =>
+        new Response(
+          JSON.stringify({
+            schema: 'leaseguard.glossary.v1',
+            version: 1,
+            entries: [{ term: 'A', definition: 'd', sources: 'not-array' }],
+          }),
+          { status: 200 },
+        ),
+    );
+    const g = await loadGlossary();
+    expect(g.entries).toEqual([]);
+  });
 });

--- a/app/src/ui/useColorScheme.test.ts
+++ b/app/src/ui/useColorScheme.test.ts
@@ -98,4 +98,61 @@ describe('useColorScheme', () => {
   it('exports a callable hook (SSR guard sanity)', () => {
     expect(typeof useColorScheme).toBe('function');
   });
+
+  it('still updates in-memory theme when localStorage.setItem throws', () => {
+    // Exercises the catch block in setTheme — ensures a broken/restricted
+    // storage does not prevent the hook from updating visible state.
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        ...window.localStorage,
+        setItem: () => { throw new Error('storage quota exceeded'); },
+        removeItem: () => { throw new Error('storage quota exceeded'); },
+        getItem: () => null,
+      },
+    });
+    const { result } = renderHook(() => useColorScheme());
+    act(() => result.current.setTheme('dark'));
+    // In-memory state updates even though persistence failed.
+    expect(result.current.theme).toBe('dark');
+  });
+
+  it('fires the media-query change listener and re-applies data-theme', () => {
+    // Exercises the onChange closure registered inside useEffect — ensures
+    // switching from light to dark via OS preference update is handled.
+    // The onChange handler reads mq.matches directly, so we capture the mql
+    // object and mutate its matches property before firing the callback.
+    const listeners: Array<(e: { matches: boolean }) => void> = [];
+    let capturedMql: { matches: boolean } | null = null;
+
+    vi.spyOn(window, 'matchMedia').mockImplementation((query) => {
+      const mql = {
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: (_ev: string, cb: (e: { matches: boolean }) => void) => {
+          listeners.push(cb);
+        },
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      };
+      if (query === '(prefers-color-scheme: dark)') capturedMql = mql;
+      return mql as unknown as MediaQueryList;
+    });
+
+    const { result } = renderHook(() => useColorScheme());
+    // Confirm system/light to start.
+    expect(result.current.resolvedScheme).toBe('light');
+
+    // Simulate OS switching to dark — update mql.matches then fire change.
+    if (capturedMql) (capturedMql as { matches: boolean }).matches = true;
+    act(() => {
+      listeners.forEach((cb) => cb({ matches: true }));
+    });
+
+    expect(result.current.resolvedScheme).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
 });

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -79,12 +79,18 @@ export default defineConfig({
         // Raised 2026-04-26 (Wave 24-C) after surgical removal of
         // unreachable defensive guards in `hybridAnalyze.ts` (loop-
         // bounded indexed accesses no longer pay v8's `?? 0` / `?? ''`
-        // branch tax). Actuals sit at 97.27 / 89.61 / 93.71 / 97.27;
-        // the +1 branch bump (88 → 89) is the honest ceiling absent
+        // branch tax). Actuals sat at 97.27 / 89.61 / 93.71 / 97.27;
+        // the +1 branch bump (88 → 89) was the honest ceiling absent
         // either (a) decomposing App.tsx further or (b) another guard
         // sweep on remaining `noUncheckedIndexedAccess` artifacts.
+        //
+        // Raised 2026-04-27 (Wave 31-C) after targeted tests on
+        // useColorScheme, loadGlossary, and useReviewMode uncovered
+        // meaningful error-path and fallback branches. Actuals landed
+        // at 97.52 / 90.21 / 94.26 / 97.52; branches cleared the 90.2
+        // threshold so the floor steps up 89 → 90.
         statements: 95,
-        branches: 89,
+        branches: 90,
         functions: 91,
         lines: 95,
       },


### PR DESCRIPTION
## Coverage before/after

| Metric | Before (post-merge main) | After (this PR) |
|---|---|---|
| Statements | 97.48% | 97.52% |
| **Branches** | **90.04%** | **90.21%** |
| Functions | 93.87% | 94.26% |
| Lines | 97.48% | 97.52% |

## Target modules

| Module | Before branches % | Uncovered branches targeted |
|---|---|---|
| `src/ui/useColorScheme.ts` | 83.87% | `setTheme` localStorage-throws catch block (line 70-71); `onChange` media-query change listener closure (lines 56-59) |
| `src/glossary/loadGlossary.ts` | 83.33% | `!isRecord(raw)` non-object payload; `raw.version !== 1` wrong version; `!Array.isArray(raw.entries)` non-array entries; `!isRecord(e)` non-object entry; `!Array.isArray(e.sources)` sources not-array |
| `src/App/useReviewMode.ts` | 83.33% | Provider-absent fallback path (lines 43-46) |

## Floor bump decision

Branches landed at **90.21%** (≥ 90.2 threshold) → bumped `branches` floor from **89 → 90** in `app/vite.config.ts`.

## Files touched

- `app/src/ui/useColorScheme.test.ts` — 2 new tests
- `app/src/glossary/loadGlossary.test.ts` — 5 new tests
- `app/src/App/useReviewMode.test.ts` — 1 new test
- `app/vite.config.ts` — branches threshold 89 → 90

## Local gate

- `npm run typecheck` ✓
- `npm run lint` ✓
- `npm run test:coverage` — all tests pass; coverage meets new 90 branch floor; one pre-existing flaky test (`FindingsPanel.feedback.test.tsx`) fails intermittently in full-suite runs but passes in isolation (introduced in wave29-C, unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)