### PR TITLE
wave33-A: scope npm-audit to prod deps; custom accept-risk filter

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,11 +24,16 @@ jobs:
             app/package-lock.json
       - name: Install root deps
         run: npm ci
-      - name: Audit root (high+ only)
-        run: npm audit --audit-level=high
+      - name: Audit root (high+ only, prod deps only)
+        run: npm audit --omit=dev --audit-level=high
       - name: Install app deps
         working-directory: app
         run: npm ci
-      - name: Audit app (high+ only)
+      # Wave 33-A — app-side audit goes through scripts/audit-prod.mjs,
+      # which scopes to prod deps and filters advisories explicitly listed
+      # in ALLOW_ADVISORIES. Each allowlisted advisory MUST have a
+      # corresponding §accept-risk note in docs/SECURITY.md. Anything else
+      # at high+ severity fails the gate.
+      - name: Audit app (high+ only, prod deps, accept-risk filter)
         working-directory: app
-        run: npm audit --audit-level=high
+        run: npm run audit:prod

--- a/app/package.json
+++ b/app/package.json
@@ -23,6 +23,7 @@
     "postinstall": "node scripts/build-tesseract-assets.mjs",
     "check:budget": "node scripts/check-bundle-budget.mjs",
     "check:csp": "node scripts/check-csp.mjs",
+    "audit:prod": "node scripts/audit-prod.mjs",
     "lhci": "lhci autorun",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/app/scripts/audit-prod.mjs
+++ b/app/scripts/audit-prod.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Wave 33-A — prod-deps-only audit gate with accept-risk filter.
+//
+// Runs `npm audit --json --omit=dev` and exits 0 iff every remaining
+// vulnerability at high+ severity traces back to an advisory in
+// ALLOW_ADVISORIES. Any new vulnerability not in the allowlist causes
+// a non-zero exit.
+//
+// Allowlist entries must each be documented in docs/SECURITY.md under
+// the accept-risk section with a rationale. Adding to ALLOW_ADVISORIES
+// without doc is a process violation — the doc is the audit trail.
+
+import { spawnSync } from 'node:child_process';
+
+/** Advisory URLs for vulnerabilities the project has accepted with rationale.
+ *  Each entry MUST have a corresponding §accept-risk note in docs/SECURITY.md. */
+const ALLOW_ADVISORIES = new Set([
+  // protobufjs <7.5.5 — arbitrary code execution. Transitive only,
+  // reached via @xenova/transformers → onnxruntime-web → onnx-proto →
+  // protobufjs. @xenova/transformers v2 is end-of-life upstream
+  // (no fix forthcoming on that line). Migration to the successor
+  // package @huggingface/transformers v4 is tracked as a future
+  // Phase 19 wave with its own brainstorm — out of scope for hygiene
+  // work. See docs/SECURITY.md §accept-risk for the standing
+  // rationale.
+  'https://github.com/advisories/GHSA-xq3m-2v4x-88gg',
+]);
+
+function collectRootUrls(name, vulns, seen) {
+  const result = new Set();
+  if (seen.has(name)) return result;
+  seen.add(name);
+  const entry = vulns[name];
+  if (!entry) return result;
+  for (const via of entry.via ?? []) {
+    if (typeof via === 'string') {
+      for (const url of collectRootUrls(via, vulns, seen)) result.add(url);
+    } else if (via && typeof via.url === 'string') {
+      result.add(via.url);
+    }
+  }
+  return result;
+}
+
+function main() {
+  const audit = spawnSync(
+    'npm',
+    ['audit', '--json', '--omit=dev', '--audit-level=high'],
+    { encoding: 'utf8' },
+  );
+
+  // npm audit exits non-zero when it finds vulns; we still want to parse stdout.
+  let report;
+  try {
+    report = JSON.parse(audit.stdout);
+  } catch (err) {
+    console.error('audit-prod: failed to parse `npm audit --json` output');
+    console.error(audit.stdout);
+    console.error(audit.stderr);
+    process.exit(2);
+  }
+
+  const vulns = report.vulnerabilities ?? {};
+  const offenders = [];
+
+  for (const [name, entry] of Object.entries(vulns)) {
+    if (entry.severity !== 'critical' && entry.severity !== 'high') continue;
+    const rootUrls = collectRootUrls(name, vulns, new Set());
+    if (rootUrls.size === 0) {
+      offenders.push({ name, severity: entry.severity, roots: ['(unknown)'] });
+      continue;
+    }
+    const allAllowed = [...rootUrls].every((url) => ALLOW_ADVISORIES.has(url));
+    if (!allAllowed) {
+      offenders.push({ name, severity: entry.severity, roots: [...rootUrls] });
+    }
+  }
+
+  if (offenders.length === 0) {
+    console.log('audit-prod: 0 unallowlisted vulnerabilities at high+ severity (prod deps).');
+    process.exit(0);
+  }
+
+  console.error('audit-prod: unallowlisted vulnerabilities at high+ severity:');
+  for (const o of offenders) {
+    console.error(`  - ${o.name} (${o.severity}) — root advisory: ${o.roots.join(', ')}`);
+  }
+  console.error('');
+  console.error('Either fix the dep, or — if the vuln is genuinely accept-risk —');
+  console.error('add the advisory URL to ALLOW_ADVISORIES in this script AND');
+  console.error('document the rationale in docs/SECURITY.md §accept-risk.');
+  process.exit(1);
+}
+
+main();

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -367,6 +367,25 @@ the breaking-change "fix" the auditor proposes. Each entry below
 includes the advisory, what we use the affected code for, why the
 fix is worse than the risk, and the trigger that flips the decision.
 
+### Dev vs. prod scope (Wave 33-A)
+
+The CI gate is **`cd app && npm run audit:prod`** (see
+`.github/workflows/security.yml`), which wraps `npm audit --json
+--omit=dev --audit-level=high` and filters the documented accept-risk
+advisory URLs in `app/scripts/audit-prod.mjs` `ALLOW_ADVISORIES`. Two
+contracts:
+
+- **Scope is prod deps only.** `--omit=dev` excludes Storybook,
+  ESLint, vitest tooling — none of which ship in `dist/`. Their
+  vulnerabilities don't reach end users and aren't gated.
+- **Allowlist is the audit trail.** Every URL in `ALLOW_ADVISORIES`
+  must have a §7.x note here with rationale + trigger. Adding to the
+  allowlist without updating this doc is a process violation.
+
+Run the unfiltered audit locally (`cd app && npm audit`) to see
+everything (including dev-only chains in §7.2 / §7.3) when doing a
+deeper review.
+
 Re-run `cd app && npm audit` quarterly (and on every Wave-N start)
 to verify nothing new has crept in.
 
@@ -391,6 +410,17 @@ class we use. Effectively a Phase 18 rollback.
 **Decision (2026-04-26, Wave 26-B):** accept. Re-evaluate when
 `@xenova/transformers` ships an upstream release with `protobufjs
 >= 7.5.5`. Recheck quarterly.
+
+**Update (Wave 33-A, 2026-04-27):** investigation confirmed
+`@xenova/transformers@2.17.2` is the end of that line — the package
+moved to `@huggingface/transformers@4.x` (different package, v2→v4
+breaking-change migration). Migration is its own future Phase 19
+wave with explicit brainstorm; not folded into hygiene work. Until
+that lands, `audit:prod` filters
+[GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg)
+via `app/scripts/audit-prod.mjs` `ALLOW_ADVISORIES`. Any *new*
+high+ advisory that doesn't trace back to that ID still fails the
+gate.
 
 ### 7.2 `esbuild <=0.24.2` — dev-server cross-origin reads
 


### PR DESCRIPTION
## Summary

Closes the noisy-CI papercut where every PR ran red on \`npm-audit\`.
Investigation revealed the spec assumption (\`--omit=dev\` alone fixes
it) was wrong: 4 critical vulns trace through the **runtime**
\`@xenova/transformers\` → \`onnxruntime-web\` → \`onnx-proto\` →
\`protobufjs\` chain, root advisory
[GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg).
That advisory has been documented accept-risk in \`SECURITY.md\` §7.1
since Wave 26-B.

Further investigation: \`@xenova/transformers@2.17.2\` is the end of
that line; the package line moved to \`@huggingface/transformers@4.x\`
(different package, v2→v4 breaking changes). Migration is a future
Phase 19 wave with its own brainstorm — not appropriate to fold into
hygiene work.

This PR replaces the raw \`npm audit\` step with a small filter
script that scopes to prod deps AND filters the documented accept-
risk advisory. New advisories still fail the gate.

## How the filter works

\`app/scripts/audit-prod.mjs\`:
1. Runs \`npm audit --json --omit=dev --audit-level=high\`.
2. Walks each vuln's \`via\` chain to resolve its root advisory URL(s).
3. Exits 0 only if every root URL is in \`ALLOW_ADVISORIES\`.
4. Exits non-zero otherwise, listing the offenders for triage.

\`ALLOW_ADVISORIES\` currently has one entry: GHSA-xq3m-2v4x-88gg.
Each entry MUST have a §7.x note in SECURITY.md (this is the audit
trail; adding to the allowlist without updating the doc is a process
violation, called out in the script and in §7).

## Files

- **NEW** \`app/scripts/audit-prod.mjs\` — the filter script (~80 LOC).
- **MOD** \`app/package.json\` — \`audit:prod\` script entry.
- **MOD** \`.github/workflows/security.yml\` — root step adds
  \`--omit=dev\`; app step calls \`npm run audit:prod\`.
- **MOD** \`docs/SECURITY.md\` — §7 gains a "Dev vs. prod scope"
  subsection; §7.1 updated with the upstream-EOL finding and pointer
  to the new gate.

## Verification

\`\`\`
$ cd app && npm audit --omit=dev --audit-level=high   # raw, before:
4 critical severity vulnerabilities

$ cd app && npm run audit:prod                          # via filter, after:
audit-prod: 0 unallowlisted vulnerabilities at high+ severity (prod deps).
exit 0
\`\`\`

If a NEW vuln were to land outside the allowlist, the script would
list it and fail with exit 1 — verified via inline reasoning of the
\`collectRootUrls\` walk + \`ALLOW_ADVISORIES.has\` check (small
script; behavior is straightforward).

## Test plan

- [x] \`npm run audit:prod\` exits 0 locally
- [x] Root \`npm audit --omit=dev\` exits 0 locally
- [x] \`npm run typecheck\` green
- [x] \`npm run lint\` green
- [ ] CI \`npm-audit\` job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)