### PR TITLE
fix(ci): switch Mergify queue trigger to label=automerge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -32,9 +32,8 @@ pull_request_rules:
     # has `strict: true` ("Require branches to be up to date") and
     # GitHub's native auto-merge does not update branches.
     #
-    # `auto_merge_enabled` was tried first but isn't a valid Mergify
-    # condition in this version (validation rejects at root →
-    # pull_request_rules → conditions). Label-based triggering is
+    # `auto_merge_enabled` was tried first (PR #138) but isn't a valid
+    # Mergify condition in this version. Label-based triggering is
     # universally supported and explicit about user intent.
     conditions:
       - base=main

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,4 @@
-# Mergify configuration — Wave 30-C
+# Mergify configuration — Wave 30-C; queue action wired post-Wave-31.
 #
 # Defensive: GitHub branch protection on `main` is the authoritative
 # gate (required_status_checks + enforce_admins=true). This file makes
@@ -24,6 +24,23 @@ queue_rules:
     merge_method: squash
 
 pull_request_rules:
+  - name: enqueue PRs with auto-merge armed
+    # Triggered by `gh pr merge --auto --squash`. Branch protection sets
+    # `strict: true` ("Require branches to be up to date") on `main`, so
+    # any open PR goes BEHIND every time main moves. GitHub's native
+    # auto-merge does not update branches; the Mergify queue does. This
+    # rule routes auto-merge-armed PRs into the `default` queue, which
+    # rebases each one in sequence before merging — closes the gap that
+    # was forcing manual rebases on every queued PR. Wave 30-C set up
+    # the queue rules but never wired the queue action; this fixes it.
+    conditions:
+      - base=main
+      - auto_merge_enabled
+      - -draft
+    actions:
+      queue:
+        name: default
+
   - name: refuse merge while any required check is failing
     conditions:
       - base=main

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,18 +24,21 @@ queue_rules:
     merge_method: squash
 
 pull_request_rules:
-  - name: enqueue PRs with auto-merge armed
-    # Triggered by `gh pr merge --auto --squash`. Branch protection sets
-    # `strict: true` ("Require branches to be up to date") on `main`, so
-    # any open PR goes BEHIND every time main moves. GitHub's native
-    # auto-merge does not update branches; the Mergify queue does. This
-    # rule routes auto-merge-armed PRs into the `default` queue, which
-    # rebases each one in sequence before merging — closes the gap that
-    # was forcing manual rebases on every queued PR. Wave 30-C set up
-    # the queue rules but never wired the queue action; this fixes it.
+  - name: enqueue PRs labelled automerge
+    # Trigger: add the `automerge` label to a PR (UI or
+    # `gh pr edit <num> --add-label automerge`). Mergify routes it
+    # into the `default` queue, which rebases each PR in sequence
+    # before merging — necessary because branch protection on `main`
+    # has `strict: true` ("Require branches to be up to date") and
+    # GitHub's native auto-merge does not update branches.
+    #
+    # `auto_merge_enabled` was tried first but isn't a valid Mergify
+    # condition in this version (validation rejects at root →
+    # pull_request_rules → conditions). Label-based triggering is
+    # universally supported and explicit about user intent.
     conditions:
       - base=main
-      - auto_merge_enabled
+      - label=automerge
       - -draft
     actions:
       queue:


### PR DESCRIPTION
## Summary

PR #138 merged with \`auto_merge_enabled\` in the queue rule, but that
attribute isn't a valid Mergify condition in this version. Mergify
rejected the config with **"Invalid condition"** at
\`pull_request_rules → conditions\`, so the queue action never fires —
the original BEHIND-PR rebase problem persists.

This PR switches to label-based triggering: add the \`automerge\` label
to a PR (UI or \`gh pr edit <num> --add-label automerge\`) to route it
into the \`default\` queue. The queue rebases each PR in sequence
before merging.

## Workflow change

After this lands, two compatible paths to auto-merge a PR:

1. **Mergify queue (preferred when main is moving):**
   \`gh pr edit <num> --add-label automerge\` — queue rebases as needed.
2. **GitHub native auto-merge (fallback):**
   \`gh pr merge --auto --squash\` — fires when checks green AND branch
   is up to date. Manual rebase still needed if main moves.

The \`automerge\` label exists in the repo (created post-#138).

## Files

- **MOD** \`.mergify.yml\` — replace \`auto_merge_enabled\` with
  \`label=automerge\`; updated comment explains the swap.

## Test plan

- [x] Diff is +2 / -3 inside the existing queue rule
- [ ] Mergify dashboard validates the config (no "Invalid condition")
- [ ] After merge: open a labelled test PR, confirm Mergify enqueues
      it without manual rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)