### PR TITLE
docs(plans): wave 32 — phase 19, dark-mode sweep, audit-id linkage, coverage

### DIFF
--- a/docs/plans/wave32-phase19-darkmode-audit-coverage.md
+++ b/docs/plans/wave32-phase19-darkmode-audit-coverage.md
@@ -1,0 +1,868 @@
+# Wave 32 — Phase 19 productionization, dark-mode sweep, audit-id linkage, coverage
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use
+> `superpowers:subagent-driven-development` (or the project's `/wave`
+> skill, which dispatches in parallel against disjoint worktrees) to
+> dispatch Parts A, B, C per the matrix in §7. Steps use checkbox
+> (`- [ ]`) syntax for tracking.
+
+**Design spec:** `docs/superpowers/specs/2026-04-27-wave32-design.md`
+(read first if any §X.Y step is ambiguous).
+
+**Goal.** Close the Phase 18 → 19 transition with a nightly real-model
+GHA + audit-id linkage, pay down dark-mode polish debt that Wave 31's
+toggle exposed, and continue the established coverage pattern. Three
+parallel parts (A/B/C), one rebases-last (E).
+
+**Architecture.** A is a CI-only workflow that schedules the existing
+`RUN_REAL_MODEL=1`-gated `hybrid-golden.spec.ts` and auto-manages a
+GitHub issue under the label `nightly-real-model-broken`. B is a
+deterministic grep-driven sweep of non-token Tailwind palette classes,
+backed by a permanent regression test plus a Storybook visual smoke
+pass against `[data-theme="dark"]`. C adds a small
+`findClassifyEntry` helper and surfaces the matching audit-entry id
+in the existing hybrid-finding disclosure.
+
+**Tech stack.** React 18 + TypeScript (`strict`,
+`noUncheckedIndexedAccess`, `noImplicitOverride`), Vite, Vitest + RTL,
+Tailwind v4, Storybook 8, Playwright, GitHub Actions. CSP-strict — no
+new network egress, no new third-party deps, no IDB schema bumps.
+
+**Base SHA.** All branches branch from `origin/main =
+41d7abb25115a7357d3fb801bc887021d4ddd492` (Wave 31-C merge).
+
+---
+
+## §0 What changed since Wave 31 (context for fresh agents)
+
+Wave 31 (PRs #127 plan + #131–#133 parts) shipped:
+
+- **A** — Demotion-candidate subsection in `HybridPrecisionPanel`,
+  gated on `≥10 fires AND <70% precision`; read-only, advisory.
+- **B** — Tri-state theme system (`system`/`light`/`dark`),
+  `useColorScheme` hook, `ThemeToggle` in `AppHeader`, dark token
+  variants under `[data-theme="dark"]` block in `app/src/index.css`.
+  Tailwind v4 wired with `@custom-variant dark (&:where(...))`.
+- **C** — Coverage push: branches **89 → 90** floor.
+
+The toggle in Wave 31-B exposed the latent debt that Wave 32-B fixes:
+components that hard-code Tailwind palette classes
+(`bg-amber-50`, `text-zinc-700`, etc.) instead of semantic tokens
+(`bg-paper`, `text-fg-muted`).
+
+The real-model spec (`tests/e2e/hybrid-golden.spec.ts`) is gated
+behind **`RUN_REAL_MODEL=1`** (note: `RUN_REAL_MODEL`, not
+`REAL_MODEL` — verified during brainstorm).
+
+## §1 Scope-shaping decisions (READ BEFORE APPROVING)
+
+1. **Part A is CI-only.** Zero app code, zero tests. New workflow file
+   plus a one-time `gh label create` step documented in the PR body.
+2. **Part A failure handling is auto-issue.** Single GitHub issue
+   labelled `nightly-real-model-broken` is opened on first failure,
+   commented on subsequent failures, closed with a "recovered"
+   comment on next success.
+3. **Part B is two-pass.** Pass 1: deterministic grep + mechanical
+   token swaps. Pass 2: Storybook visual smoke against dark theme.
+4. **Part B excludes the hybrid-finding disclosure surface.** Owned
+   by Part C: `HybridFeedbackButton.tsx`, `HybridPrecisionPanel.tsx`,
+   the hybrid-finding render lines inside `FindingsPanel.tsx`.
+5. **Part B has a bail-out.** If grep returns >15 distinct files,
+   split B into B1 (mechanical swaps) + B2 (Storybook sweep) and
+   absorb B2 into a future wave.
+6. **Part C is read-only over the audit chain.** No new audit kinds,
+   no IDB writes.
+7. **Part C surfaces the audit entry id as plain text.** No "jump to
+   audit log", no inlined payload. Truncated to 8 chars in the `<dd>`;
+   full id in `title=` for hover/copy.
+8. **Part E rebases last.** Source cap **0**. Conditional floor bump:
+   ≥91.2 → 91, ≥90.7 → 90.5, else no bump.
+9. **No CSP / bundle-budget / IDB-schema changes** in Wave 32. No new
+   third-party dependencies. No new audit `kind`s.
+
+## §2 Out of scope
+
+- "Jump to audit log" interaction or audit-log search by entry id.
+- Inline-rendering the full `llm-classify` payload — already in the
+  disclosure.
+- Demoting rules off the hybrid allowlist (`packV1.ts hybridAnchors`).
+  Still gated on real `hybrid-feedback` data volume.
+- Hybrid feedback "review queue" UI.
+- Worker-path classifier; `@xenova/transformers` upstream-bump watch.
+- Nightly Lighthouse / nightly bundle-budget jobs.
+- Slack / email notifications on Part A failure.
+- Adding new semantic tokens beyond 1–2 in Part B's sweep.
+- Pushing branch coverage past 91 via contrived tests on defensive code.
+
+## §3 Execution dependency graph
+
+```
+   ┌──────────┐   ┌──────────┐   ┌──────────┐
+   │ Part A   │   │ Part B   │   │ Part C   │
+   │ nightly  │   │ dark-mode│   │ click-to-│
+   │ real-    │   │ regression│  │ explain  │
+   │ model    │   │ sweep    │   │ audit id │
+   │ GHA      │   │ + sb pass│   │ link     │
+   └────┬─────┘   └────┬─────┘   └────┬─────┘
+        │              │              │
+        └──────────────┴──────┬───────┘
+                              ▼
+                        ┌──────────┐
+                        │ Part E   │
+                        │ coverage │
+                        │ (rebase) │
+                        └──────────┘
+```
+
+A, B, C branch from `origin/main` (`41d7abb`) and dispatch in parallel.
+E rebases off `main` after A, B, C merge.
+
+---
+
+## §4 Part A — Nightly real-model GHA
+
+**Branch:** `wave32-A-real-model-nightly`
+**Worktree:** `worktrees/wave32-A-real-model-nightly`
+**Heartbeat:** `.claude/agent-status/wave32-A.log`
+
+**Files (cap: 0 src, 0 test):**
+
+- Create: `.github/workflows/real-model-nightly.yml`
+- One-time external action (GitHub repo state, not in git):
+  `gh label create nightly-real-model-broken --color FF0000
+   --description "Nightly real-model spec is broken"`. Document in PR.
+
+### Acceptance
+
+- [ ] **A.1** Pre-implementation verification.
+  - Read `tests/e2e/hybrid-golden.spec.ts` header; confirm env var is
+    `RUN_REAL_MODEL=1` and the local invocation pattern matches the
+    workflow steps below.
+  - Run `cd app && cat package.json | grep -A1 '"build:classifier-assets"'`
+    to confirm the script exists. Inspect the script body:
+    `cat app/scripts/build-classifier-assets.* 2>/dev/null` (or
+    wherever it lives) and verify it does NOT require any secret not
+    in `secrets.GITHUB_TOKEN`. If it does (e.g. private model
+    registry), STOP and report — do not invent secrets.
+  - Confirm the label `nightly-real-model-broken` does not already
+    exist with a different colour/description:
+    `gh label list --search nightly-real-model-broken`. If absent,
+    create it once:
+    ```
+    gh label create nightly-real-model-broken \
+      --color FF0000 \
+      --description "Nightly real-model spec is broken"
+    ```
+    Document in the eventual PR description.
+
+- [ ] **A.2** Create `.github/workflows/real-model-nightly.yml` with
+      this exact content:
+
+```yaml
+name: real-model-nightly
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  real-model:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            app/package-lock.json
+
+      - name: Install root dev deps (Playwright runner)
+        run: npm ci
+
+      - name: Install app deps
+        working-directory: app
+        run: npm ci
+
+      - name: Install chromium for Playwright
+        run: npx playwright install --with-deps chromium
+
+      - name: Build classifier assets
+        working-directory: app
+        run: npm run build:classifier-assets
+
+      - name: Build app
+        working-directory: app
+        run: npm run build
+
+      - name: Run real-model spec
+        env:
+          RUN_REAL_MODEL: '1'
+        run: npx playwright test --project=chromium tests/e2e/hybrid-golden.spec.ts
+
+      - name: Open or update issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          label=nightly-real-model-broken
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          existing=$(gh issue list --state open --label "$label" --json number --jq '.[0].number // empty')
+          body="Run failed at $(date -u +%FT%TZ). Run: $run_url"
+          if [ -z "$existing" ]; then
+            gh issue create \
+              --title "Nightly real-model spec broken" \
+              --label "$label" \
+              --body "$body"
+          else
+            gh issue comment "$existing" --body "$body"
+          fi
+
+      - name: Close issue on success
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          label=nightly-real-model-broken
+          existing=$(gh issue list --state open --label "$label" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Recovered at $(date -u +%FT%TZ). Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            gh issue close "$existing"
+          fi
+```
+
+  Commit:
+  ```
+  git add .github/workflows/real-model-nightly.yml
+  git commit -m "wave32-A: nightly real-model GHA + auto-issue management"
+  ```
+
+- [ ] **A.3** Trigger a manual run via `workflow_dispatch` to verify
+      the workflow lints and the happy path works:
+  ```
+  git push -u origin wave32-A-real-model-nightly
+  gh workflow run real-model-nightly.yml --ref wave32-A-real-model-nightly
+  gh run watch
+  ```
+  Expected: green run end-to-end. Note the run number; capture in PR
+  description.
+
+- [ ] **A.4** Verify the failure path on a throwaway commit. On the
+      same branch:
+  - Add a temporary always-failing line to the spec or pass an
+    obviously-bad arg to playwright; commit (do NOT push to main).
+  - Trigger `workflow_dispatch` again; expect failure.
+  - Confirm an issue with title "Nightly real-model spec broken" and
+    label `nightly-real-model-broken` was opened. Note the issue
+    number.
+  - Revert the temporary breakage; commit; trigger again; expect
+    success.
+  - Confirm a "Recovered at" comment was added and the issue was
+    closed.
+  - Force-push to drop the throwaway commits; ensure the branch only
+    contains the workflow-add commit before opening the PR.
+
+- [ ] **A.5** Open PR with title `wave32-A: nightly real-model GHA`.
+      Body must include:
+  - Run URL from A.3 (happy path proof).
+  - Issue URL from A.4 (failure-path proof; OK if closed).
+  - Label-create command from A.1 (one-time setup record).
+
+  Then `gh pr merge --auto --squash` exactly once. Do not bypass
+  hooks.
+
+## §5 Part B — Dark-mode regression sweep + Storybook smoke
+
+**Branch:** `wave32-B-dark-mode-sweep`
+**Worktree:** `worktrees/wave32-B-dark-mode-sweep`
+**Heartbeat:** `.claude/agent-status/wave32-B.log`
+
+**Files (cap: ≤ 12 component edits + 1 test + 1 Storybook config edit;
+0 new src files unless adding a token to `index.css`, which counts in
+the 12-cap as an edit):**
+
+- Modify: ≤ 12 component files in `app/src/ui/**` and/or
+  `app/src/App/**` (token swaps).
+- Modify (only if needed): `app/src/index.css` (1–2 new tokens
+  maximum).
+- Create: `app/src/test/dark-mode-regression.test.ts`
+- Modify: `app/.storybook/preview.ts` (theme decorator).
+
+**Excluded from this part (owned by Part C):**
+- `app/src/ui/HybridFeedbackButton.tsx`, `app/src/ui/HybridFeedbackButton.test.tsx`,
+  `app/src/ui/HybridFeedbackButton.stories.tsx`
+- `app/src/ui/HybridPrecisionPanel.tsx`, `app/src/ui/HybridPrecisionPanel.test.tsx`
+- The hybrid-finding render lines inside `app/src/ui/FindingsPanel.tsx`.
+  Other parts of FindingsPanel (severity headers, search,
+  virtualized list) are fair game for B. **If a single line bridges
+  both** (e.g. a wrapper `<div className=...>` around both), the line
+  stays unmodified by B; C absorbs it.
+
+### Acceptance
+
+- [ ] **B.1** Audit grep (Pass 1). From the worktree root run:
+
+```bash
+grep -rEn '\b(bg|text|border|ring|outline|fill|stroke|from|to|via)-(amber|stone|zinc|slate|neutral|gray|red|orange|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|white|black)(-[0-9]+)?(/[0-9]+)?\b' app/src --include='*.tsx' --include='*.ts'
+```
+
+  And:
+
+```bash
+grep -rEn "className=.*['\"\`].*#[0-9a-fA-F]{3,8}|style=\{\{[^}]*#[0-9a-fA-F]{3,8}|style=\{\{[^}]*rgb\(|style=\{\{[^}]*hsl\(" app/src --include='*.tsx' --include='*.ts'
+```
+
+  Tabulate distinct files. Save the file list to the eventual PR
+  description. **If >15 distinct files, BAIL OUT** per §1.5: split
+  this part into B1 (the smaller mechanical-swap subset, capped at
+  10 files) and absorb the remainder into a B2 follow-up wave.
+  Document the split decision in the PR description and STOP this
+  task — do not push the larger sweep.
+
+- [ ] **B.2** Mechanical token swaps. For each match in B.1's
+      tabulation (≤ 12 files), apply the default mappings below by
+      editing each file with `Edit`. Mappings:
+
+| Hard-coded | Replace with |
+|-----------|--------------|
+| `bg-white`, `bg-amber-50`, `bg-stone-50`, `bg-stone-100` | `bg-paper` or `bg-paper-raised` (raised for elevated cards) |
+| `bg-stone-200`, `bg-zinc-100`, `bg-amber-100` | `bg-paper-sunken` |
+| `text-black`, `text-zinc-900`, `text-stone-900` | `text-fg` |
+| `text-zinc-700`, `text-stone-700` | `text-fg-body` |
+| `text-zinc-500`, `text-stone-500`, `text-zinc-600` | `text-fg-muted` |
+| `text-zinc-400`, `text-stone-400` | `text-fg-faint` |
+| `border-zinc-200`, `border-stone-200`, `border-amber-200` | `border-rule` (or `border-rule-subtle` if it's a low-emphasis divider) |
+| `text-blue-*`, `bg-blue-*` (accent role) | `text-ink`, `bg-ink` |
+| `bg-red-*`, `text-red-*` (severity-high) | `text-severity-high`, `bg-severity-bg-error` |
+| `bg-amber-*`, `text-amber-*` (severity-medium role) | `text-severity-medium`, `bg-severity-bg-warn` |
+
+  If a match has no obvious mapping, prefer the closest existing
+  token; only add a new token to `app/src/index.css` if the same
+  semantic role surfaces in 2+ places and no existing token covers
+  it. New tokens go in BOTH the `@theme` block (light defaults) AND
+  the `[data-theme="dark"]` override block.
+
+  Commit each file (or small batch) as you go:
+  ```
+  git add app/src/ui/<File>.tsx
+  git commit -m "wave32-B: swap palette classes to semantic tokens in <File>"
+  ```
+
+- [ ] **B.3** Re-run the B.1 grep. Expected: zero matches across the
+      changed files. If any remain, fix them (still within the 12-cap)
+      or add to the regression test's allow-list (B.4) with an inline
+      comment documenting why.
+
+- [ ] **B.4** Create `app/src/test/dark-mode-regression.test.ts`.
+      First, decide which implementation to use by checking for any
+      existing `execSync`-based test in the repo:
+      `grep -rln "execSync" app/src --include='*.test.*'`.
+
+  - **If an `execSync` test pattern already exists**, mirror it.
+    Test contents:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+
+const FORBIDDEN_PATTERN =
+  '\\b(bg|text|border|ring|outline|fill|stroke|from|to|via)-(amber|stone|zinc|slate|neutral|gray|red|orange|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|white|black)(-[0-9]+)?(/[0-9]+)?\\b';
+
+// Hybrid-finding disclosure surface — owned by Part C; fixed there.
+// Keep this list short and document why each path is excluded.
+const ALLOW_LIST_PATHS: ReadonlyArray<string> = [
+  'src/ui/HybridFeedbackButton.tsx',
+  'src/ui/HybridPrecisionPanel.tsx',
+  // FindingsPanel.tsx is partially owned by C (hybrid-finding render
+  // lines only). Excluded entirely from this regression to avoid
+  // bouncing back-and-forth across waves; if non-hybrid lines drift
+  // to non-token colours after this lands, a future wave re-tightens.
+  'src/ui/FindingsPanel.tsx',
+];
+
+describe('dark-mode regression: no hard-coded palette colors in components', () => {
+  it('finds zero forbidden Tailwind palette classes in app/src outside the allow list', () => {
+    const exclude = ALLOW_LIST_PATHS.map((p) => `--exclude=${p.replace(/[^/]*\//, '')}`).join(' ');
+    // grep --exclude takes a basename glob; we list relative paths above
+    // for documentation but pass basenames at the boundary.
+    const cmd = `grep -rEn ${exclude} '${FORBIDDEN_PATTERN}' src --include='*.tsx' --include='*.ts' || true`;
+    const out = execSync(cmd, { cwd: 'app' }).toString().trim();
+    expect(out, `Found hard-coded Tailwind palette classes:\n${out}`).toBe('');
+  });
+});
+```
+
+  - **If no `execSync` test pattern exists**, fall back to a pure-Node
+    walker. Replace the body with:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+const FORBIDDEN = /\b(bg|text|border|ring|outline|fill|stroke|from|to|via)-(amber|stone|zinc|slate|neutral|gray|red|orange|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|white|black)(-\d+)?(\/\d+)?\b/;
+
+const ALLOW_LIST_PATHS: ReadonlyArray<string> = [
+  'src/ui/HybridFeedbackButton.tsx',
+  'src/ui/HybridPrecisionPanel.tsx',
+  'src/ui/FindingsPanel.tsx',
+];
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) yield* walk(full);
+    else yield full;
+  }
+}
+
+function isExcluded(rel: string): boolean {
+  return ALLOW_LIST_PATHS.some((p) => rel.split(sep).join('/') === p);
+}
+
+describe('dark-mode regression: no hard-coded palette colors in components', () => {
+  it('finds zero forbidden Tailwind palette classes in app/src outside the allow list', () => {
+    const root = 'app/src';
+    const offenders: Array<{ file: string; line: number; text: string }> = [];
+    for (const path of walk(root)) {
+      if (!/\.(tsx|ts)$/.test(path) || /\.test\.tsx?$/.test(path) || /\.stories\.tsx?$/.test(path)) continue;
+      const rel = relative('app', path);
+      if (isExcluded(rel)) continue;
+      const lines = readFileSync(path, 'utf8').split('\n');
+      lines.forEach((text, i) => {
+        if (FORBIDDEN.test(text)) offenders.push({ file: rel, line: i + 1, text: text.trim() });
+      });
+    }
+    const formatted = offenders.map((o) => `${o.file}:${o.line}  ${o.text}`).join('\n');
+    expect(offenders, `Found hard-coded Tailwind palette classes:\n${formatted}`).toEqual([]);
+  });
+});
+```
+
+  Run: `cd app && npx vitest run src/test/dark-mode-regression.test.ts`.
+  Expected: PASS (because B.2 cleared the offending classes).
+
+  If it FAILS, inspect output: either fix more files (within the
+  12-cap) or add an explicit allow-list path with a one-line comment
+  documenting why. Do NOT silence failures by overly-broad allow-list
+  entries.
+
+  Commit:
+  ```
+  git add app/src/test/dark-mode-regression.test.ts
+  git commit -m "wave32-B: regression test pinning palette-class absence"
+  ```
+
+- [ ] **B.5** Storybook theme decorator (Pass 2 setup). Read the
+      existing `app/.storybook/preview.ts` first to see the current
+      shape, then merge the theme toolbar in. Pattern:
+
+```ts
+// Add to existing Preview object.
+globalTypes: {
+  theme: {
+    description: 'Theme override',
+    defaultValue: 'light',
+    toolbar: {
+      title: 'Theme',
+      icon: 'paintbrush',
+      items: [
+        { value: 'light', title: 'Light' },
+        { value: 'dark', title: 'Dark' },
+      ],
+    },
+  },
+},
+decorators: [
+  // ...keep existing decorators
+  (Story, ctx) => {
+    const theme = (ctx.globals as { theme?: string }).theme ?? 'light';
+    if (typeof document !== 'undefined') {
+      document.documentElement.setAttribute('data-theme', theme);
+    }
+    return Story();
+  },
+],
+```
+
+  Do NOT overwrite existing decorators or globalTypes — merge.
+  Commit:
+  ```
+  git add app/.storybook/preview.ts
+  git commit -m "wave32-B: Storybook theme decorator (light/dark toolbar)"
+  ```
+
+- [ ] **B.6** Storybook visual smoke pass. Run `cd app && npm run
+      storybook` and toggle the theme to dark. Eyeball each story:
+  - Invisible text (token mismatch grep can't catch)
+  - Focus-ring visibility on dark surfaces (try Tab through a story)
+  - `:hover` / `:active` state contrast on `--state-hover` /
+    `--state-active`
+  - Hard-coded colours inside `style={{...}}` props that grep missed
+
+  For any visual issue found, fix with a token swap in the offending
+  component (still within the 12-cap; if you've already exceeded the
+  cap, document the remaining issue in the PR body as a follow-up).
+
+- [ ] **B.7** Local gate:
+```
+cd app && npm run typecheck && npm run lint && npm test
+```
+  All green. Specifically verify the new
+  `dark-mode-regression.test.ts` passes and the existing
+  axe-against-light test still passes.
+
+- [ ] **B.8** Push, open PR titled `wave32-B: dark-mode regression
+      sweep + Storybook smoke`. PR body must include:
+  - The B.1 grep file list (before swap)
+  - The post-swap grep output (should be empty, modulo allow-list)
+  - File count vs. the 12-cap; if bail-out triggered, the B1/B2 split
+    rationale
+  - One Storybook screenshot or short note confirming the dark smoke
+    pass landed clean
+  - Confirmation that no excluded files were touched
+
+  Then `gh pr merge --auto --squash` exactly once.
+
+## §6 Part C — Click-to-explain audit-id linkage
+
+**Branch:** `wave32-C-explain-audit-link`
+**Worktree:** `worktrees/wave32-C-explain-audit-link`
+**Heartbeat:** `.claude/agent-status/wave32-C.log`
+
+**Files (cap: ≤ 2 src + 1 test, possibly + 1 hook if no audit-chain
+access pattern is already in use; +1 unrelated dark-mode token swap
+allowed only on files this part already edits):**
+
+- Create: `app/src/audit/findClassifyEntry.ts`
+- Create: `app/src/audit/findClassifyEntry.test.ts`
+- Modify: the hybrid-finding disclosure component (path verified in
+  C.1; most likely `app/src/ui/FindingsPanel.tsx` or a sub-component).
+- Optionally create: a small hook (e.g. `useClassifyEntry.ts`) ONLY
+  if the existing audit-chain access pattern from Wave 30-A
+  (`HybridPrecisionPanel`) cannot be reused by the disclosure
+  component.
+
+### Acceptance
+
+- [ ] **C.1** Pre-implementation verification.
+  - Read `app/src/audit/auditLog.ts` (or wherever `AuditEntry` is
+    defined). Confirm the `AuditEntry` shape, particularly:
+    - whether each entry has a stable `id` field, and
+    - what the canonical reference is (if there's a `hash` field, use
+      that; if neither exists, fall back to deterministic synthesis
+      `<modelId>-<ruleId>-<paragraphIndex>-<ts>` and document why in
+      the implementation).
+    - Where the `hybrid-feedback` and `llm-classify` payloads are
+      shaped (`{ ruleId, paragraphIndex, modelId, similarity }` from
+      Wave 23 / Wave 29-C).
+  - Read `app/src/audit/hybridStats.ts` and `app/src/ui/HybridPrecisionPanel.tsx`
+    to learn the audit-chain access pattern in use post-Wave-30-A.
+    **Mirror that pattern**; do NOT introduce a new data-access path.
+  - Read `app/src/ui/FindingsPanel.tsx` and identify the exact
+    insertion point for the new `<dt>/<dd>` pair. Look for the existing
+    hybrid-finding evidence section (where `modelId` and `similarity`
+    render). Note the file path and approximate line range; record in
+    PR description.
+  - Document findings (id-field availability, audit-chain access
+    pattern, insertion point) in the eventual PR description.
+
+- [ ] **C.2** Write `app/src/audit/findClassifyEntry.test.ts` FIRST
+      (TDD), watch it fail with module-not-found. Adapt the
+      `AuditEntry` literal shape from C.1's verification.
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { findClassifyEntry } from './findClassifyEntry';
+import type { AuditEntry } from './auditLog';
+
+// Adapt this factory to match the actual AuditEntry shape verified in C.1.
+function entry(
+  kind: string,
+  payload: Record<string, unknown>,
+  id = 'x',
+): AuditEntry {
+  return { kind, payload, id /* + other required fields per C.1 */ } as AuditEntry;
+}
+
+describe('findClassifyEntry', () => {
+  it('returns null on empty chain', () => {
+    expect(findClassifyEntry([], 'rule.x', 3)).toBeNull();
+  });
+
+  it('returns null when no entry matches (ruleId + paragraphIndex)', () => {
+    const chain = [entry('llm-classify', { ruleId: 'rule.y', paragraphIndex: 3 })];
+    expect(findClassifyEntry(chain, 'rule.x', 3)).toBeNull();
+    const wrongPara = [entry('llm-classify', { ruleId: 'rule.x', paragraphIndex: 4 })];
+    expect(findClassifyEntry(wrongPara, 'rule.x', 3)).toBeNull();
+  });
+
+  it('returns the matching entry when one exists', () => {
+    const match = entry('llm-classify', { ruleId: 'rule.x', paragraphIndex: 3 }, 'a1');
+    const chain = [entry('other', {}), match];
+    expect(findClassifyEntry(chain, 'rule.x', 3)).toBe(match);
+  });
+
+  it('returns the most recent when multiple match', () => {
+    const old = entry('llm-classify', { ruleId: 'rule.x', paragraphIndex: 3 }, 'old');
+    const recent = entry('llm-classify', { ruleId: 'rule.x', paragraphIndex: 3 }, 'recent');
+    const chain = [old, entry('other', {}), recent];
+    expect(findClassifyEntry(chain, 'rule.x', 3)?.id).toBe('recent');
+  });
+
+  it('ignores entries with non-llm-classify kinds (incl. hybrid-feedback)', () => {
+    const chain = [
+      entry('hybrid-feedback', { ruleId: 'rule.x', paragraphIndex: 3 }),
+      entry('parse-lease', { ruleId: 'rule.x', paragraphIndex: 3 }),
+    ];
+    expect(findClassifyEntry(chain, 'rule.x', 3)).toBeNull();
+  });
+});
+```
+
+  Run: `cd app && npx vitest run src/audit/findClassifyEntry.test.ts`.
+  Expected: 5 tests fail with module-not-found.
+
+- [ ] **C.3** Implement `app/src/audit/findClassifyEntry.ts`:
+
+```ts
+import type { AuditEntry } from './auditLog';
+
+/**
+ * Find the most recent kind:'llm-classify' audit entry matching
+ * (ruleId, paragraphIndex). Returns null if none exists.
+ *
+ * Iterates from the tail to find the most recent match. O(n) in
+ * chain length; the caller is responsible for memoisation if the
+ * chain is large.
+ */
+export function findClassifyEntry(
+  chain: ReadonlyArray<AuditEntry>,
+  ruleId: string,
+  paragraphIndex: number,
+): AuditEntry | null {
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const entry = chain[i];
+    if (!entry || entry.kind !== 'llm-classify') continue;
+    const payload = entry.payload as { ruleId?: unknown; paragraphIndex?: unknown };
+    if (payload.ruleId === ruleId && payload.paragraphIndex === paragraphIndex) {
+      return entry;
+    }
+  }
+  return null;
+}
+```
+
+  Adapt the `payload` cast to match the actual shape verified in C.1
+  if `AuditEntry.payload` is more strongly typed.
+
+  Rerun C.2's vitest command. Expected: all 5 pass. Commit:
+  ```
+  git add app/src/audit/findClassifyEntry.ts app/src/audit/findClassifyEntry.test.ts
+  git commit -m "wave32-C: findClassifyEntry helper"
+  ```
+
+- [ ] **C.4** Wire into the hybrid-finding disclosure. Following the
+      audit-chain access pattern documented in C.1, wire
+      `findClassifyEntry(chain, ruleId, paragraphIndex)` into the
+      disclosure component identified in C.1. Insert below the
+      existing evidence pairs (`modelId`, `similarity`):
+
+```tsx
+{classifyEntry && (
+  <>
+    <dt>audit entry</dt>
+    <dd
+      className="font-mono text-small text-fg-muted"
+      title={classifyEntry.id}
+    >
+      {classifyEntry.id.slice(0, 8)}
+    </dd>
+  </>
+)}
+```
+
+  Adapt `.id` to the canonical reference field from C.1. If a stable
+  id doesn't exist, derive a deterministic synthesis:
+
+```tsx
+const refId =
+  classifyEntry.id ??
+  `${(classifyEntry.payload as { modelId?: string }).modelId ?? 'unknown'}` +
+  `-${(classifyEntry.payload as { ruleId?: string }).ruleId}` +
+  `-${(classifyEntry.payload as { paragraphIndex?: number }).paragraphIndex}` +
+  `-${classifyEntry.ts ?? 0}`;
+```
+
+  ...and document the fallback choice in code comments + PR description.
+
+  When `findClassifyEntry` returns `null` (fresh installs, pre-Wave-21
+  chains, non-hybrid findings), render nothing. The disclosure
+  already handles partial evidence gracefully.
+
+- [ ] **C.5** Optional hook (only if needed). If the disclosure
+      component cannot reach the audit chain via the pattern from
+      C.1 (e.g. it sits below the level where the chain is loaded),
+      add a small hook:
+
+```ts
+// app/src/ui/useClassifyEntry.ts
+import { useMemo } from 'react';
+import { findClassifyEntry } from '../audit/findClassifyEntry';
+import type { AuditEntry } from '../audit/auditLog';
+
+export function useClassifyEntry(
+  chain: ReadonlyArray<AuditEntry>,
+  ruleId: string,
+  paragraphIndex: number,
+) {
+  return useMemo(
+    () => findClassifyEntry(chain, ruleId, paragraphIndex),
+    [chain, ruleId, paragraphIndex],
+  );
+}
+```
+
+  Skip this entirely if the chain is already prop-passed where you
+  need it. `findClassifyEntry` is pure and fine to call inline in a
+  React component as long as the chain reference is stable across
+  renders.
+
+- [ ] **C.6** Extend the existing FindingsPanel test (or whichever
+      test file currently exercises the hybrid-finding disclosure
+      from Wave 25/29) with one test asserting:
+  - When the audit chain has a matching `kind:'llm-classify'` entry,
+    the truncated id is rendered with a `title` containing the full
+    id.
+  - When no match exists, the new `<dt>` does NOT render (assert via
+    `queryByText` returning null).
+
+  This assertion lives in the existing test file rather than a new
+  one, to stay within the 1-test-file cap and to share fixtures.
+
+- [ ] **C.7** Dark-mode boundary fix-as-found. While editing the
+      disclosure component (and any other touched files), if you see
+      a hard-coded Tailwind palette class (`bg-amber-50`, `text-zinc-700`,
+      etc.), fix it in the same PR with the appropriate semantic
+      token from §5.B.2's mapping table. Do NOT punt to Part B —
+      that's the explicit "fix it where you find it" rule.
+
+- [ ] **C.8** Local gate:
+```
+cd app && npm run typecheck && npm run lint && npm test
+```
+  All green. The new `findClassifyEntry.test.ts` and the extended
+  FindingsPanel test must pass.
+
+- [ ] **C.9** Push, open PR titled `wave32-C: click-to-explain audit
+      entry id`. PR body must include:
+  - C.1 verification findings (id-field availability + access pattern)
+  - The exact files touched (must match cap)
+  - Any dark-mode-fix-as-found edits made under §6.C.7
+  - A screenshot of the disclosure with the new id readout
+
+  Then `gh pr merge --auto --squash` exactly once.
+
+## §7 Dispatch matrix
+
+| Part | Branch                              | Files cap (src/test/other)       | Depends on        | Heartbeat                                  |
+|------|-------------------------------------|----------------------------------|-------------------|---------------------------------------------|
+| A    | `wave32-A-real-model-nightly`       | 0 / 0 / 1 workflow               | `origin/main` (`41d7abb`) | `.claude/agent-status/wave32-A.log` |
+| B    | `wave32-B-dark-mode-sweep`          | ≤ 12 / 1 / 1 SB config           | `origin/main` (`41d7abb`) | `.claude/agent-status/wave32-B.log` |
+| C    | `wave32-C-explain-audit-link`       | ≤ 2 / 1 / —                      | `origin/main` (`41d7abb`) | `.claude/agent-status/wave32-C.log` |
+| E    | `wave32-E-coverage`                 | 0 / N / 1 vitest config edit max | A + B + C merged  | `.claude/agent-status/wave32-E.log`         |
+
+Per `~/.claude/CLAUDE.md` Subagent Dispatch Rules: each subagent
+heartbeats every ~5 min; orchestrator polls every 10 min and treats
+≥30 min idle as stalled. Per Worktree convention: worktrees go under
+`<project>/worktrees/<branch>`.
+
+## §8 PR / merge protocol
+
+1. **Per-part local gate.** `npm run typecheck && npm run lint &&
+   npm test` green before any push.
+2. **CI gate.** `gh pr checks <pr>` must be green before
+   `gh pr ready`. Wave 30-C closed the Mergify red-bypass; A/B/C can
+   merge in parallel.
+3. **Auto-merge attempt.** `gh pr merge --auto --squash` exactly
+   once per PR. If rejected, print PR URL + blocking reason and stop.
+4. **Merge order.** A, B, C in any order; E rebases off post-merge
+   `main`.
+5. **Post-wave sweep.** After E merges, run `npm run test:coverage`
+   on `main`; record final number in E's PR body.
+
+## §9 Part E — Coverage push (rebases last)
+
+**Branch:** `wave32-E-coverage` — cut **after** A, B, C merge.
+**Worktree:** `worktrees/wave32-E-coverage`
+**Heartbeat:** `.claude/agent-status/wave32-E.log`
+
+**Files (cap: 0 src; tests as needed; 1 coverage-config edit max):**
+
+### Acceptance
+
+- [ ] **E.1** From `main` (after A, B, C merge), run:
+```
+cd app && npm run test:coverage
+```
+  Capture post-merge branches/lines/functions/statements percentages.
+  Identify the 5–10 lowest-covered branches in actually-meaningful
+  code. Prioritize new code from Wave 32: `findClassifyEntry.ts`,
+  `dark-mode-regression.test.ts` (verify the test itself has
+  coverage), and any new tokens in `index.css` (note: CSS isn't in
+  the coverage report; tokens add to bundle size, not branches).
+
+  Verify the coverage-config path: `grep -n "thresholds\|branches:"
+  app/vite.config.ts | head`.
+
+- [ ] **E.2** Add targeted tests against those branches. Each test
+      must have a "what does this protect" reason in its `describe`
+      block name. Forbidden: noop-fixture filler tests, snapshot tests
+      added purely for coverage.
+
+  Rerun coverage after each test file lands.
+
+- [ ] **E.3** Conditional floor bump in `app/vite.config.ts`:
+  - if branches ≥ 91.2% → bump `branches` to **91**
+  - else if branches ≥ 90.7% → bump to **90.5**
+  - else → ship tests without floor bump
+
+  Don't lower other thresholds. Mirror Wave 31-C's discipline.
+
+- [ ] **E.4** Local gate:
+```
+cd app && npm run typecheck && npm run lint && npm run test:coverage
+```
+  All green at the (possibly bumped) floor.
+
+- [ ] **E.5** Push, open PR titled `wave32-E: coverage push`. PR body
+      includes a before/after coverage table and the list of modules
+      from E.1. Then `gh pr merge --auto --squash` exactly once.
+
+## §10 Success criteria
+
+- [ ] Nightly real-model GHA runs daily at 06:00 UTC; auto-issue
+      proven on a force-failure throwaway commit; auto-close proven
+      on recovery.
+- [ ] Audit grep of `app/src/**/*.{ts,tsx}` returns zero hard-coded
+      Tailwind palette classes outside the documented allow-list.
+- [ ] Storybook theme toolbar lets a maintainer toggle between
+      `light` and `dark` per story; dark smoke pass landed clean.
+- [ ] `findClassifyEntry` covers five behavior cases with passing
+      tests; the disclosure renders the truncated id with `title=`
+      full id; renders nothing when no match exists.
+- [ ] Branch coverage ≥ pre-wave baseline + meaningful gain;
+      conditional floor bump applied per §9.E.3.
+- [ ] All four PRs CI-green at merge.
+- [ ] No new audit `kind`s, no CSP / bundle / IDB schema bumps, no
+      new third-party deps.

--- a/docs/superpowers/specs/2026-04-27-wave32-design.md
+++ b/docs/superpowers/specs/2026-04-27-wave32-design.md
@@ -1,0 +1,640 @@
+# Wave 32 — Phase 19 productionization, dark-mode sweep, audit linkage, coverage
+
+**Date:** 2026-04-27
+**Status:** Design — pending user approval
+**Predecessors:** Wave 30 (PRs #127–#130), Wave 31 (PRs #131–#133)
+
+---
+
+## Goal
+
+Close the Phase 18 → 19 transition with operational rails (nightly
+real-model job, click-to-explain audit linkage), pay down the dark-mode
+polish debt that Wave 31's toggle exposed, and continue the established
+coverage pattern. Three parallel parts (A/B/C), one rebases-last (E).
+
+## What changed since Wave 31 (context for fresh agents)
+
+Wave 31 (PRs #127 plan + #131–#133 parts) shipped:
+
+- **A** — Demotion-candidate subsection in `HybridPrecisionPanel`, gated
+  on `≥10 fires AND <70% precision`; read-only, advisory.
+- **B** — Tri-state theme system (`system`/`light`/`dark`),
+  `useColorScheme` hook, `ThemeToggle` in `AppHeader`, dark token
+  variants under `[data-theme="dark"]` block in `app/src/index.css`.
+  Tailwind v4 wired with `@custom-variant dark (&:where(...))`.
+- **C** — Coverage push: branches 89 → **90** floor; helpers covered
+  including `useColorScheme` SSR/storage guards and OS-dark-mode
+  listener.
+
+A latent debt the toggle exposed: components that hard-code Tailwind
+palette classes (`bg-amber-50`, `text-zinc-700`, etc.) instead of
+semantic tokens (`bg-paper`, `text-fg-muted`) will look wrong in dark
+mode. No user has reported it yet, but the toggle just shipped — this
+wave gets ahead of the regression. Wave 32 Part B addresses it.
+
+Phase 19 productionization candidates from `docs/ROADMAP.md`:
+nightly real-model GHA (Wave 32-A), click-to-explain → audit-log id
+linkage (Wave 32-C). Branches-≥-90 push closed in Wave 31-C.
+
+## §1 Scope-shaping decisions (READ BEFORE APPROVING)
+
+1. **Part A is CI-only.** Zero app code, zero tests. New workflow file
+   plus a one-time label-create step. The real-model spec
+   (`tests/e2e/hybrid-golden.spec.ts`) already exists and is gated
+   behind `RUN_REAL_MODEL=1`; Part A only schedules it and wires
+   issue auto-management.
+2. **Part A failure handling is auto-issue.** A single GitHub issue
+   labelled `nightly-real-model-broken` is opened on first failure and
+   commented on subsequent failures; closed with a "recovered" comment
+   on next success. Persistent surface so silent regressions can't slip
+   past unwatched Action runs.
+3. **Part B is two-pass.** Pass 1: deterministic `grep` for non-token
+   color classes, mechanical token swaps. Pass 2: visual Storybook
+   smoke pass against dark theme to catch contrast / hover-state
+   issues grep can't see. The Pass 1 grep is captured as a permanent
+   regression test so future PRs can't reintroduce non-token colors
+   without explicit allowlisting.
+4. **Part B excludes the hybrid-finding disclosure surface.** Files
+   owned by Part C (`HybridFeedbackButton.tsx`,
+   `HybridPrecisionPanel.tsx`, the hybrid-finding render lines inside
+   `FindingsPanel.tsx`) are excluded from Part B's sweep to avoid
+   cherry-pick conflicts. Part C absorbs dark-mode fixes for those
+   files as it edits them ("fix it where you find it" rule).
+5. **Part B has a bail-out.** If the audit grep returns >15 distinct
+   files, B is too big as one PR. Split into B1 (mechanical token
+   swaps) + B2 (Storybook visual sweep) and absorb B2 into a future
+   wave. Pin in the spec; the implementing agent makes this call after
+   running the grep in B.1.
+6. **Part C is read-only over the audit chain.** No new audit kinds,
+   no IDB writes, no IDB schema bumps. Linear scan of the existing
+   chain to find the most recent matching `kind:'llm-classify'` entry.
+7. **Part C surfaces the audit entry id as plain text.** No "jump to
+   audit log" button, no inlined payload. Per ROADMAP wording: surface
+   the id alongside the existing evidence. Truncated to 8 chars in the
+   `<dd>`; full id in `title=` for hover/copy.
+8. **Part E rebases last.** Branches off `main` AFTER A and B and C
+   merge so it sees the real coverage delta. Source cap **0**.
+   Conditional floor bump tiers continue Wave 31-C's pattern:
+   ≥91.2 → 91, ≥90.7 → 90.5, else no bump.
+9. **No CSP / bundle-budget / IDB-schema changes** in Wave 32. No new
+   third-party dependencies. No new audit `kind`s.
+
+## §2 Out of scope
+
+- "Jump to audit log" interaction or audit-log search by entry id.
+  Bigger than this wave; gated on whether the inline id readout proves
+  insufficient in practice.
+- Inline-rendering of the full `llm-classify` payload (`modelId`,
+  `similarity`, `ts`) — already in the disclosure. Part C only adds
+  the entry id.
+- Demoting rules off the hybrid allowlist (`packV1.ts hybridAnchors`
+  edits). Still gated on real `hybrid-feedback` data volume — Wave 31-A
+  just shipped the panel.
+- Hybrid feedback "review queue" UI. Same gate.
+- Worker-path classifier (Phase 19 candidate). Only when real-world
+  documents prove main-thread embedding blocks the UI; today's corpus
+  is sub-second.
+- `@xenova/transformers` upstream-bump watch. Mostly investigative;
+  fits a future wave better than this one.
+- Nightly Lighthouse / nightly bundle-budget jobs. Different concerns;
+  follow-up workflows.
+- Slack / email notifications on Part A failure. The auto-issue +
+  GitHub watch is the notification path.
+- Adding new semantic tokens beyond 1–2 in Part B's sweep. If that
+  many surface, flag for separate design discussion rather than
+  improvise during a sweep.
+- Pushing branch coverage past 91% via contrived tests on defensive
+  code. Discipline mirrors Wave 31-C: don't bump for the metric's
+  sake.
+
+## §3 Execution dependency graph
+
+```
+   ┌──────────┐   ┌──────────┐   ┌──────────┐
+   │ Part A   │   │ Part B   │   │ Part C   │
+   │ nightly  │   │ dark-mode│   │ click-to-│
+   │ real-    │   │ regression│  │ explain  │
+   │ model    │   │ sweep    │   │ audit id │
+   │ GHA      │   │ + sb pass│   │ link     │
+   └────┬─────┘   └────┬─────┘   └────┬─────┘
+        │              │              │
+        └──────────────┴──────┬───────┘
+                              ▼
+                        ┌──────────┐
+                        │ Part E   │
+                        │ coverage │
+                        │ (rebase) │
+                        └──────────┘
+```
+
+A, B, C branch from `origin/main` (`2544b4a` post-Wave-31 or whatever
+`origin/main` becomes once Wave 31-C merges). E rebases off post-merge
+`main` after A/B/C merge.
+
+## §4 File-touch matrix (proposed)
+
+| Part | Branch                              | Src cap | Test cap | Notes |
+|------|-------------------------------------|---------|----------|-------|
+| A    | `wave32-A-real-model-nightly`       | 0 (CI-only) | 0     | New `.github/workflows/real-model-nightly.yml`; one-time `gh label create` documented in PR. |
+| B    | `wave32-B-dark-mode-sweep`          | ≤ 12 component edits + (only if needed) `app/src/index.css` token additions | 1 (regression-grep test) | + 1 Storybook config edit (`app/.storybook/preview.ts`). Excludes Part C's files. |
+| C    | `wave32-C-explain-audit-link`       | ≤ 2 (new helper + 1 disclosure edit; +1 hook only if not already in use) | 1 (helper test) | Fixes own dark-mode issues in touched files. |
+| E    | `wave32-E-coverage`                 | 0 src   | as needed | Tests only; conditional floor bump per §1.8. |
+
+The matrix is disjoint by design. B owns `app/src/ui/*.tsx` minus
+hybrid-finding disclosure surface; C owns the hybrid-finding files; A
+owns `.github/workflows/`; E owns tests + coverage config.
+
+## §5 Part A — Nightly real-model GHA
+
+**Goal.** Schedule the existing `RUN_REAL_MODEL=1`-gated
+`hybrid-golden.spec.ts` to run daily, with persistent issue-based
+notification on regression.
+
+**File:** `.github/workflows/real-model-nightly.yml`
+
+**Trigger:**
+- `schedule: cron: '0 6 * * *'` (06:00 UTC daily — outside US/EU peak;
+  runner contention low)
+- `workflow_dispatch:` for manual runs
+
+**Permissions block (mandatory):**
+```yaml
+permissions:
+  contents: read
+  issues: write
+```
+
+**Job (single ubuntu-latest):**
+1. `actions/checkout@v4`
+2. `actions/setup-node@v4` (Node 20, npm cache against root +
+   `app/package-lock.json`, matching the existing `e2e.yml` pattern).
+3. Install root dev deps + app deps: `npm ci` at root, `cd app &&
+   npm ci`.
+4. Playwright browsers: `npx playwright install --with-deps chromium`
+   (chromium-only — matches the spec's local invocation).
+5. Build classifier assets: `cd app && npm run build:classifier-assets`
+   (one-time per run; verify in A.1 that this script does not require
+   any secrets we don't have).
+6. Build app: `cd app && npm run build`.
+7. Run the gated spec:
+   ```
+   RUN_REAL_MODEL=1 npx playwright test --project=chromium tests/e2e/hybrid-golden.spec.ts
+   ```
+8. **On failure (`if: failure()`):** open or update issue (script
+   below).
+9. **On success (`if: success()`):** comment "recovered" + close any
+   open issue with the label.
+
+**Auto-issue script (failure path):**
+
+```yaml
+- name: Open or update issue on failure
+  if: failure()
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: |
+    set -euo pipefail
+    label=nightly-real-model-broken
+    run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+    existing=$(gh issue list --state open --label "$label" --json number --jq '.[0].number // empty')
+    body="Run failed at $(date -u +%FT%TZ). Run: $run_url"
+    if [ -z "$existing" ]; then
+      gh issue create \
+        --title "Nightly real-model spec broken" \
+        --label "$label" \
+        --body "$body"
+    else
+      gh issue comment "$existing" --body "$body"
+    fi
+```
+
+**Auto-close script (success path):**
+
+```yaml
+- name: Close issue on success
+  if: success()
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: |
+    set -euo pipefail
+    label=nightly-real-model-broken
+    existing=$(gh issue list --state open --label "$label" --json number --jq '.[0].number // empty')
+    if [ -n "$existing" ]; then
+      gh issue comment "$existing" --body "Recovered at $(date -u +%FT%TZ). Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      gh issue close "$existing"
+    fi
+```
+
+### A.1 — Pre-implementation verification
+
+- Read `tests/e2e/hybrid-golden.spec.ts` header and confirm
+  `RUN_REAL_MODEL=1` env var name (verified during brainstorm — name
+  is `RUN_REAL_MODEL`, not `REAL_MODEL`).
+- Confirm `cd app && npm run build:classifier-assets` exists in
+  `app/package.json` and that the script does NOT require any secrets
+  not in `secrets.GITHUB_TOKEN` scope.
+- Confirm the label `nightly-real-model-broken` does not already exist
+  with a different colour / description; if not present, create it
+  one-time via `gh label create nightly-real-model-broken --color
+  FF0000 --description "Nightly real-model spec is broken"`. Document
+  in PR description.
+
+### A.2 — Acceptance
+
+- [ ] Workflow file lints (`actionlint` or `gh workflow view` doesn't
+      complain).
+- [ ] `workflow_dispatch` triggers a successful run end-to-end on the
+      branch (verify via `gh workflow run` and `gh run watch`).
+- [ ] Force a failure (e.g. temporarily break the spec on a throwaway
+      commit pushed to a test branch) to verify the auto-issue path
+      end-to-end. Revert before merge.
+- [ ] Force a recovery (revert the breakage) to verify the close path.
+- [ ] PR description documents the label-create step.
+
+## §6 Part B — Dark-mode regression sweep
+
+**Goal.** Eliminate hard-coded Tailwind palette classes that would
+render incorrectly under `[data-theme="dark"]`, lock the absence in as
+a permanent regression test, and run a Storybook visual smoke pass to
+catch issues grep can't see.
+
+### B.1 — Audit grep (Pass 1, deterministic)
+
+Run from `app/`:
+
+```bash
+grep -rn -E '\b(bg|text|border|ring|outline|fill|stroke|from|to|via)-(amber|stone|zinc|slate|neutral|gray|red|orange|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|white|black)(-[0-9]+)?(/\d+)?\b' src --include='*.tsx' --include='*.ts'
+```
+
+And:
+
+```bash
+grep -rn -E "className=.*['\"\`].*#[0-9a-fA-F]{3,8}|style=\{\{[^}]*#[0-9a-fA-F]{3,8}|style=\{\{[^}]*rgb\(|style=\{\{[^}]*hsl\(" src --include='*.tsx' --include='*.ts'
+```
+
+Tabulate distinct files. **If >15 distinct files: bail out per §1.5
+and split into B1/B2.**
+
+### B.2 — Mechanical token swaps
+
+For each match in B.1, replace with a semantic token. Default
+mappings (use `app/src/index.css` `@theme` block as source of truth):
+
+| Hard-coded | Replace with |
+|-----------|--------------|
+| `bg-white`, `bg-amber-50`, `bg-stone-50`, `bg-stone-100` | `bg-paper` or `bg-paper-raised` |
+| `bg-stone-200`, `bg-zinc-100`, `bg-amber-100` | `bg-paper-sunken` |
+| `text-black`, `text-zinc-900`, `text-stone-900` | `text-fg` |
+| `text-zinc-700`, `text-stone-700` | `text-fg-body` |
+| `text-zinc-500`, `text-stone-500`, `text-zinc-600` | `text-fg-muted` |
+| `text-zinc-400`, `text-stone-400` | `text-fg-faint` |
+| `border-zinc-200`, `border-stone-200`, `border-amber-200` | `border-rule` or `border-rule-subtle` |
+| `text-blue-*`, `bg-blue-*` (accent) | `text-ink`, `bg-ink` |
+| `bg-red-*`, `text-red-*` (severity-high) | severity tokens (`text-severity-high`, `bg-severity-bg-error`) |
+| `bg-amber-*`, `text-amber-*` (severity-medium) | severity tokens (`text-severity-medium`, `bg-severity-bg-warn`) |
+
+If a match has no obvious mapping (e.g. a one-off `text-emerald-600`
+used as positive feedback, where `text-positive` token already exists
+but isn't quite right), prefer the closest existing token. Only add a
+new token to `index.css` if the same semantic role surfaces in 2+
+places and no existing token covers it.
+
+### B.3 — Permanent regression test
+
+`app/src/test/dark-mode-regression.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+
+const FORBIDDEN_PATTERN = '\\b(bg|text|border|ring|outline|fill|stroke|from|to|via)-(amber|stone|zinc|slate|neutral|gray|red|orange|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|white|black)(-[0-9]+)?(/\\d+)?\\b';
+
+const ALLOW_LIST_PATHS: string[] = [
+  // Hybrid-finding disclosure surface — owned by Part C, fixed there.
+  // Add path-globs here only with explicit reason.
+];
+
+describe('dark-mode regression: no hard-coded palette colors in components', () => {
+  it('finds zero forbidden Tailwind palette classes in app/src outside the allow list', () => {
+    const exclude = ALLOW_LIST_PATHS.map((p) => `--exclude=${p}`).join(' ');
+    const cmd = `grep -rEn ${exclude} '${FORBIDDEN_PATTERN}' src --include='*.tsx' --include='*.ts' || true`;
+    const out = execSync(cmd, { cwd: 'app' }).toString().trim();
+    expect(out, `Found hard-coded Tailwind palette classes:\n${out}`).toBe('');
+  });
+});
+```
+
+(Adjust `cwd` if vitest's working directory is `app/` already; mirror
+the pattern from existing repo-shell tests if any exist.)
+
+**Implementation note.** If `execSync`-based tests are not idiomatic
+in this repo (verify by `grep -rn 'execSync' app/src --include='*.test.*'`),
+fall back to a pure-Node walker using `fs.readdirSync` + `fs.readFileSync`
++ a single `RegExp.test` per file. The contract is the same — find zero
+matches in components — but the implementation stays inside the Node
+runtime vitest already provides. Do NOT add `execa` or any new
+test-time dep.
+
+The test runs against the source tree at test time, not at runtime, so
+it has zero production impact. New components that introduce a
+forbidden class will fail the test in CI; the fix is either to use a
+semantic token or to add an explicit allow-list path with a comment
+documenting why.
+
+### B.4 — Storybook smoke pass (Pass 2, visual)
+
+Edit `app/.storybook/preview.ts` to add a global theme decorator:
+
+```ts
+import type { Preview } from '@storybook/react';
+
+const preview: Preview = {
+  // ...existing config
+  globalTypes: {
+    theme: {
+      description: 'Theme override',
+      defaultValue: 'light',
+      toolbar: {
+        title: 'Theme',
+        icon: 'paintbrush',
+        items: [
+          { value: 'light', title: 'Light' },
+          { value: 'dark', title: 'Dark' },
+        ],
+      },
+    },
+  },
+  decorators: [
+    (Story, ctx) => {
+      const theme = ctx.globals.theme ?? 'light';
+      // jsdoc/runtime guard: in CSF the decorator runs in a real DOM
+      if (typeof document !== 'undefined') {
+        document.documentElement.setAttribute('data-theme', theme);
+      }
+      return Story();
+    },
+  ],
+};
+
+export default preview;
+```
+
+(Merge with existing preview content; do not overwrite.)
+
+Then run `npm run build-storybook` (or `npm run storybook` for live
+review), toggle to dark, and visually scan each story. **Done
+condition for B.4:** maintainer eyeballs the dark Storybook once and
+confirms no obvious breakage. Subjective — accepted, because pure-grep
+can't catch contrast issues, focus-ring visibility, or hover-state
+contrast.
+
+### B.5 — Acceptance
+
+- [ ] B.1 grep returns zero matches in components after swaps land.
+- [ ] B.3 regression test passes locally and in CI.
+- [ ] B.4 Storybook decorator allows toggling between themes; dark
+      smoke-pass complete and any issues fixed.
+- [ ] No new third-party deps.
+- [ ] No edits to files in §1.4's exclusion list.
+- [ ] Local gate (`typecheck`, `lint`, `test`) green.
+- [ ] PR description lists files touched + count vs. the 12-cap; if
+      bail-out triggered (>15 files), explain B1/B2 split decision.
+
+## §7 Part C — Click-to-explain audit-id linkage
+
+**Goal.** Surface the matching `kind:'llm-classify'` audit entry id
+alongside the existing `modelId` / `similarity` readout in the
+hybrid-finding disclosure.
+
+### C.1 — Verify audit chain access pattern
+
+Read:
+- `app/src/audit/auditLog.ts` (or wherever audit entries are typed) —
+  confirm the `AuditEntry` shape, particularly whether each entry has a
+  stable `id` field, and what the canonical reference is. If no
+  stable id exists, the spec falls back to a deterministic synthesis
+  string (`<modelId>-<ruleId>-<paragraphIndex>-<ts>`) and documents
+  why in the implementation.
+- `app/src/ui/HybridPrecisionPanel.tsx` and `app/src/audit/hybridStats.ts`
+  (Wave 30-A and Wave 31-A) — confirm the audit-chain access pattern
+  already in use. **Mirror that pattern** in C.3; do NOT introduce a
+  new data-access path.
+- `app/src/ui/FindingsPanel.tsx` (or sub-component) — confirm where
+  the hybrid-finding evidence (`modelId`, `similarity`) currently
+  renders. Typically a `<dl>` of `<dt>/<dd>` pairs inside a disclosure.
+  Identify the exact insertion point for the new audit-entry-id pair.
+
+### C.2 — Helper
+
+`app/src/audit/findClassifyEntry.ts` (new):
+
+```ts
+import type { AuditEntry } from './auditLog';
+
+/**
+ * Find the most recent kind:'llm-classify' audit entry matching
+ * (ruleId, paragraphIndex). Returns null if none exists.
+ *
+ * Iterates from the tail to find the most recent match. Linear in the
+ * size of the chain; O(n). The caller is responsible for memoisation
+ * if the chain is large.
+ */
+export function findClassifyEntry(
+  chain: ReadonlyArray<AuditEntry>,
+  ruleId: string,
+  paragraphIndex: number,
+): AuditEntry | null {
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const entry = chain[i];
+    if (entry?.kind !== 'llm-classify') continue;
+    const payload = entry.payload as { ruleId?: unknown; paragraphIndex?: unknown };
+    if (payload.ruleId === ruleId && payload.paragraphIndex === paragraphIndex) {
+      return entry;
+    }
+  }
+  return null;
+}
+```
+
+(Adapt typing to the actual `AuditEntry` shape verified in C.1.)
+
+### C.3 — Helper test
+
+`app/src/audit/findClassifyEntry.test.ts` (new, write FIRST):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { findClassifyEntry } from './findClassifyEntry';
+import type { AuditEntry } from './auditLog';
+
+const e = (
+  kind: string,
+  payload: Record<string, unknown>,
+  id = 'x',
+): AuditEntry => ({ kind, payload, id /* + other fields adapted in C.1 */ }) as AuditEntry;
+
+describe('findClassifyEntry', () => {
+  it('returns null on empty chain', () => {
+    expect(findClassifyEntry([], 'rule.x', 3)).toBeNull();
+  });
+
+  it('returns null when no entry matches', () => {
+    const chain = [e('llm-classify', { ruleId: 'rule.y', paragraphIndex: 3 })];
+    expect(findClassifyEntry(chain, 'rule.x', 3)).toBeNull();
+  });
+
+  it('returns the matching entry when one exists', () => {
+    const match = e('llm-classify', { ruleId: 'rule.x', paragraphIndex: 3 }, 'a1');
+    const chain = [e('other', {}), match];
+    expect(findClassifyEntry(chain, 'rule.x', 3)).toBe(match);
+  });
+
+  it('returns the most recent when multiple match', () => {
+    const old = e('llm-classify', { ruleId: 'rule.x', paragraphIndex: 3 }, 'old');
+    const recent = e('llm-classify', { ruleId: 'rule.x', paragraphIndex: 3 }, 'recent');
+    const chain = [old, e('other', {}), recent];
+    expect(findClassifyEntry(chain, 'rule.x', 3)?.id).toBe('recent');
+  });
+
+  it('ignores entries with other kinds', () => {
+    const chain = [e('hybrid-feedback', { ruleId: 'rule.x', paragraphIndex: 3 })];
+    expect(findClassifyEntry(chain, 'rule.x', 3)).toBeNull();
+  });
+});
+```
+
+### C.4 — Disclosure surface
+
+In the hybrid-finding disclosure component (path verified in C.1, most
+likely `app/src/ui/FindingsPanel.tsx` or a sub-component), wire up:
+- Call `findClassifyEntry` (via the audit-chain access pattern in
+  use) for the current finding.
+- Render one new `<dt>/<dd>` pair below the existing evidence:
+
+  ```tsx
+  {classifyEntry && (
+    <>
+      <dt>audit entry</dt>
+      <dd
+        className="font-mono text-small text-fg-muted"
+        title={classifyEntry.id}
+      >
+        {classifyEntry.id.slice(0, 8)}
+      </dd>
+    </>
+  )}
+  ```
+
+  Adapt `.id` to whatever the canonical reference field turned out to
+  be in C.1. If a stable id doesn't exist, synthesize one
+  deterministically (`<modelId>-<ruleId>-<paragraphIndex>-<ts>`) and
+  truncate that.
+
+When `findClassifyEntry` returns `null` (fresh installs, pre-Wave-21
+chains, non-hybrid findings), render nothing. The disclosure already
+handles partial evidence gracefully.
+
+### C.5 — Dark-mode boundary fix-as-found
+
+While editing files in C.4, if a hard-coded Tailwind palette class
+shows up in the touched component (`bg-amber-50`, `text-zinc-700`,
+etc.), **fix it in the same PR**. Don't punt to Part B. This prevents
+B/C cross-merging conflicts.
+
+### C.6 — Acceptance
+
+- [ ] C.1 verification documented in PR description.
+- [ ] `findClassifyEntry.test.ts` has the five cases above; all pass.
+- [ ] `<dl>` insertion lands and the entry id appears in dark + light
+      mode.
+- [ ] Hover (`title=`) reveals the full id.
+- [ ] When chain has no matching entry, no extra DOM is rendered (test
+      this in the existing FindingsPanel test file if one exists).
+- [ ] Local gate green.
+- [ ] No new audit `kind`s, no IDB writes, no third-party deps.
+
+## §8 Part E — Coverage push (rebases last)
+
+**Goal.** Continue Wave 31-C's pattern. Branches off `main` AFTER A,
+B, C merge.
+
+### E.1 — Pre-flight
+
+```bash
+cd app && npm run test:coverage
+```
+
+Capture the post-merge baseline (branches, lines, functions,
+statements). Open `coverage/lcov-report/index.html` and identify the
+5–10 lowest-covered branches in actually-meaningful code. Prioritize:
+- New code from A/B/C: `findClassifyEntry.ts`,
+  `dark-mode-regression.test.ts`, any new tokens added to
+  `index.css`.
+- Pre-existing low-coverage modules with reachable, meaningful
+  branches.
+
+### E.2 — Targeted tests
+
+Add tests with a "what does this protect" reason in each `describe`
+block name. Forbidden:
+- Coverage-filler tests that pass noop fixtures through a function
+  just to hit a branch.
+- Snapshot tests added purely to bump line coverage.
+
+### E.3 — Conditional floor bump
+
+In `app/vite.config.ts` (the coverage thresholds object), apply:
+
+| Post-E branches % | Action |
+|---|---|
+| ≥ 91.2 | bump `branches` floor to **91** |
+| ≥ 90.7 | bump `branches` floor to **90.5** |
+| < 90.7 | no floor bump; ship targeted tests as-is |
+
+Don't lower other thresholds. Mirror Wave 31-C's discipline: don't
+bump for the metric's sake. If the gap is genuinely all defensive
+code, the right call is no bump.
+
+### E.4 — Acceptance
+
+- [ ] No `src/` edits.
+- [ ] All new tests have a "what does this protect" reason in their
+      describe-block name.
+- [ ] PR description shows before/after coverage table.
+- [ ] If floor bumped, the bump is in the same PR.
+
+## §9 Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| `build:classifier-assets` requires network egress to a model registry that CI runner can't reach | A.1 verifies the script's network requirements before adding it to the workflow |
+| Auto-issue label `nightly-real-model-broken` doesn't exist; first failure errors during issue create | A.1 documents one-time `gh label create`; PR description lists this step |
+| Part B audit grep returns >15 distinct files; B becomes too big as one PR | §1.5 bail-out: split into B1/B2 |
+| Part B sweep accidentally edits a file C owns, causing cherry-pick collision | §1.4 explicit exclusion list; the regression test's allow-list path comments document the boundary |
+| `AuditEntry` doesn't have a stable `id` field | C.1 fallback: deterministic synthesis (`<modelId>-<ruleId>-<paragraphIndex>-<ts>`) |
+| Truncated 8-char id is ambiguous for grep | `title=` on `<dd>` reveals full id; copy-paste from there |
+| Diminishing returns on coverage push past 90% | E.3 explicitly allows "no bump" if the gap is defensive code |
+
+## §10 Tech stack
+
+React 18 + TypeScript (`strict`, `noUncheckedIndexedAccess`,
+`noImplicitOverride`), Vite, Vitest + RTL +
+`@testing-library/user-event`, Tailwind v4, Storybook 8, Playwright,
+Lighthouse CI (a11y ≥ 95). CSP-strict — no new network egress, no new
+third-party deps, no IDB schema bumps.
+
+## §11 Dispatch instructions
+
+For agentic workers: use `superpowers:subagent-driven-development` (or
+the project's `/wave` skill which dispatches in parallel against
+disjoint worktrees) to dispatch Parts A, B, C in parallel against
+`origin/main`. Each subagent gets a worktree under
+`<project>/worktrees/<branch>` per the global CLAUDE.md Worktree
+convention. Each subagent appends a heartbeat to
+`.claude/agent-status/<id>.log` every ~5 minutes per the
+`subagent-heartbeat` skill. Orchestrator polls every 10 minutes and
+treats any agent idle >30 minutes as stalled.
+
+After A, B, C merge: dispatch E as a single direct task (no
+parallelism needed for one part).


### PR DESCRIPTION
## Summary

Adds Wave 32 design spec + implementation plan. Pure docs, no app code.

- `docs/superpowers/specs/2026-04-27-wave32-design.md`
- `docs/plans/wave32-phase19-darkmode-audit-coverage.md`

Four-part wave (A/B/C parallel, E rebases last; D skipped per Wave
21/29/30/31 convention).

## Test plan

- [x] No app code changed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)