### PR TITLE
wave33-C: tighten dark-mode regression allow-list

### DIFF
--- a/app/src/test/dark-mode-regression.test.ts
+++ b/app/src/test/dark-mode-regression.test.ts
@@ -18,15 +18,9 @@ import { join, relative, resolve, sep } from 'node:path';
 const FORBIDDEN =
   /\b(bg|text|border|ring|outline|fill|stroke|from|to|via)-(amber|stone|zinc|slate|neutral|gray|red|orange|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|white|black)(-\d+)?(\/\d+)?\b/;
 
-// Hybrid-finding disclosure surface — owned by Wave 32 Part C; this
-// regression intentionally skips those files so Part C's wave can edit
-// them without tripping. Tighten via a follow-up once C lands and any
-// remaining hard-coded classes there are cleaned up.
-const ALLOW_LIST_PATHS: ReadonlyArray<string> = [
-  'src/ui/HybridFeedbackButton.tsx',
-  'src/ui/HybridPrecisionPanel.tsx',
-  'src/ui/FindingsPanel.tsx',
-];
+// Wave 33-C verified all three previously-allow-listed files are clean
+// (zero hard-coded palette classes). Allow-list emptied.
+const ALLOW_LIST_PATHS: ReadonlyArray<string> = [];
 
 function* walk(dir: string): Generator<string> {
   for (const entry of readdirSync(dir)) {


### PR DESCRIPTION
## Summary

Wave 32-B's regression test allow-listed three files pending Wave
32-C's audit-id work. C landed at \`380b7b9\`. This PR removes the
allow-list entries — verified clean.

## C.1 verification

```bash
grep -En '\b(bg|text|border|...)-(amber|stone|...)\b' \
  app/src/ui/HybridFeedbackButton.tsx \
  app/src/ui/HybridPrecisionPanel.tsx \
  app/src/ui/FindingsPanel.tsx
# → 0 matches

grep -rEn 'FindingsPanel|HybridFeedbackButton|HybridPrecisionPanel' \
  app/src --include='*.tsx' | grep -E 'className=.*"'
# → 0 call-site color-prop drift
```

All three files are clean. No fix-as-found edits required.

## Files

- **MOD** \`app/src/test/dark-mode-regression.test.ts\` — empty
  \`ALLOW_LIST_PATHS\`; refresh comment.

## Test plan

- [x] \`npx vitest run src/test/dark-mode-regression.test.ts\` — passes
- [x] typecheck + lint clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)