### PR TITLE
wave33-B: lazy-load AppRedlinePane + AuditLogPanel; document shell-eligible rule

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useState } from 'react';
 import { usePipeline } from './App/usePipeline';
 import { usePackManager } from './App/usePackManager';
 import { useAnnotations } from './App/useAnnotations';
@@ -37,7 +37,14 @@ import {
 import { buildAuditLogJson, downloadAuditLogBlob } from './audit/auditExport';
 import { PortfolioPanel } from './ui/PortfolioPanel';
 import { paragraphShingles } from './portfolio/shingles';
-import { AppRedlinePane } from './ui/AppRedlinePane';
+// Wave 33-B — AppRedlinePane and its three child panels (RedlinePanel,
+// VersionHistoryPanel, SideLetterPanel) only render when the user switches
+// to the redline view tab. Lazy-loading lets the shell skip ~the entire
+// redline subsystem on first paint. Pattern matches HybridFeedbackButton
+// (Wave 29-C) and HybridPrecisionDisclosure (Wave 30-A).
+const AppRedlinePane = lazy(() =>
+  import('./ui/AppRedlinePane').then((m) => ({ default: m.AppRedlinePane })),
+);
 import { discoverOcrLanguages, type OcrLanguage } from './ocr/availableLanguages';
 import type { Finding } from './rules/types';
 import type { ClauseTemplate } from './templates/types';
@@ -376,15 +383,17 @@ function AppContent(): JSX.Element {
         hidden={view !== 'redline'}
       >
         {view === 'redline' && status.kind === 'analyzed' && (
-          <AppRedlinePane
-            doc={status.result.doc}
-            leaseName={status.fileName}
-            redline={redline}
-            versionHistory={versionHistory}
-            sideLetter={sideLetter}
-            sectionForParagraph={sectionForParagraph}
-            safeAudit={safeAudit}
-          />
+          <Suspense fallback={null}>
+            <AppRedlinePane
+              doc={status.result.doc}
+              leaseName={status.fileName}
+              redline={redline}
+              versionHistory={versionHistory}
+              sideLetter={sideLetter}
+              sectionForParagraph={sectionForParagraph}
+              safeAudit={safeAudit}
+            />
+          </Suspense>
         )}
       </div>
 

--- a/app/src/ui/AppLibraryAndPacksPane.test.tsx
+++ b/app/src/ui/AppLibraryAndPacksPane.test.tsx
@@ -99,14 +99,16 @@ describe('AppLibraryAndPacksPane', () => {
     expandAllSectionsViaStorage();
   });
 
-  it('renders the library / templates / pack-manager / audit-log panels', () => {
+  it('renders the library / templates / pack-manager / audit-log panels', async () => {
     defaults();
     expect(screen.getByRole('heading', { name: /my leases/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /diff rule pack/i })).toBeInTheDocument();
     // Wave 28 Part C: SectionGroup wrappers also expose role="region";
     // AuditLogPanel renders its own region with the same accessible name,
-    // so we assert at least one match.
-    expect(screen.getAllByRole('region', { name: /audit log/i }).length).toBeGreaterThanOrEqual(1);
+    // so we assert at least one match. Wave 33-B made AuditLogPanel lazy,
+    // so the audit-log region resolves async on first paint.
+    const regions = await screen.findAllByRole('region', { name: /audit log/i });
+    expect(regions.length).toBeGreaterThanOrEqual(1);
   });
 
   it('hides the ComparePanel when comparison is null', () => {
@@ -117,7 +119,10 @@ describe('AppLibraryAndPacksPane', () => {
   it('fires onRefreshAuditLog when the audit-log refresh button is clicked', async () => {
     const onRefreshAuditLog = vi.fn();
     defaults({ onRefreshAuditLog });
-    await userEvent.click(screen.getByRole('button', { name: /^refresh$/i }));
+    // Wave 33-B: AuditLogPanel is lazy; await its render before
+    // querying its refresh button.
+    const refreshBtn = await screen.findByRole('button', { name: /^refresh$/i });
+    await userEvent.click(refreshBtn);
     expect(onRefreshAuditLog).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/src/ui/AppLibraryAndPacksPane.tsx
+++ b/app/src/ui/AppLibraryAndPacksPane.tsx
@@ -37,7 +37,12 @@ import { JurisdictionPickerPanel } from './JurisdictionPickerPanel';
 import { SeverityOverridesPanel } from './SeverityOverridesPanel';
 import { PackDiffPanel } from './PackDiffPanel';
 import { BulkImportPanel } from './BulkImportPanel';
-import { AuditLogPanel } from './AuditLogPanel';
+// Wave 33-B — AuditLogPanel renders inside the `governance` SectionGroup
+// which is `defaultOpen: false`. Lazy-load to keep the audit-log code
+// path (and its dependencies) out of the eager shell.
+const AuditLogPanel = lazy(() =>
+  import('./AuditLogPanel').then((m) => ({ default: m.AuditLogPanel })),
+);
 import { SigningKeyPanel } from './SigningKeyPanel';
 import { ComparePanel } from './ComparePanel';
 import { Section } from './system/Section';
@@ -232,13 +237,15 @@ export function AppLibraryAndPacksPane({
             overrides={severityOverridesPanelMap}
             onChange={severityOverridesPanelOnChange}
           />
-          <AuditLogPanel
-            entries={auditEntries}
-            verification={auditVerification}
-            onRefresh={onRefreshAuditLog}
-            onVerify={onVerifyAuditChain}
-            onDownload={() => onDownloadAuditLog(auditEntries, auditVerification)}
-          />
+          <Suspense fallback={null}>
+            <AuditLogPanel
+              entries={auditEntries}
+              verification={auditVerification}
+              onRefresh={onRefreshAuditLog}
+              onVerify={onVerifyAuditChain}
+              onDownload={() => onDownloadAuditLog(auditEntries, auditVerification)}
+            />
+          </Suspense>
           <SigningKeyPanel
             state={{ publicKey: signingKey.publicKey }}
             onCreateKey={(pp) => void signingKey.createKey(pp)}

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -290,6 +290,19 @@ table for the authoritative figures):
   picker is hidden and OCR runs in `eng` by default; when it lists a
   single entry the UI renders a static label rather than a dropdown.
 
+### App shell vs. lazy chunks
+
+Components that are visible the moment the app boots (header,
+view-mode tabs, the empty-state of the findings list) live in the
+eager `index-*.js` shell. Components that only render on user
+interaction (clicking a disclosure, opening a panel, switching to a
+non-default view) MUST be converted to `React.lazy` boundaries. The
+shell budget cap (`app/scripts/check-bundle-budget.mjs`) is *not* a
+number to nudge — it's a contract that says "if you need more,
+lazy-load instead." Existing examples: `HybridFeedbackButton`
+(Wave 29-C), `HybridPrecisionDisclosure` (Wave 30-A), `AppRedlinePane`
++ `AuditLogPanel` (Wave 33-B).
+
 ## Privacy contract
 
 - Strict CSP in `index.html`: `default-src 'self'; script-src 'self';


### PR DESCRIPTION
## Summary

App shell budget was sitting at 354 KiB cap (per the budget script's
warning that "next add will be a refactor, not a bump"). Two
conversions reclaim **11.0 KiB**:

| metric    | before     | after      | delta      |
|-----------|------------|------------|------------|
| app shell | 343.8 KiB  | 332.8 KiB  | **−11.0 KiB** |
| (bytes)   | 352,071    | 340,792    | −11,279    |

Plus codifies the "shell-eligible = always-rendered-on-load" rule in
\`docs/SYSTEM_DESIGN.md\` so future PRs stop nudging the budget cap.

## B.1 candidate analysis

| Candidate | Eager? | Conditional gate | Decision |
|-----------|--------|------------------|----------|
| \`AppRedlinePane\` (incl. RedlinePanel + VersionHistoryPanel + SideLetterPanel) | yes | \`view === 'redline' && status.kind === 'analyzed'\` | **convert** |
| \`AuditLogPanel\` | yes | rendered inside \`governance\` SectionGroup, \`defaultOpen: false\` | **convert** |
| \`AppCurrentPane\` | yes | \`view === 'current' && status.kind === 'analyzed'\` (default view; renders on first lease) | skip — first-paint surface for typical user |
| \`ClauseSimilarityPanel\` | n/a | not imported in shell | skip |

## Chosen 2 conversions

- \`app/src/App.tsx\` — \`AppRedlinePane\` becomes lazy. Wrapped its
  conditional render in \`<Suspense fallback={null}>\`. Bundles to
  \`AppRedlinePane-B2thY9aa.js\` (9171 bytes) plus the existing
  \`sideLetterPdf-jWID7-Cu.js\` (430k, was already lazy).
- \`app/src/ui/AppLibraryAndPacksPane.tsx\` — \`AuditLogPanel\` becomes
  lazy. Bundles to \`AuditLogPanel-BgWS4sE2.js\` (2594 bytes).

## Test changes (mechanical)

\`app/src/ui/AppLibraryAndPacksPane.test.tsx\` — two queries converted
from sync \`getByRole\` → async \`findByRole\` because the
audit-log region/button now resolves async on first paint.

## Files

- **MOD** \`app/src/App.tsx\` — lazy import + Suspense for AppRedlinePane.
- **MOD** \`app/src/ui/AppLibraryAndPacksPane.tsx\` — lazy import + Suspense for AuditLogPanel.
- **MOD** \`app/src/ui/AppLibraryAndPacksPane.test.tsx\` — sync→async queries.
- **MOD** \`docs/SYSTEM_DESIGN.md\` — new "App shell vs. lazy chunks" section under Bundle layout.

\`app/scripts/check-bundle-budget.mjs\` cap unchanged (354_000); reclaim
visible in the size column.

## Test plan

- [x] \`npm run typecheck\` green
- [x] \`npm run lint\` green
- [x] \`npm test\` green (179 files / 1400 passed)
- [x] \`npm run check:budget\` green; shell at 332.8 KiB (well under 354 cap)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)