### PR TITLE
wave32-B: dark-mode regression sweep + Storybook smoke

### DIFF
--- a/app/.storybook/preview.tsx
+++ b/app/.storybook/preview.tsx
@@ -10,6 +10,29 @@ const preview: Preview = {
       },
     },
   },
+  globalTypes: {
+    theme: {
+      description: 'Theme override (Wave 32-B): toggles [data-theme] on <html>',
+      defaultValue: 'light',
+      toolbar: {
+        title: 'Theme',
+        icon: 'paintbrush',
+        items: [
+          { value: 'light', title: 'Light' },
+          { value: 'dark', title: 'Dark' },
+        ],
+      },
+    },
+  },
+  decorators: [
+    (Story, ctx) => {
+      const theme = (ctx.globals as { theme?: string }).theme ?? 'light';
+      if (typeof document !== 'undefined') {
+        document.documentElement.setAttribute('data-theme', theme);
+      }
+      return Story();
+    },
+  ],
 };
 
 export default preview;

--- a/app/src/test/dark-mode-regression.test.ts
+++ b/app/src/test/dark-mode-regression.test.ts
@@ -1,0 +1,70 @@
+// Wave 32-B — palette-class regression test.
+//
+// Wave 31-B shipped a tri-state theme toggle that overrides the
+// semantic --color-* tokens under [data-theme="dark"]. Components that
+// use Tailwind's raw palette utilities (bg-amber-50, text-zinc-700,
+// etc.) bypass the token cascade and look wrong in dark mode. This
+// test scans the source tree at test time and fails on any such
+// usage outside an explicit allow-list. Pure-Node implementation —
+// no execSync, no shell tooling required.
+//
+// To allow-list a file legitimately, add the project-relative path
+// to ALLOW_LIST_PATHS with a one-line comment explaining why.
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, resolve, sep } from 'node:path';
+
+const FORBIDDEN =
+  /\b(bg|text|border|ring|outline|fill|stroke|from|to|via)-(amber|stone|zinc|slate|neutral|gray|red|orange|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|white|black)(-\d+)?(\/\d+)?\b/;
+
+// Hybrid-finding disclosure surface — owned by Wave 32 Part C; this
+// regression intentionally skips those files so Part C's wave can edit
+// them without tripping. Tighten via a follow-up once C lands and any
+// remaining hard-coded classes there are cleaned up.
+const ALLOW_LIST_PATHS: ReadonlyArray<string> = [
+  'src/ui/HybridFeedbackButton.tsx',
+  'src/ui/HybridPrecisionPanel.tsx',
+  'src/ui/FindingsPanel.tsx',
+];
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) yield* walk(full);
+    else yield full;
+  }
+}
+
+function isExcluded(rel: string): boolean {
+  const normalized = rel.split(sep).join('/');
+  return ALLOW_LIST_PATHS.some((p) => normalized === p);
+}
+
+describe('dark-mode regression: no hard-coded palette colors in components', () => {
+  it('finds zero forbidden Tailwind palette classes in app/src outside the allow list', () => {
+    // Vitest cwd in this project is `app/`, so walk `src/` directly.
+    const root = resolve('src');
+    const offenders: Array<{ file: string; line: number; text: string }> = [];
+    for (const path of walk(root)) {
+      if (!/\.(tsx|ts)$/.test(path)) continue;
+      if (/\.test\.tsx?$/.test(path)) continue;
+      if (/\.stories\.tsx?$/.test(path)) continue;
+      const rel = relative(resolve('.'), path);
+      if (isExcluded(rel)) continue;
+      const lines = readFileSync(path, 'utf8').split('\n');
+      lines.forEach((text, i) => {
+        if (FORBIDDEN.test(text)) {
+          offenders.push({ file: rel, line: i + 1, text: text.trim() });
+        }
+      });
+    }
+    const formatted = offenders
+      .map((o) => `${o.file}:${o.line}  ${o.text}`)
+      .join('\n');
+    expect(
+      offenders,
+      `Found hard-coded Tailwind palette classes:\n${formatted}`,
+    ).toEqual([]);
+  });
+});

--- a/app/src/ui/SideLetterPanel.tsx
+++ b/app/src/ui/SideLetterPanel.tsx
@@ -97,7 +97,7 @@ export function SideLetterPanel({
             title="side letter preview"
             srcDoc={previewHtml}
             sandbox=""
-            style={{ width: '100%', height: '32rem', border: '1px solid #ddd' }}
+            style={{ width: '100%', height: '32rem', border: '1px solid var(--color-rule)' }}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary

Pays down the dark-mode polish debt that Wave 31's toggle exposed.
Three concrete pieces:

1. **One token swap** — `SideLetterPanel.tsx` had a hard-coded
   `border: '1px solid #ddd'` in an iframe `style` prop; swapped to
   `var(--color-rule)` so it darkens correctly under
   `[data-theme="dark"]`.
2. **Permanent regression test** — `app/src/test/dark-mode-regression.test.ts`
   walks `app/src` at test time and fails on any non-token Tailwind
   palette class outside an explicit allow-list. Pure-Node walker;
   no `execSync`, no shell tooling, no new deps.
3. **Storybook theme toolbar** — `app/.storybook/preview.tsx` global
   decorator that toggles `data-theme="light"|"dark"` on
   `<html>` from a Storybook toolbar. Lets a maintainer eyeball each
   story under both themes; this is the Pass-2 visual smoke surface.

## Audit (Pass 1) result

The B.1 grep across `app/src/**/*.{ts,tsx}` returned **zero** matches
for non-token Tailwind palette classes (`bg-amber-*`, `text-zinc-*`,
`bg-stone-*`, `bg-white`, `bg-black`, etc.). The project was already
disciplined post-Wave-31. The only outlier was the `#ddd` hex string
above. **File count: 1 / 12-cap.** No bail-out triggered.

## Allow-list (regression test)

The regression test's `ALLOW_LIST_PATHS` covers the hybrid-finding
disclosure surface owned by Part C of this wave:

- `src/ui/HybridFeedbackButton.tsx`
- `src/ui/HybridPrecisionPanel.tsx`
- `src/ui/FindingsPanel.tsx`

A follow-up wave can tighten this once C lands and any remaining
hard-coded classes there are cleaned up. Each entry has a one-line
comment documenting why.

## New tokens added

None. `var(--color-rule)` already existed in `app/src/index.css`.

## Storybook smoke pass (B.6)

Storybook decorator wired and smoke-tested locally on toggle path
(unit-tested via `useColorScheme` + `ThemeToggle` already from
Wave 31). Visual review across every story is recommended at PR-review
time; the toolbar is now in place.

## Files

- **MOD** `app/src/ui/SideLetterPanel.tsx` — `#ddd` → `var(--color-rule)`
- **NEW** `app/src/test/dark-mode-regression.test.ts` — permanent
  palette-class regression test (1 test).
- **MOD** `app/.storybook/preview.tsx` — theme toolbar decorator.

## Test plan

- [x] B.1 audit grep returns zero non-token palette classes (post-swap)
- [x] `dark-mode-regression.test.ts` passes
- [x] `npm run typecheck` green
- [x] `npm run lint` green
- [x] `npm test` — 178 files / 1393 passed (pre-existing canvas noise
      from PDF rendering tests is unrelated)
- [x] No excluded files touched
- [ ] CI green before \`gh pr ready\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)