### PR TITLE
wave32-A: nightly real-model GHA

### DIFF
--- a/.github/workflows/real-model-nightly.yml
+++ b/.github/workflows/real-model-nightly.yml
@@ -1,0 +1,80 @@
+name: real-model-nightly
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  real-model:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            app/package-lock.json
+
+      - name: Install root dev deps (Playwright runner)
+        run: npm ci
+
+      - name: Install app deps
+        working-directory: app
+        run: npm ci
+
+      - name: Install chromium for Playwright
+        run: npx playwright install --with-deps chromium
+
+      - name: Build classifier assets
+        working-directory: app
+        run: npm run build:classifier-assets
+
+      - name: Build app
+        working-directory: app
+        run: npm run build
+
+      - name: Run real-model spec
+        env:
+          RUN_REAL_MODEL: '1'
+        run: npx playwright test --project=chromium tests/e2e/hybrid-golden.spec.ts
+
+      - name: Open or update issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          label=nightly-real-model-broken
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          existing=$(gh issue list --state open --label "$label" --json number --jq '.[0].number // empty')
+          body="Run failed at $(date -u +%FT%TZ). Run: $run_url"
+          if [ -z "$existing" ]; then
+            gh issue create \
+              --title "Nightly real-model spec broken" \
+              --label "$label" \
+              --body "$body"
+          else
+            gh issue comment "$existing" --body "$body"
+          fi
+
+      - name: Close issue on success
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          label=nightly-real-model-broken
+          existing=$(gh issue list --state open --label "$label" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Recovered at $(date -u +%FT%TZ). Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            gh issue close "$existing"
+          fi


### PR DESCRIPTION
## Summary

Adds nightly GitHub Actions workflow that runs the existing
`RUN_REAL_MODEL=1`-gated `tests/e2e/hybrid-golden.spec.ts` daily at
06:00 UTC and on `workflow_dispatch`. Auto-manages a single issue
under the label `nightly-real-model-broken` (open on first failure,
comment on subsequent failures, close on recovery).

CI-only; zero app code; no new dependencies.

## Files

- **NEW** `.github/workflows/real-model-nightly.yml` — schedule + 7
  steps + auto-issue scripts.

## Verification

- **A.1 — env var:** Confirmed `RUN_REAL_MODEL=1` (not `REAL_MODEL`)
  per `tests/e2e/hybrid-golden.spec.ts` header.
- **A.1 — classifier-assets script:** `app/scripts/build-classifier-assets.mjs`
  fetches from `huggingface.co` (public, no secrets required).
- **A.1 — label setup:** Created via
  `gh label create nightly-real-model-broken --color FF0000 --description "Nightly real-model spec is broken"`.
  Verified present.
- **A.3 — happy-path manual run:** **Deferred to post-merge.** GitHub
  Actions only allows `workflow_dispatch` on workflows that exist on
  the default branch (the `gh workflow run` call returns HTTP 404 on
  feature-branch workflows). After this PR merges, run
  `gh workflow run real-model-nightly.yml` against `main` to confirm
  the happy path.
- **A.4 — force-failure verification:** Same constraint as A.3;
  must be exercised post-merge against `main`. Logical inspection of
  the failure / recovery scripts confirms idempotency:
  - Failure: dedupes on label (one open issue at a time); comments
    instead of duplicating.
  - Success: no-op if no issue is open; closes + comments otherwise.

## Test plan

- [x] Workflow committed at the correct path with `permissions: { issues: write }`.
- [x] Label `nightly-real-model-broken` created.
- [ ] Post-merge: trigger one manual run and confirm green.
- [ ] Post-merge: optional force-failure round-trip if desired.
- [ ] CI green before \`gh pr ready\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)