### PR TITLE
docs(plans): wave 33 — hygiene (audit scope, lazy-shell, regression-allowlist, coverage)

### DIFF
--- a/docs/plans/wave33-hygiene-audit-lazy-allowlist-coverage.md
+++ b/docs/plans/wave33-hygiene-audit-lazy-allowlist-coverage.md
@@ -1,0 +1,659 @@
+# Wave 33 — Operational hygiene: audit scope, lazy-shell, regression-allowlist, coverage
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use
+> `superpowers:subagent-driven-development` (or the project's `/wave`
+> skill) to dispatch Parts A, B, C per the matrix in §7. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Design spec:** `docs/superpowers/specs/2026-04-27-wave33-design.md`
+(read first if any §X.Y step is ambiguous).
+
+**Goal.** Clear four accumulated operational papercuts so the next
+user-facing wave starts from a clean baseline: noisy npm-audit on
+every PR; cap-pinned bundle budget; allow-list-shaped dark-mode
+regression test; missing coverage push.
+
+**Architecture.** A is a one-flag CI patch + docs paragraph. B
+converts ≤ 5 interaction-gated panels to `React.lazy` boundaries to
+reclaim ≥ 10 KiB of app-shell budget AND codifies the shell-eligible
+rule in `docs/SYSTEM_DESIGN.md`. C deletes the W32-B regression-test
+allow-list entries (or fixes any non-token classes the grep
+surfaces). E rebases last with the established conditional bump.
+
+**Tech stack.** React 18 + TypeScript (`strict`,
+`noUncheckedIndexedAccess`), Vite, Vitest + RTL, Tailwind v4,
+Storybook 8, GitHub Actions. CSP-strict; no new third-party deps; no
+IDB schema bumps.
+
+**Base SHA.** All branches branch from `origin/main =
+380b7b97b0389acfc386c9b1cc7919293915621f` (Wave 32-C merge).
+
+---
+
+## §0 What changed since Wave 32 (context for fresh agents)
+
+Wave 32 (PRs #134 docs + #135–#137 parts) shipped:
+
+- **A** — Nightly real-model GHA workflow at
+  `.github/workflows/real-model-nightly.yml`. Runs daily at 06:00
+  UTC + on `workflow_dispatch`; auto-manages the
+  `nightly-real-model-broken` issue.
+- **B** — Dark-mode regression sweep. Audit found only one hit
+  (`#ddd` border in `SideLetterPanel.tsx`); permanent regression test
+  at `app/src/test/dark-mode-regression.test.ts`. Storybook theme
+  toolbar wired in `app/.storybook/preview.tsx`. Three files
+  allow-listed:
+  - `src/ui/HybridFeedbackButton.tsx`
+  - `src/ui/HybridPrecisionPanel.tsx`
+  - `src/ui/FindingsPanel.tsx`
+- **C** — `findClassifyEntry` helper + audit-entry `entryHash`
+  readout (truncated to 8 chars; full hash in `title=`) in the
+  hybrid-finding disclosure inside `FindingsPanel.tsx`. C also bumped
+  the app shell budget from 352k to 354k in
+  `app/scripts/check-bundle-budget.mjs`. The budget comment now
+  says: *"Future waves should lazy-load new shell-bound UI to claw
+  back headroom rather than nudging this number; the next add will be
+  a meaningful refactor, not a bump."*
+
+Mid-wave CI fixes:
+- **PR #138** — wired Mergify queue action with `auto_merge_enabled`,
+  not a valid Mergify condition; merged with broken config.
+- **PR #139** — replaced trigger with `label=automerge`. Workflow now:
+  add the `automerge` label to a PR via UI or
+  `gh pr edit <num> --add-label automerge`; Mergify queues +
+  rebases + merges. `gh pr merge --auto --squash` continues to work
+  as a parallel fallback.
+
+The `npm-audit` CI job is currently a noisy false-positive: 4 critical
+vulns trace through `@storybook/addon-actions` → `uuid` (devDep
+transitives). The deployed PWA bundle (`dist/`) has none of those
+deps; `--omit=dev` should return zero locally.
+
+## §1 Scope-shaping decisions (READ BEFORE APPROVING)
+
+1. **Part A is a one-flag patch + a docs paragraph.** Add `--omit=dev`
+   to the existing `npm audit` command in
+   `.github/workflows/security.yml`. Document the dev-vs-prod
+   vulnerability split in `docs/SECURITY.md`. No app code, no tests.
+2. **Part B converts ≤ 5 panels** rendered conditionally / on
+   interaction to `React.lazy`. Target reclaim ≥ 10 KiB; **soft goal.**
+   If real reclaim is 6 KiB after honest measurement, document the
+   bail-out and proceed — don't reach.
+3. **Part B candidates are discovered**, not pre-enumerated. Likely:
+   `AnnotationsPanel`, `AuditLogPanel`, `SideLetterPanel`,
+   `RedlinePanel`, `ClauseSimilarityPanel`. Verify each is currently
+   eager and gated behind a render-time conditional before converting.
+4. **Part C may be a 3-line PR.** Clean case = delete the three
+   allow-list entries. Dirty case = swap to semantic tokens within
+   the 3-file boundary; allow-list survivors only with a one-line
+   comment explaining deliberate intent.
+5. **Part C does NOT add new semantic tokens** (Wave 32-B rule).
+6. **Part C halts on call-site color-prop drift.** If a parent passes
+   `className="bg-amber-50"` into one of the three files, fix
+   requires touching the parent — that's drift. Stop and report.
+7. **Part E rebases last.** Source cap **0**. Conditional floor bump:
+   ≥91.2 → 91; ≥90.7 → 90.5; else no bump. Wave 31-C discipline.
+8. **B/C boundary on `FindingsPanel.tsx`:** B owns import-style edits
+   (lazy conversion); C owns className edits (token swaps). Both can
+   touch the file in parallel without cherry-pick conflict.
+9. **No CSP / IDB schema / new third-party deps** in Wave 33.
+
+## §2 Out of scope
+
+- Upgrading Storybook past the vuln window; dropping
+  `addon-essentials`; adding `npm overrides` for `uuid`. Part A's
+  `--omit=dev` scope is the correct fix.
+- Restructuring the entire bundle architecture beyond the ≤ 5 lazy
+  conversions. The shell-eligible rule is documented *policy*, not a
+  redesign.
+- Codifying the lazy rule as an ESLint plugin / build-time check.
+- Coverage past 91% via contrived tests on defensive code.
+- Hybrid review queue UI; "jump to audit log" cross-ref;
+  `@xenova/transformers` upstream-bump watch; worker-path classifier;
+  real-model on by default — all parked at Wave 32 §2 status.
+
+## §3 Execution dependency graph
+
+```
+   ┌──────────┐   ┌──────────┐   ┌──────────┐
+   │ Part A   │   │ Part B   │   │ Part C   │
+   │ npm-     │   │ system-  │   │ tighten  │
+   │ audit    │   │ atic     │   │ dark-    │
+   │ scope    │   │ lazy-    │   │ mode     │
+   │ to prod  │   │ load     │   │ allowlist│
+   └────┬─────┘   └────┬─────┘   └────┬─────┘
+        │              │              │
+        └──────────────┴──────┬───────┘
+                              ▼
+                        ┌──────────┐
+                        │ Part E   │
+                        │ coverage │
+                        │ (rebase) │
+                        └──────────┘
+```
+
+A, B, C branch from `origin/main` (`380b7b9`) in parallel. E rebases
+off post-merge `main` after A, B, C merge.
+
+---
+
+## §4 Part A — Scope npm audit to runtime deps
+
+**Branch:** `wave33-A-audit-prod-only`
+**Worktree:** `worktrees/wave33-A-audit-prod-only`
+**Heartbeat:** `.claude/agent-status/wave33-A.log`
+
+**Files (cap: 0 src, 0 test):**
+
+- Modify: `.github/workflows/security.yml` (the existing audit step)
+- Modify: `docs/SECURITY.md` (add a paragraph; verify exact path in A.1)
+
+### Acceptance
+
+- [ ] **A.1** Pre-implementation verification.
+  - Find the audit job:
+    ```
+    grep -rn "npm audit" .github/workflows/
+    ```
+    Likely result: a step in `.github/workflows/security.yml` running
+    `cd app && npm audit --audit-level=high` or similar. Read the
+    full step (name + run line); copy verbatim to PR description.
+  - Capture local before/after counts:
+    ```
+    cd app && npm audit --audit-level=high            # current
+    cd app && npm audit --omit=dev --audit-level=high # new
+    ```
+    Record both counts in the PR description. The new run should
+    return 0 vulnerabilities.
+  - Verify `docs/SECURITY.md` exists. Read the file and identify a
+    natural location for the dev-vs-prod paragraph (likely near an
+    existing "accept-risk" register, a "vulnerabilities" heading, or
+    the end of the document if no obvious anchor exists). Do NOT
+    create a new file.
+
+- [ ] **A.2** Patch the workflow. In `.github/workflows/security.yml`,
+      change the npm-audit step. Example before/after — adapt the
+      step name and exact path to match what A.1 found:
+
+```yaml
+# Before:
+- name: Audit app (high+ only)
+  working-directory: app
+  run: npm audit --audit-level=high
+
+# After:
+- name: Audit app (high+ only, prod deps only)
+  working-directory: app
+  run: npm audit --omit=dev --audit-level=high
+```
+
+  Don't touch other steps in `security.yml` (gitleaks, trivy,
+  osv-scanner, etc. — different concerns). Commit:
+
+```bash
+git add .github/workflows/security.yml
+git commit -m "wave33-A: scope npm audit to prod deps (--omit=dev)"
+```
+
+- [ ] **A.3** Document the policy. Add to `docs/SECURITY.md` at the
+      location identified in A.1:
+
+```markdown
+### Dev vs. prod vulnerability scope
+
+The `npm-audit` CI job runs with `--omit=dev` because LeaseGuard's
+deployed surface is the static PWA bundle (`dist/`), which contains
+only runtime deps. Build-time / dev-time deps (Storybook, ESLint,
+vitest tooling) are NOT bundled and cannot be exploited by an end
+user. Their vulnerabilities are tracked separately and
+accepted-with-context in §accept-risk if material. Run `npm audit`
+(no flag) locally to see all transitives if you're doing a deeper
+review.
+```
+
+  Adapt the heading depth (`###` vs `##`) and any "§accept-risk"
+  cross-reference to match `SECURITY.md`'s existing voice and
+  structure. Keep the paragraph short.
+
+  Commit:
+```bash
+git add docs/SECURITY.md
+git commit -m "wave33-A: document dev-vs-prod npm-audit scope"
+```
+
+- [ ] **A.4** Local sanity:
+```
+cd app && npm audit --omit=dev --audit-level=high
+```
+  Expected: exit 0 (no vulnerabilities at high+ in prod deps).
+
+- [ ] **A.5** Push and PR:
+```
+git push -u origin wave33-A-audit-prod-only
+```
+  PR title: `wave33-A: scope npm audit to runtime deps`
+  Body must include:
+  - The exact A.1 step before/after.
+  - Before/after vuln counts from local `npm audit`.
+  - The doc-location decision.
+
+  Then label-route via Mergify:
+```
+gh pr edit <num> --add-label automerge
+```
+
+  (Mergify queue is functional post-Wave-32 PR #139.) Auto-merge via
+  `gh pr merge --auto --squash` is also acceptable as the GitHub-side
+  fallback.
+
+## §5 Part B — Systematic shell lazy-load
+
+**Branch:** `wave33-B-lazy-shell`
+**Worktree:** `worktrees/wave33-B-lazy-shell`
+**Heartbeat:** `.claude/agent-status/wave33-B.log`
+
+**Files (cap: ≤ 5 component conversions + parent call-site edits + 1
+docs paragraph; mechanical test edits as needed for sync→async query
+updates):**
+
+- Modify: ≤ 5 source component files in `app/src/ui/**` or
+  `app/src/App/**` (lazy-conversion sites + their import sites).
+- Modify: their existing test files (sync→async query updates).
+- Modify: `docs/SYSTEM_DESIGN.md` (add the shell-eligible paragraph).
+- DO NOT touch: `app/scripts/check-bundle-budget.mjs` (cap stays at
+  354_000 in this PR; the reclaim is visible in measured size, not
+  the cap).
+
+### Acceptance
+
+- [ ] **B.1** Identify candidates. Run a clean build:
+```
+cd app && rm -rf dist && npm run build
+ls -lh dist/assets/index-*.js
+```
+  Capture current shell file sizes (largest `index-*.js` is the
+  primary).
+
+  Inspect existing lazy patterns:
+```
+grep -rn "lazy(() =>" app/src/App app/src/ui --include='*.tsx' | head
+```
+
+  Existing lazy boundaries (do NOT re-convert):
+  - `HybridFeedbackButton` — Wave 29-C
+  - `HybridPrecisionDisclosure` — Wave 30-A
+
+  Identify currently-eager panels rendered conditionally or on
+  interaction. For each candidate:
+  - Confirm it's eagerly imported.
+  - Confirm it's gated behind a render-time conditional (view-mode
+    branch, `<details>` body, click-handler open state, etc.). If it
+    renders unconditionally on app load, it's NOT a candidate — skip.
+
+  Write the candidate list with current vs. expected weight to the
+  PR body. Pin the chosen ≤ 5. **If you can't credibly meet ≥ 10 KiB
+  with ≤ 5 conversions, lower the target and document why.** Don't
+  reach.
+
+- [ ] **B.2** Convert each chosen panel. Pattern (mirror existing
+      `HybridFeedbackButton` boundary in
+      `app/src/ui/FindingsPanel.tsx`):
+
+```tsx
+// Before — eager:
+import { AnnotationsPanel } from './ui/AnnotationsPanel';
+// ...
+<AnnotationsPanel ... />
+
+// After — lazy:
+import { lazy, Suspense } from 'react';
+const AnnotationsPanel = lazy(() =>
+  import('./ui/AnnotationsPanel').then((m) => ({ default: m.AnnotationsPanel })),
+);
+// ...
+<Suspense fallback={null}>
+  <AnnotationsPanel ... />
+</Suspense>
+```
+
+  - If the parent already lives inside a `<Suspense>`, don't add
+    another — just lazy-import.
+  - **Do NOT introduce a new `Suspense` fallback pattern.** Match
+    existing usage (`null` for no flash; or whatever the existing
+    boundary uses).
+  - The named-import bridging (`{ default: m.AnnotationsPanel }`) is
+    necessary because `React.lazy` expects a default export and these
+    components use named exports.
+
+  Run the local gate after each conversion:
+```
+cd app && npm run typecheck && npm run lint && npm test
+```
+
+  Mechanical test edits expected: tests using
+  `screen.getByText(...)` synchronously after a previously-eager
+  render must change to `await screen.findByText(...)` (or `await
+  waitFor(...)`) once the component is lazy. Update tests in the
+  same conversion commit. Don't bulk-edit unrelated tests.
+
+  Commit each conversion (or batch of related conversions):
+```
+git add app/src/ui/<Panel>.tsx app/src/<call-site>.tsx \
+        app/src/ui/<Panel>.test.tsx
+git commit -m "wave33-B: lazy-load <Panel>"
+```
+
+- [ ] **B.3** Document the shell-eligible rule. Add to
+      `docs/SYSTEM_DESIGN.md`. Read the file first to find a
+      natural placement (likely under an existing
+      "Architecture" / "Module boundaries" section). Use this exact
+      paragraph (adapt heading depth to match):
+
+```markdown
+### App shell vs. lazy chunks
+
+Components that are visible the moment the app boots (header,
+view-mode tabs, the empty-state of the findings list) live in the
+eager `index-*.js` shell. Components that only render on user
+interaction (clicking a disclosure, opening a panel, switching to a
+non-default view) MUST be converted to `React.lazy` boundaries. The
+shell budget cap (`app/scripts/check-bundle-budget.mjs`) is *not* a
+number to nudge — it's a contract that says "if you need more,
+lazy-load instead." Existing examples: `HybridFeedbackButton`
+(Wave 29-C), `HybridPrecisionDisclosure` (Wave 30-A), and the panels
+converted in Wave 33-B (see PR #<N>).
+```
+
+  Replace `#<N>` with the actual PR number once it's open. Commit:
+```
+git add docs/SYSTEM_DESIGN.md
+git commit -m "wave33-B: document shell-eligible rule"
+```
+
+- [ ] **B.4** Verify reclaim:
+```
+cd app && rm -rf dist && npm run build && npm run check:budget
+```
+  Expected: green `[ok] app shell` line; size meaningfully below
+  354_000 bytes. The cap stays at 354_000 — Wave 33-B does NOT bump
+  or lower it. Reclaim is visible in the size column.
+
+  Capture the measured before/after for the PR body:
+
+```
+metric           before    after     delta
+app shell        354.0 KiB <new>     -<X> KiB
+```
+
+  If `<X>` < 10 KiB, document the bail-out: which candidates were
+  considered, why reclaim is smaller, and whether the documented
+  rule still warrants the wave (it does — the rule is the larger
+  contribution).
+
+- [ ] **B.5** Local gate (mandatory before push):
+```
+cd app && npm run typecheck && npm run lint && npm test
+```
+  All green. If anything red, fix before push.
+
+- [ ] **B.6** Push, PR, label:
+```
+git push -u origin wave33-B-lazy-shell
+```
+  PR title: `wave33-B: lazy-load shell-bound UI; document
+  shell-eligible rule`
+  Body must include:
+  - B.1 candidate list with weights.
+  - The chosen ≤ 5 conversions and per-component before/after weight.
+  - B.4 before/after shell-size table.
+  - Bail-out rationale if reclaim < 10 KiB.
+  - The exact `docs/SYSTEM_DESIGN.md` snippet added.
+
+  Then:
+```
+gh pr edit <num> --add-label automerge
+```
+
+## §6 Part C — Tighten dark-mode regression allowlist
+
+**Branch:** `wave33-C-darkmode-allowlist`
+**Worktree:** `worktrees/wave33-C-darkmode-allowlist`
+**Heartbeat:** `.claude/agent-status/wave33-C.log`
+
+**Files (cap: ≤ 3 src + 1 test):**
+
+- Modify: `app/src/test/dark-mode-regression.test.ts` (delete /
+  narrow `ALLOW_LIST_PATHS`)
+- Modify (only if grep flags non-token classes):
+  - `app/src/ui/HybridFeedbackButton.tsx`
+  - `app/src/ui/HybridPrecisionPanel.tsx`
+  - `app/src/ui/FindingsPanel.tsx`
+
+### Acceptance
+
+- [ ] **C.1** Verify current state. From the worktree root:
+
+```
+grep -En '\b(bg|text|border|ring|outline|fill|stroke|from|to|via)-(amber|stone|zinc|slate|neutral|gray|red|orange|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|white|black)(-[0-9]+)?(/[0-9]+)?\b' \
+  app/src/ui/HybridFeedbackButton.tsx \
+  app/src/ui/HybridPrecisionPanel.tsx \
+  app/src/ui/FindingsPanel.tsx
+```
+
+  Tabulate any matches per file. Document the result in the PR
+  description.
+
+  Then scan call sites for color-prop drift:
+```
+grep -rEn 'FindingsPanel|HybridFeedbackButton|HybridPrecisionPanel' \
+  app/src --include='*.tsx' | grep -E 'className=.*"' | head -20
+```
+
+  If a parent passes a `className` prop containing a non-token color
+  (e.g. `<FindingsPanel className="bg-amber-50" />`), fixing it
+  requires touching the parent — that's drift. **Halt and report.**
+  Do not silently expand scope.
+
+- [ ] **C.2** Two outcomes:
+
+  **Clean case (zero matches in C.1):**
+  Edit `app/src/test/dark-mode-regression.test.ts`. Replace:
+
+```ts
+const ALLOW_LIST_PATHS: ReadonlyArray<string> = [
+  'src/ui/HybridFeedbackButton.tsx',
+  'src/ui/HybridPrecisionPanel.tsx',
+  'src/ui/FindingsPanel.tsx',
+];
+```
+
+  with:
+
+```ts
+const ALLOW_LIST_PATHS: ReadonlyArray<string> = [];
+```
+
+  Run:
+```
+cd app && npx vitest run src/test/dark-mode-regression.test.ts
+```
+  Expected: PASS.
+
+  Commit:
+```
+git add app/src/test/dark-mode-regression.test.ts
+git commit -m "wave33-C: remove dark-mode regression allow-list entries (verified clean)"
+```
+
+  **Dirty case (matches found in C.1):**
+  For each match, apply the standard token mappings (Wave 32-B
+  table — repeated here for offline-readability):
+
+| Hard-coded | Replace with |
+|-----------|--------------|
+| `bg-white`, `bg-amber-50`, `bg-stone-50`, `bg-stone-100` | `bg-paper` (default) or `bg-paper-raised` (elevated cards) |
+| `bg-stone-200`, `bg-zinc-100`, `bg-amber-100` | `bg-paper-sunken` |
+| `text-black`, `text-zinc-900`, `text-stone-900` | `text-fg` |
+| `text-zinc-700`, `text-stone-700` | `text-fg-body` |
+| `text-zinc-500`, `text-stone-500`, `text-zinc-600` | `text-fg-muted` |
+| `text-zinc-400`, `text-stone-400` | `text-fg-faint` |
+| `border-zinc-200`, `border-stone-200`, `border-amber-200` | `border-rule` (default) or `border-rule-subtle` (low-emphasis) |
+| `text-blue-*`, `bg-blue-*` (accent role) | `text-ink`, `bg-ink` |
+| `bg-red-*`, `text-red-*` (severity-high role) | `text-severity-high`, `bg-severity-bg-error` |
+| `bg-amber-*`, `text-amber-*` (severity-medium role) | `text-severity-medium`, `bg-severity-bg-warn` |
+
+  If a match is intentionally a hardcoded color (e.g. an evidence
+  overlay using `bg-yellow-300/30` as a deliberate annotation
+  contrast like `--color-highlight: rgba(255, 235, 59, 0.35)`), keep
+  that file in the allow-list with a one-line comment in
+  `dark-mode-regression.test.ts` documenting why:
+
+```ts
+const ALLOW_LIST_PATHS: ReadonlyArray<string> = [
+  // Intentional: hybrid-finding evidence overlay uses bg-yellow-300/30
+  // as a deliberate annotation contrast, not a theme color.
+  // See app/src/ui/FindingsPanel.tsx:<line>.
+  'src/ui/FindingsPanel.tsx',
+];
+```
+
+  Commit each fix as you go:
+```
+git add app/src/ui/<File>.tsx
+git commit -m "wave33-C: swap palette classes to semantic tokens in <File>"
+```
+
+  Final commit narrows / empties the allow-list:
+```
+git add app/src/test/dark-mode-regression.test.ts
+git commit -m "wave33-C: tighten dark-mode regression allow-list"
+```
+
+  Do NOT add new semantic tokens. If a match has no obvious mapping,
+  STOP and report.
+
+- [ ] **C.3** Fix-as-found rule. While editing any of the three
+      files, any *other* hard-coded color you spot (e.g.
+      `border: '1px solid #ddd'` in inline styles) gets the same
+      token swap (use `var(--color-rule)`, `var(--color-fg-muted)`,
+      etc.). Don't punt.
+
+- [ ] **C.4** Local gate:
+```
+cd app && npm run typecheck && npm run lint && npm test
+```
+  All green. Specifically verify:
+  - `dark-mode-regression.test.ts` passes.
+  - Existing axe-against-light tests still pass (no regression).
+
+- [ ] **C.5** Push, PR, label:
+```
+git push -u origin wave33-C-darkmode-allowlist
+```
+  PR title: `wave33-C: tighten dark-mode regression allow-list`
+  Body must include:
+  - C.1 grep output (per-file match counts).
+  - Outcome: clean (0 entries) or dirty (which entries survive + why).
+  - Any fix-as-found edits.
+
+  Then:
+```
+gh pr edit <num> --add-label automerge
+```
+
+## §7 Dispatch matrix
+
+| Part | Branch                          | Files cap (src/test/other)              | Depends on        | Heartbeat                              |
+|------|---------------------------------|------------------------------------------|-------------------|-----------------------------------------|
+| A    | `wave33-A-audit-prod-only`      | 0 src + 0 test + 1 workflow + 1 doc     | `origin/main` (`380b7b9`) | `.claude/agent-status/wave33-A.log` |
+| B    | `wave33-B-lazy-shell`           | ≤ 5 src + mechanical test edits + 1 doc | `origin/main` (`380b7b9`) | `.claude/agent-status/wave33-B.log` |
+| C    | `wave33-C-darkmode-allowlist`   | ≤ 3 src + 1 test                        | `origin/main` (`380b7b9`) | `.claude/agent-status/wave33-C.log` |
+| E    | `wave33-E-coverage`             | 0 src + N tests + 1 vitest config max   | A + B + C merged  | `.claude/agent-status/wave33-E.log`     |
+
+Per `~/.claude/CLAUDE.md`: each subagent heartbeats every ~5 min;
+orchestrator polls every 10 min and treats ≥ 30 min idle as stalled.
+Worktrees go under `<project>/worktrees/<branch>`.
+
+## §8 PR / merge protocol
+
+1. **Per-part local gate.** `npm run typecheck && npm run lint &&
+   npm test` green before any push.
+2. **CI gate.** `gh pr checks <pr>` must be green before flipping to
+   ready.
+3. **Label-route via Mergify.** `gh pr edit <num> --add-label
+   automerge` after pushing — the queue rebases each PR before
+   merging, so no manual rebase chasing across the wave. Native
+   `gh pr merge --auto --squash` continues to work as a parallel
+   fallback.
+4. **Merge order.** A, B, C in any order; E rebases off post-merge
+   `main` after all three land.
+5. **Post-wave sweep.** After E merges, run `npm run test:coverage`
+   on `main`; record final number in E's PR body.
+
+## §9 Part E — Coverage push (rebases last)
+
+**Branch:** `wave33-E-coverage` — cut **after** A, B, C merge.
+**Worktree:** `worktrees/wave33-E-coverage`
+**Heartbeat:** `.claude/agent-status/wave33-E.log`
+
+**Files (cap: 0 src; tests as needed; 1 coverage-config edit max):**
+
+### Acceptance
+
+- [ ] **E.1** From `main` (after A, B, C merge), run:
+```
+cd app && npm run test:coverage
+```
+  Capture post-merge branches/lines/functions/statements percentages.
+  Identify the 5–10 lowest-covered branches in actually-meaningful
+  code. Prioritize new code from Wave 33: B's lazy-boundary fallback
+  paths, any conditional logic introduced by C's token swaps, and
+  pre-existing low-coverage modules with reachable branches.
+
+  Verify the coverage-config path: `grep -n "thresholds\|branches:"
+  app/vite.config.ts | head`.
+
+- [ ] **E.2** Add targeted tests. Each `describe` block name must
+      communicate "what does this protect," not the metric served.
+      Forbidden: noop-fixture filler tests; snapshot tests purely to
+      bump line coverage.
+
+  Rerun coverage after each test file lands.
+
+- [ ] **E.3** Conditional floor bump in `app/vite.config.ts`:
+  - if branches ≥ 91.2% → bump `branches` to **91**
+  - else if branches ≥ 90.7% → bump to **90.5**
+  - else → ship tests without floor bump
+
+  Don't lower other thresholds.
+
+- [ ] **E.4** Local gate:
+```
+cd app && npm run typecheck && npm run lint && npm run test:coverage
+```
+  All green at the (possibly bumped) floor.
+
+- [ ] **E.5** Push, PR titled `wave33-E: coverage push`. PR body
+      includes a before/after coverage table and the list of modules
+      from E.1. Then:
+```
+gh pr edit <num> --add-label automerge
+```
+
+## §10 Success criteria
+
+- [ ] `npm-audit` CI step runs green (returns 0 vulns at high+ in
+      prod deps); `docs/SECURITY.md` documents the dev-vs-prod policy.
+- [ ] `npm run check:budget` reports app-shell size meaningfully
+      below 354 KiB; ≥ 10 KiB reclaim achieved (or documented
+      bail-out below the goal); `docs/SYSTEM_DESIGN.md` documents
+      the shell-eligible rule.
+- [ ] Dark-mode regression test runs with allow-list ≤ original
+      three entries (zero entries in clean case; surviving entries
+      have one-line comment justifying intent).
+- [ ] Branch coverage ≥ pre-wave baseline + meaningful gain;
+      conditional floor bump applied per §9.E.3 (or no bump
+      documented).
+- [ ] All four PRs CI-green at merge.
+- [ ] No new audit `kind`s, no CSP / IDB schema bumps, no new
+      third-party deps.

--- a/docs/superpowers/specs/2026-04-27-wave33-design.md
+++ b/docs/superpowers/specs/2026-04-27-wave33-design.md
@@ -1,0 +1,611 @@
+# Wave 33 — Operational hygiene: audit scope, lazy-shell, regression-allowlist, coverage
+
+**Date:** 2026-04-27
+**Status:** Design — pending user approval
+**Predecessors:** Wave 30 (PRs #127–#130), Wave 31 (PRs #131–#133), Wave 32 (PRs #134–#137)
+
+---
+
+## Goal
+
+Clear four accumulated operational papercuts so the next user-facing
+wave starts from a clean baseline:
+
+1. `npm-audit` is failing on every PR with critical vulns flagged in
+   Storybook devDeps that don't ship to users.
+2. App shell bundle pinned at 354 KiB cap; the budget script comment
+   says "next add will be a refactor, not a bump."
+3. Wave 32-B's dark-mode regression test allow-listed three files
+   pending Wave 32-C's audit-id work; C has now landed.
+4. Wave 32-E coverage push was never dispatched (same orphan pattern
+   as Wave 30-E).
+
+Three parallel parts (A/B/C), one rebases-last (E). Letter D skipped
+per Wave 21/29/30/31/32 convention.
+
+## What changed since Wave 32 (context for fresh agents)
+
+Wave 32 (PRs #134 docs + #135–#137 parts) shipped:
+
+- **A** — `.github/workflows/real-model-nightly.yml` schedules the
+  `RUN_REAL_MODEL=1`-gated `tests/e2e/hybrid-golden.spec.ts` daily at
+  06:00 UTC; auto-manages a single `nightly-real-model-broken` issue.
+- **B** — Dark-mode regression sweep. Audit grep returned only one
+  hit (`#ddd` border in `SideLetterPanel.tsx`); permanent regression
+  test added at `app/src/test/dark-mode-regression.test.ts` (pure-Node
+  walker, no execSync). Storybook theme toolbar wired in
+  `app/.storybook/preview.tsx`. Three files allow-listed:
+  `HybridFeedbackButton.tsx`, `HybridPrecisionPanel.tsx`,
+  `FindingsPanel.tsx`. **Wave 33-C tightens this list.**
+- **C** — `findClassifyEntry` helper + audit-entry `entryHash`
+  readout (truncated to 8 chars) in the hybrid-finding disclosure.
+  `AuditEntry` shape verified: no stable `id` field; `entryHash`
+  (SHA-256 hex) is canonical.
+
+Two CI-side fixes also landed mid-wave:
+- **PR #138** — wired Mergify queue action with `auto_merge_enabled`,
+  which turned out not to be a valid Mergify condition in this
+  version; merged with broken config.
+- **PR #139** — replaced with `label=automerge`. Workflow now: add the
+  `automerge` label to a PR (UI or `gh pr edit <num> --add-label
+  automerge`) to route it into the queue, which rebases each PR in
+  sequence before merging.
+
+Wave 32-C's commit also bumped the app shell budget from 352k to 354k
+to absorb the `findClassifyEntry` import. The budget comment now says
+"next add will be a refactor, not a bump" — Wave 33-B addresses this.
+
+The `npm-audit` CI job is currently a noisy false-positive: its 4
+critical vulns trace through `@storybook/addon-actions` → `uuid` (all
+devDep transitives), but the actual deployed PWA bundle (`dist/`) has
+none of those deps. Wave 33-A scopes the audit gate accordingly.
+
+## §1 Scope-shaping decisions (READ BEFORE APPROVING)
+
+1. **Part A is a one-flag patch + a docs paragraph.** Add `--omit=dev`
+   to the existing `npm audit` command in
+   `.github/workflows/security.yml` (or wherever audit runs — verify
+   in A.1). Document the dev-vs-prod vulnerability split in
+   `docs/SECURITY.md`. No app code, no tests. The scoping is
+   defensible because LeaseGuard ships only static `dist/` assets;
+   build-time tooling vulns can't be exploited by an end user.
+2. **Part B is bigger than the others.** Convert ≤ 5 currently-eager
+   panels to `React.lazy` boundaries to reclaim ≥ 10 KiB of app shell
+   budget (354k → ≤ 344k). Codify a "shell-eligible =
+   always-rendered-on-load" rule in `docs/SYSTEM_DESIGN.md`. The
+   reclaim target is a soft goal: if real-world reclaim is 6 KiB,
+   that's still a meaningful win and the documented rule is the
+   bigger contribution. Don't chase the number with risky
+   conversions.
+3. **Part B's candidate set is discovered, not pre-enumerated.** The
+   implementing agent identifies candidates in B.1 by inspecting
+   actual current-bundle composition. Likely candidates include
+   `AnnotationsPanel`, `AuditLogPanel`, `SideLetterPanel`,
+   `RedlinePanel`, `ClauseSimilarityPanel` — but the chosen subset is
+   pinned in the PR description after measuring.
+4. **Part C may be a 3-line PR.** If grep over the three previously-
+   allow-listed files returns zero matches, Part C is just deleting
+   the entries. If matches surface, fix-as-found within the 3-file
+   boundary; keep allow-list entries (with one-line comment
+   explaining intent) only for deliberate visual-design choices like
+   the existing `--color-highlight` annotation pattern.
+5. **Part C does NOT add new semantic tokens.** Wave 32-B already
+   included the rule that adding more than 1–2 new tokens warrants
+   separate design discussion. C honours that.
+6. **Part E rebases last.** Source cap **0**. Conditional floor bump:
+   ≥91.2 → 91, ≥90.7 → 90.5, else no bump. Mirror Wave 31-C
+   discipline: don't bump for the metric's sake.
+7. **No CSP / IDB-schema / new-third-party-dep changes** in Wave 33.
+   Part A may add a `--omit=dev` flag; Part B may convert eager imports
+   to lazy imports (no new package installs); Parts C and E are
+   internal.
+
+## §2 Out of scope
+
+- **Upgrading Storybook** to dodge the audit chain (rejected as
+  Q2.A — risk of API breaks). Part A scopes the audit instead.
+- **Dropping `@storybook/addon-essentials`** entirely (rejected as
+  Q2.C — bigger refactor than this hygiene wave warrants).
+- **`npm overrides` to force `uuid >= 14`** (rejected as Q2.D —
+  brittle, drift-prone). Part A scopes the audit instead.
+- **Restructuring the entire bundle architecture** (rejected as
+  Q3.C-prime). Part B's "shell-eligible rule" is the documented
+  *policy*, not an architectural redesign. The next architecture
+  wave (Phase 20-style) is its own future scoping.
+- **Codifying the lazy rule as an ESLint plugin or build-time check.**
+  Convention + docs only this wave; mechanical enforcement can come
+  later.
+- **Pushing branch coverage past 91% via contrived tests on
+  defensive code.** Wave 31-C discipline applies.
+- Hybrid review queue UI; "jump to audit log" cross-ref;
+  `@xenova/transformers` upstream-bump watch; worker-path classifier;
+  real-model on by default — all parked at Wave 32 §2 status.
+
+## §3 Execution dependency graph
+
+```
+   ┌──────────┐   ┌──────────┐   ┌──────────┐
+   │ Part A   │   │ Part B   │   │ Part C   │
+   │ npm-     │   │ system-  │   │ tighten  │
+   │ audit    │   │ atic     │   │ dark-    │
+   │ scope    │   │ lazy-    │   │ mode     │
+   │ to prod  │   │ load     │   │ allowlist│
+   └────┬─────┘   └────┬─────┘   └────┬─────┘
+        │              │              │
+        └──────────────┴──────┬───────┘
+                              ▼
+                        ┌──────────┐
+                        │ Part E   │
+                        │ coverage │
+                        │ (rebase) │
+                        └──────────┘
+```
+
+A, B, C branch from `origin/main` (`380b7b9` post-Wave-32-C, or
+whatever main becomes when Wave 33 starts) and dispatch in parallel.
+E rebases off post-merge `main` after A, B, C merge.
+
+## §4 File-touch matrix (proposed)
+
+| Part | Branch                              | Src cap | Test cap | Notes |
+|------|-------------------------------------|---------|----------|-------|
+| A    | `wave33-A-audit-prod-only`          | 0 (CI + 1 doc paragraph) | 0     | Edit `.github/workflows/security.yml`; add paragraph to `docs/SECURITY.md`. |
+| B    | `wave33-B-lazy-shell`               | ≤ 5 component conversions + parent call-site edits + 1 doc paragraph | mechanical test edits as needed (sync→async query updates) | Document the shell-eligible rule in `docs/SYSTEM_DESIGN.md`. |
+| C    | `wave33-C-darkmode-allowlist`       | ≤ 3 (only if grep flags non-token classes) | 1 (regression-test allow-list edit) | Fix-as-found applies. |
+| E    | `wave33-E-coverage`                 | 0       | as needed | Conditional floor bump per §1.6. |
+
+The matrix is disjoint by design. A only touches `.github/workflows/`
+and docs. B touches app/src components plus their test files (sync→
+async updates) and one paragraph in `docs/SYSTEM_DESIGN.md`. C touches
+at most three previously-allow-listed UI files and one test file. E is
+tests only plus coverage config.
+
+**Boundary rule (B vs C):** if Part B's chosen candidates include any
+of the three files Part C is tightening (`HybridFeedbackButton.tsx`,
+`HybridPrecisionPanel.tsx`, `FindingsPanel.tsx`), B converts the
+component lazily but does NOT touch its color classes. C still owns
+those. If C finds non-token classes there, C fixes them. Two parallel
+PRs touching the same file is acceptable as long as B owns the
+import-style edit and C owns the className edits.
+
+## §5 Part A — Scope npm audit to runtime deps
+
+**Goal.** Stop `npm-audit` from failing on every PR over devDep
+transitives that never ship.
+
+### A.1 — Pre-implementation verification
+
+1. Find the audit job:
+   ```
+   grep -rn "npm audit" .github/workflows/
+   ```
+   Likely result: `.github/workflows/security.yml` runs
+   `npm audit --audit-level=high` (or similar) in a step. Verify the
+   exact step name and current command. Document in PR description.
+
+2. Run locally to capture the baseline:
+   ```
+   cd app && npm audit --audit-level=high            # current behavior
+   cd app && npm audit --omit=dev --audit-level=high # new behavior
+   ```
+   The new behavior should return 0 vulnerabilities. Document
+   before/after counts in PR description.
+
+3. Find `docs/SECURITY.md` (or equivalent — `grep -rn "security" docs/
+   --include='*.md' -l | head`). The repo has a `SECURITY.md` per the
+   Wave 14-C release / versioning policy and a hardening pipeline per
+   the global skill set. Verify the path; do NOT create a new file.
+
+### A.2 — Patch the workflow
+
+In `.github/workflows/security.yml`, change the npm-audit step:
+
+```yaml
+# Before:
+- name: Audit app (high+ only)
+  run: cd app && npm audit --audit-level=high
+
+# After:
+- name: Audit app (high+ only, prod deps only)
+  run: cd app && npm audit --omit=dev --audit-level=high
+```
+
+Adapt the exact step name to whatever's there. Adjust `cd app && `
+prefix to match the existing form. **Don't touch other steps in
+`security.yml`** (e.g. `gitleaks`, `trivy`, `osv-scanner`); those have
+different scoping requirements.
+
+Commit:
+```
+git add .github/workflows/security.yml
+git commit -m "wave33-A: scope npm audit to prod deps (--omit=dev)"
+```
+
+### A.3 — Document the policy
+
+Add to `docs/SECURITY.md` (or equivalent — verified in A.1) under a new
+short subsection (place near the existing `accept-risk` register if one
+exists; otherwise as a new heading):
+
+> **Dev vs. prod vulnerability scope.** The `npm-audit` CI job runs
+> with `--omit=dev` because LeaseGuard's deployed surface is the
+> static PWA bundle (`dist/`), which contains only runtime deps.
+> Build-time / dev-time deps (Storybook, ESLint, vitest tooling) are
+> NOT bundled and cannot be exploited by an end user. Their
+> vulnerabilities are tracked separately and accepted-with-context in
+> §accept-risk if material. Run `npm audit` (no flag) locally to see
+> all transitives if you're doing a deeper review.
+
+Adapt phrasing to match `SECURITY.md`'s existing voice (e.g. if it
+uses bullet lists or tables for similar policies, mirror that). Keep
+the paragraph short.
+
+Commit:
+```
+git add docs/SECURITY.md
+git commit -m "wave33-A: document dev-vs-prod npm-audit scope"
+```
+
+### A.4 — Acceptance
+
+- [ ] `.github/workflows/security.yml` patched.
+- [ ] `cd app && npm audit --omit=dev --audit-level=high` returns 0
+      locally.
+- [ ] `docs/SECURITY.md` gains the dev-vs-prod paragraph.
+- [ ] First PR run after merge shows green `npm-audit`.
+- [ ] No edits to other steps in `security.yml`.
+
+## §6 Part B — Systematic shell lazy-load
+
+**Goal.** Reclaim ≥ 10 KiB of app shell budget (354 KiB → ≤ 344 KiB)
+by converting interaction-gated panels to `React.lazy` boundaries.
+Document the shell-eligible rule so future PRs don't quietly re-bloat
+the shell.
+
+### B.1 — Identify candidates
+
+Run a clean build:
+```
+cd app && rm -rf dist && npm run build
+ls -lh dist/assets/index-*.js
+```
+
+Capture the current shell size in bytes (multiple chunks may match
+`index-*.js` if Vite splits — focus on the largest, which is the
+"main" shell entry).
+
+Inspect existing lazy chunks for the pattern in use:
+```
+grep -rn "React.lazy\|lazy(() =>" app/src/App app/src/ui --include='*.tsx' | head
+```
+
+Existing lazy boundaries (do NOT re-convert these):
+- `HybridFeedbackButton` — Wave 29-C
+- `HybridPrecisionDisclosure` — Wave 30-A
+
+Identify currently-eager panels rendered conditionally / on
+interaction. Likely candidates (verify each is currently eager):
+- `AnnotationsPanel`
+- `AuditLogPanel`
+- `SideLetterPanel`
+- `RedlinePanel`
+- `ClauseSimilarityPanel`
+
+For each candidate, capture:
+- Current eager import location (where it's `import`ed and rendered).
+- Whether it's gated behind a render-time conditional (e.g.
+  `view === 'redline'`, `<details>` expanded, etc.). If it's NOT
+  gated and ALWAYS rendered, it's not a candidate — skip.
+- Estimated weight contribution to shell (Vite's bundle analyzer
+  output, or a rough `wc -c` on the source plus its imports).
+
+Pin the chosen subset (≤ 5) in the PR description with target weight
+reclaim. **If you can't credibly meet ≥ 10 KiB with ≤ 5 conversions,
+lower the target and document why.** Don't reach.
+
+### B.2 — Convert each chosen panel
+
+Pattern (mirroring the existing `HybridFeedbackButton` boundary in
+`app/src/ui/FindingsPanel.tsx`):
+
+```tsx
+// Before — eager:
+import { AnnotationsPanel } from './ui/AnnotationsPanel';
+
+// After — lazy:
+import { lazy, Suspense } from 'react';
+const AnnotationsPanel = lazy(() =>
+  import('./ui/AnnotationsPanel').then((m) => ({ default: m.AnnotationsPanel })),
+);
+```
+
+At each render site, ensure a `<Suspense>` wraps the lazy component.
+If the component already lives inside a Suspense boundary higher up,
+no new one is needed; otherwise add `<Suspense fallback={null}>`.
+**Do NOT introduce a new fallback pattern** — match what existing
+boundaries use (likely `null` for no flash, or a small skeleton).
+
+Run the project's local gate after each conversion:
+```
+cd app && npm run typecheck && npm run lint && npm test
+```
+
+Mechanical test edits (sync `getByText` → async `findByText` /
+`waitFor`) are expected when a previously-eager component becomes
+async. Update tests within the same conversion commit.
+
+Commit each conversion (or small batch) with a clear message:
+```
+git add app/src/ui/AnnotationsPanel.tsx app/src/<call-site>.tsx \
+        app/src/ui/AnnotationsPanel.test.tsx
+git commit -m "wave33-B: lazy-load AnnotationsPanel"
+```
+
+### B.3 — Document the shell-eligible rule
+
+Add to `docs/SYSTEM_DESIGN.md` under a new short heading (place near
+the existing module-boundaries section):
+
+> **App shell vs. lazy chunks.** Components that are visible the
+> moment the app boots (header, view-mode tabs, the empty-state of
+> the findings list) live in the eager `index-*.js` shell. Components
+> that only render on user interaction (clicking a disclosure,
+> opening a panel, switching to a non-default view) MUST be converted
+> to `React.lazy` boundaries. The shell budget cap
+> (`app/scripts/check-bundle-budget.mjs`) is *not* a number to
+> nudge — it's a contract that says "if you need more, lazy-load
+> instead." Existing examples: `HybridFeedbackButton` (Wave 29-C),
+> `HybridPrecisionDisclosure` (Wave 30-A), and the panels converted
+> in Wave 33-B (see PR description).
+
+Match `SYSTEM_DESIGN.md`'s existing voice and section depth. If the
+file uses subsection headings like `## Architecture`, place this as a
+`### App shell vs. lazy chunks` under the most relevant parent.
+
+Commit:
+```
+git add docs/SYSTEM_DESIGN.md
+git commit -m "wave33-B: document shell-eligible rule"
+```
+
+### B.4 — Verify reclaim and the budget script
+
+Run:
+```
+cd app && rm -rf dist && npm run build && npm run check:budget
+```
+
+Expected: green `[ok] app shell` line with size meaningfully below
+354_000 bytes (the current cap). The cap itself stays at 354_000 in
+this PR — Wave 33-B does NOT bump or lower the cap. The reclaim is
+visible in the size column.
+
+PR description must include:
+
+```
+metric           before    after     delta
+app shell        354.0 KiB <new>     -<X> KiB
+```
+
+If `<X>` < 10 KiB, document the bail-out: which candidates were
+considered, why the reclaim is smaller, and whether the documented
+rule still warrants the wave.
+
+### B.5 — Acceptance
+
+- [ ] B.1 enumerates candidates with current shell-bound status; chosen
+      subset (≤ 5) pinned in PR description.
+- [ ] Each chosen candidate is now lazy via `React.lazy` + `Suspense`.
+- [ ] No new `Suspense` fallback pattern introduced; existing pattern
+      reused.
+- [ ] `docs/SYSTEM_DESIGN.md` gains the shell-eligible paragraph.
+- [ ] `npm run check:budget` passes; PR shows ≥ 10 KiB reclaim (or
+      documented bail-out below the goal).
+- [ ] All tests still green; any test edits are mechanical
+      (sync→async query).
+- [ ] No new third-party deps; no IDB schema bumps; no CSP changes.
+
+## §7 Part C — Tighten dark-mode regression allowlist
+
+**Goal.** Wave 32-B's regression test allow-listed
+`HybridFeedbackButton.tsx`, `HybridPrecisionPanel.tsx`,
+`FindingsPanel.tsx` pending Wave 32-C. C has landed. Time to remove
+the entries.
+
+### C.1 — Verify current state
+
+From the worktree root:
+
+```
+grep -En '\b(bg|text|border|ring|outline|fill|stroke|from|to|via)-(amber|stone|zinc|slate|neutral|gray|red|orange|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|white|black)(-\d+)?(/\d+)?\b' \
+  app/src/ui/HybridFeedbackButton.tsx \
+  app/src/ui/HybridPrecisionPanel.tsx \
+  app/src/ui/FindingsPanel.tsx
+```
+
+Tabulate any matches per file. Document the result in the PR
+description.
+
+Also scan call sites of these files for color-prop drift:
+```
+grep -rn "FindingsPanel\|HybridFeedbackButton\|HybridPrecisionPanel" \
+  app/src --include='*.tsx' | grep -E 'className=.*"' | head
+```
+
+If a parent passes a `className` prop that contains a non-token color
+(e.g. `<FindingsPanel className="bg-amber-50" />`), fixing it requires
+touching the parent — that's drift. **If drift exists, halt and
+report**; the implementing agent does NOT silently expand scope.
+
+### C.2 — Two outcomes
+
+**Clean case (zero matches in C.1):**
+Edit `app/src/test/dark-mode-regression.test.ts` and remove all three
+entries from `ALLOW_LIST_PATHS`:
+
+```ts
+const ALLOW_LIST_PATHS: ReadonlyArray<string> = [];
+```
+
+Run the test:
+```
+cd app && npx vitest run src/test/dark-mode-regression.test.ts
+```
+Expected: PASS.
+
+Commit:
+```
+git add app/src/test/dark-mode-regression.test.ts
+git commit -m "wave33-C: remove dark-mode regression allow-list entries (verified clean)"
+```
+
+**Dirty case (matches found in C.1):**
+For each match, apply the standard token mappings from Wave 32-B's
+table:
+
+| Hard-coded | Replace with |
+|-----------|--------------|
+| `bg-white`, `bg-amber-50`, `bg-stone-50`, `bg-stone-100` | `bg-paper` or `bg-paper-raised` |
+| `bg-stone-200`, `bg-zinc-100`, `bg-amber-100` | `bg-paper-sunken` |
+| `text-black`, `text-zinc-900`, `text-stone-900` | `text-fg` |
+| `text-zinc-700`, `text-stone-700` | `text-fg-body` |
+| `text-zinc-500`, `text-stone-500`, `text-zinc-600` | `text-fg-muted` |
+| `text-zinc-400`, `text-stone-400` | `text-fg-faint` |
+| `border-zinc-200`, `border-stone-200`, `border-amber-200` | `border-rule` or `border-rule-subtle` |
+| `text-blue-*`, `bg-blue-*` (accent) | `text-ink`, `bg-ink` |
+| `bg-red-*`, `text-red-*` (severity-high) | `text-severity-high`, `bg-severity-bg-error` |
+| `bg-amber-*`, `text-amber-*` (severity-medium) | `text-severity-medium`, `bg-severity-bg-warn` |
+
+If a match is intentionally a hardcoded color (e.g. an evidence
+overlay using a deliberate annotation contrast like the existing
+`--color-highlight: rgba(255, 235, 59, 0.35)` token), keep that file
+in the allow-list with a one-line comment in the test file
+documenting why:
+
+```ts
+const ALLOW_LIST_PATHS: ReadonlyArray<string> = [
+  // Intentional: the hybrid-finding evidence overlay uses bg-yellow-300/30
+  // as a deliberate annotation contrast (see file:line). Not a theme color.
+  'src/ui/FindingsPanel.tsx',
+];
+```
+
+Be honest: only files with deliberate non-token colors stay
+allow-listed. Drive the rest to zero.
+
+Commit each fix as you go:
+```
+git add app/src/ui/<File>.tsx
+git commit -m "wave33-C: swap palette classes to semantic tokens in <File>"
+```
+
+After all fixes, re-run the test. Final commit deletes the now-empty
+or comment-narrowed allow-list entries.
+
+### C.3 — Fix-as-found rule
+
+While editing any of the three files, fix-as-found from Wave 32-B
+applies: any *other* hard-coded color you spot gets the same token
+swap. Don't punt.
+
+### C.4 — Acceptance
+
+- [ ] C.1 grep run; output documented in PR description (zero matches
+      OR per-file match count).
+- [ ] Test allow-list updated: zero entries (clean case) OR remaining
+      entries each have a one-line comment explaining intent (dirty
+      case).
+- [ ] `dark-mode-regression.test.ts` passes locally.
+- [ ] No drift outside the 3-file boundary; if call-site drift was
+      detected in C.1, the part halted and was reported instead.
+- [ ] No new semantic tokens added.
+- [ ] Local gate green.
+
+## §8 Part E — Coverage push (rebases last)
+
+**Goal.** Continue Wave 31-C / 32-E pattern. Branches off `main`
+AFTER A, B, C merge.
+
+### E.1 — Pre-flight
+
+```
+cd app && npm run test:coverage
+```
+
+Capture post-merge baseline (branches, lines, functions, statements).
+Open `app/coverage/lcov-report/index.html` and identify 5–10
+lowest-covered branches in actually-meaningful code. Prioritize:
+- New code from B's lazy boundaries (Suspense fallback paths,
+  error boundaries if any).
+- Any new logic from C's token-swap fixes.
+- Pre-existing low-coverage modules with reachable, meaningful
+  branches.
+
+Verify the coverage-config path in `app/vite.config.ts` (or
+`vitest.config.*`).
+
+### E.2 — Targeted tests
+
+Forbidden:
+- Coverage-filler tests that pass noop fixtures through a function
+  just to hit a branch.
+- Snapshot tests added purely to bump line coverage.
+
+Each test must protect a real behavior; coverage gain is a side
+effect. Each `describe` block name communicates "what does this
+protect," not the metric served.
+
+### E.3 — Conditional floor bump
+
+In `app/vite.config.ts`:
+- if branches ≥ 91.2% → bump `branches` floor to **91**
+- else if branches ≥ 90.7% → bump to **90.5**
+- else → no floor bump; ship targeted tests as-is
+
+Mirror Wave 31-C's discipline. If the gap is genuinely all defensive
+code, no bump is the right call.
+
+### E.4 — Acceptance
+
+- [ ] No `src/` edits.
+- [ ] All new tests have a "what does this protect" reason in their
+      describe-block name.
+- [ ] PR description shows before/after coverage table.
+- [ ] If floor bumped, the bump is in the same PR.
+
+## §9 Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| `--omit=dev` hides a vuln in a dep that's both runtime and dev | A.1 captures before/after counts; deltas should be limited to known Storybook chain |
+| Part B reclaim falls short of 10 KiB | B.5 explicit bail-out documented; lower target rather than reach |
+| Suspense placement causes test regressions | B.2 expects mechanical sync→async edits; existing Wave 30-A pattern as template |
+| Part C exposes call-site color-prop drift | C.1 explicitly halts on drift; agent reports rather than expanding scope |
+| Coverage push diminishing returns | E.3 explicitly allows "no bump" if gap is defensive |
+| B and C concurrent edits to same file (FindingsPanel) | §4 boundary rule: B owns import-style edits; C owns className edits; both can land in parallel |
+
+## §10 Tech stack
+
+React 18 + TypeScript (`strict`, `noUncheckedIndexedAccess`,
+`noImplicitOverride`), Vite, Vitest + RTL +
+`@testing-library/user-event`, Tailwind v4, Storybook 8, Playwright,
+Lighthouse CI (a11y ≥ 95). CSP-strict — no new network egress, no new
+third-party deps, no IDB schema bumps.
+
+## §11 Dispatch instructions
+
+For agentic workers: use `superpowers:subagent-driven-development`
+(or the project's `/wave` skill) to dispatch Parts A, B, C in
+parallel against `origin/main`. Each subagent gets a worktree under
+`<project>/worktrees/<branch>` per the global CLAUDE.md Worktree
+convention. Each subagent appends a heartbeat to
+`.claude/agent-status/<id>.log` every ~5 minutes per the
+`subagent-heartbeat` skill.
+
+After A, B, C merge: dispatch E as a single direct task against
+post-merge `main`.
+
+Mergify queue is now functional (per Wave 32 PR #139): add the
+`automerge` label after opening each PR (`gh pr edit <num>
+--add-label automerge`) to route through the queue. Native
+`gh pr merge --auto --squash` still works as a parallel fallback.


### PR DESCRIPTION
## Summary

Adds Wave 33 design spec + implementation plan. Pure docs; no app code.

- \`docs/superpowers/specs/2026-04-27-wave33-design.md\`
- \`docs/plans/wave33-hygiene-audit-lazy-allowlist-coverage.md\`

Four-part hygiene wave (A/B/C parallel, E rebases last):

- **A** — scope npm-audit to prod deps via \`--omit=dev\`
- **B** — convert ≤5 interaction-gated panels to \`React.lazy\` (≥10 KiB shell reclaim, soft target); document shell-eligible rule
- **C** — tighten dark-mode regression allowlist now Wave 32-C landed
- **E** — coverage push, rebases last

## Test plan

- [x] No app code changed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)