### PR TITLE
fix(ci): wire Mergify queue action to auto-merge-armed PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,4 @@
-# Mergify configuration — Wave 30-C
+# Mergify configuration — Wave 30-C; queue action wired post-Wave-31.
 #
 # Defensive: GitHub branch protection on `main` is the authoritative
 # gate (required_status_checks + enforce_admins=true). This file makes
@@ -24,6 +24,23 @@ queue_rules:
     merge_method: squash
 
 pull_request_rules:
+  - name: enqueue PRs with auto-merge armed
+    # Triggered by `gh pr merge --auto --squash`. Branch protection sets
+    # `strict: true` ("Require branches to be up to date") on `main`, so
+    # any open PR goes BEHIND every time main moves. GitHub's native
+    # auto-merge does not update branches; the Mergify queue does. This
+    # rule routes auto-merge-armed PRs into the `default` queue, which
+    # rebases each one in sequence before merging — closes the gap that
+    # was forcing manual rebases on every queued PR. Wave 30-C set up
+    # the queue rules but never wired the queue action; this fixes it.
+    conditions:
+      - base=main
+      - auto_merge_enabled
+      - -draft
+    actions:
+      queue:
+        name: default
+
   - name: refuse merge while any required check is failing
     conditions:
       - base=main


### PR DESCRIPTION
## Summary

Wave 30-C added the \`queue_rules\` infrastructure but never wired a
\`pull_request_rules.queue\` action to feed it. Branch protection on
\`main\` has \`strict=true\` (Require branches to be up to date), so
every open PR goes \`BEHIND\` each time main moves; GitHub's native
auto-merge does not update branches. Result: every queued PR required
a manual rebase.

This rule routes any open, non-draft PR with auto-merge armed into
the existing \`default\` queue. Mergify's queue rebases each PR in
sequence before merging, closing the gap.

Trigger condition \`auto_merge_enabled\` matches \`gh pr merge --auto
--squash\`, which is the project's documented merge driver per
\`~/.claude/CLAUDE.md\` PR Merge Policy and
\`docs/wave30-ci-postmortem.md\`.

## Files

- **MOD** \`.mergify.yml\` — added \`enqueue PRs with auto-merge armed\`
  rule + 1-line note in the file header about post-Wave-31 wiring.

## Test plan

- [x] Diff is +18 / -1, no other files touched
- [ ] CI green
- [ ] After merge: confirm subsequent waves' PRs queue without
      requiring manual rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)