### PR TITLE
wave34-A: branch-coverage push (W33-E carry-over) — no-bump

### DIFF
--- a/app/src/versioning/deltaPacket.test.ts
+++ b/app/src/versioning/deltaPacket.test.ts
@@ -22,7 +22,7 @@ import { describe, it, expect } from 'vitest';
 //   }): Promise<DeltaPacket>
 //
 //   verifyDeltaPacket(packet: DeltaPacket): Promise<{ ok: boolean }>
-import { buildDeltaPacket, verifyDeltaPacket } from './deltaPacket';
+import { applyLineDiff, buildDeltaPacket, verifyDeltaPacket } from './deltaPacket';
 
 async function genKey(): Promise<CryptoKeyPair> {
   return (await crypto.subtle.generateKey(
@@ -70,6 +70,31 @@ describe('deltaPacket', () => {
     });
     const r = await verifyDeltaPacket(packet);
     expect(r.ok).toBe(true);
+  });
+
+  it('verifyDeltaPacket returns ok:false on a malformed signature (catch path)', async () => {
+    // The catch branch fires when fromBase64 / importKey blow up before
+    // the actual verify call — distinct from a "verify returned false"
+    // path. Hand it a packet with a non-base64 signature.
+    const key = await genKey();
+    const packet = await buildDeltaPacket({
+      baseBytes: bytes('a'),
+      targetBytes: bytes('b'),
+      rulePackVersion: '1.0.0',
+      signingKey: key,
+      signedByKeyId: 'key-1',
+    });
+    const malformed = { ...packet, signature: 'not-valid-base64-!!!' };
+    const r = await verifyDeltaPacket(malformed);
+    expect(r.ok).toBe(false);
+  });
+
+  it('applyLineDiff throws when the patch does not consume the full base', () => {
+    // Construct a patch that only matches the first line — bi never
+    // advances to baseLines.length, so the trailing guard fires.
+    const baseText = 'line one\nline two\n';
+    const shortPatch = ' line one\n'; // only consumes one base line
+    expect(() => applyLineDiff(baseText, shortPatch)).toThrow(/did not consume full base/);
   });
 
   it('tampering with changes invalidates the signature', async () => {

--- a/app/src/worker/leaseWorkerClient.test.ts
+++ b/app/src/worker/leaseWorkerClient.test.ts
@@ -169,4 +169,56 @@ describe('createLeaseWorkerClient', () => {
     expect(out.doc.pages.length).toBeGreaterThan(0);
     client.terminate();
   });
+
+  it('uses createWorkerPipelineClient when globalThis.Worker is available', async () => {
+    // Stub a Worker constructor that hands every postMessage to the real
+    // request handler — proves the auto-select takes the worker branch
+    // (not the inline fallback) when `typeof Worker !== 'undefined'`.
+    const constructed = vi.fn();
+    class FakeWorker {
+      onmessage: ((ev: MessageEvent<WorkerResponse>) => void) | null = null;
+      onerror: ((ev: { message?: string }) => void) | null = null;
+      constructor() {
+        constructed();
+      }
+      postMessage(message: unknown): void {
+        const req = message as WorkerRequest;
+        void handleWorkerRequest(req).then((resp) => {
+          this.onmessage?.({ data: resp } as MessageEvent<WorkerResponse>);
+        });
+      }
+      terminate(): void {}
+    }
+    vi.stubGlobal('Worker', FakeWorker);
+    try {
+      const client = createLeaseWorkerClient();
+      const out = await client.parseAndAnalyze(await makeBytes(), RULE_PACK_V1);
+      expect(constructed).toHaveBeenCalledTimes(1);
+      expect(out.doc.pages.length).toBeGreaterThan(0);
+      client.terminate();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('falls back to inline pipeline when the Worker constructor throws', async () => {
+    // Some browsers (older Safari, Tauri edge cases) throw when
+    // constructing a module worker. The auto-selector must catch and
+    // still return a working client.
+    class ThrowingWorker {
+      constructor() {
+        throw new Error('module worker construction not supported');
+      }
+    }
+    vi.stubGlobal('Worker', ThrowingWorker);
+    try {
+      const client = createLeaseWorkerClient();
+      // The fallback inline client must still work end-to-end.
+      const out = await client.parseAndAnalyze(await makeBytes(), RULE_PACK_V1);
+      expect(out.doc.pages.length).toBeGreaterThan(0);
+      client.terminate();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Targeted tests on real (non-defensive) branches:

- **leaseWorkerClient.test.ts** (+2 tests): exercise `createLeaseWorkerClient`'s real-Worker happy path (with `globalThis.Worker` stubbed) and the catch fallback when the Worker constructor throws. Lines 102-114 were entirely uncovered.
- **deltaPacket.test.ts** (+2 tests): cover `applyLineDiff`'s "did not consume full base" guard (171-173) and `verifyDeltaPacket`'s catch path on a malformed base64 signature (236-238).

## Coverage delta

| Metric     | Before | After  | Δ      |
|------------|--------|--------|--------|
| statements | 97.49  | 97.62  | +0.13  |
| branches   | 90.21  | 90.35  | +0.14  |
| functions  | 94.14  | 94.40  | +0.26  |
| lines      | 97.49  | 97.62  | +0.13  |

## Floor decision: NO BUMP

Per W33 §4-E rule:

- ≥91.2 → bump to 91
- ≥90.7 → bump to 90.5
- else **no bump**

We're at **90.35** — still in the no-bump zone. Pushing the remaining ~0.35pp to clear 90.7 would require defensive-guard tests on `noUncheckedIndexedAccess` artifacts (`?? 0` / `?? ''` branches) per Wave 24-C's lesson. The honest read of the remaining surface is "we got the meaningful branches; the rest is guard noise."

`vite.config.ts` `branches` floor stays at 90.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npm test` — 179 files / 1404 passed (+4 vs baseline)
- [x] `npm run test:coverage` — all thresholds passing with floor 90
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)