### PR TITLE
wave34-C: storybook dark-mode audit + ≤8 fixes

### DIFF
--- a/app/src/test/dark-mode-regression.test.ts
+++ b/app/src/test/dark-mode-regression.test.ts
@@ -1,4 +1,13 @@
 // Wave 32-B — palette-class regression test.
+// Wave 34-C — extended with three additional static checks that close
+// the gaps the original Tailwind-utility scan missed: arbitrary-value
+// hex (`bg-[#fff]`), inline-style hex (`style={{ color: '#...' }}`),
+// and SVG attribute hex (`fill="#..."`). All three would render the
+// same color in light and dark, defeating the [data-theme="dark"]
+// token cascade. The existing palette-class allow-list pattern is
+// reused for legitimate exemptions (notably the static-HTML export
+// modules, which emit standalone documents that are intentionally
+// light-only).
 //
 // Wave 31-B shipped a tri-state theme toggle that overrides the
 // semantic --color-* tokens under [data-theme="dark"]. Components that
@@ -15,12 +24,38 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, relative, resolve, sep } from 'node:path';
 
-const FORBIDDEN =
+const PALETTE_CLASS =
   /\b(bg|text|border|ring|outline|fill|stroke|from|to|via)-(amber|stone|zinc|slate|neutral|gray|red|orange|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|white|black)(-\d+)?(\/\d+)?\b/;
 
+// Tailwind arbitrary value with a hex literal:
+// `bg-[#fff]`, `text-[#a1b2c3]`, `border-[#abcdef99]`, etc.
+const ARBITRARY_HEX =
+  /\b(bg|text|border|ring|outline|fill|stroke|from|to|via|shadow|decoration)-\[#[0-9a-fA-F]{3,8}\]/;
+
+// Inline-style hex on a color-bearing key:
+// `style={{ color: '#fff' }}`, `style={{ background: "#abc" }}`, etc.
+// We match the key, optional whitespace, ':' or '=', a quote, then '#'.
+const INLINE_STYLE_HEX =
+  /\b(color|background(?:Color)?|fill|stroke|borderColor|outlineColor)\s*[:=]\s*['"`]#[0-9a-fA-F]{3,8}/;
+
+// SVG attribute with a hex literal: `fill="#fff"`, `stroke='#abc'`.
+const SVG_ATTR_HEX = /\b(fill|stroke)=['"]#[0-9a-fA-F]{3,8}['"]/;
+
 // Wave 33-C verified all three previously-allow-listed files are clean
-// (zero hard-coded palette classes). Allow-list emptied.
+// of palette classes. Wave 34-C re-confirms the palette-class allow-list
+// is empty.
 const ALLOW_LIST_PATHS: ReadonlyArray<string> = [];
+
+// Files that intentionally emit static HTML for the user to download
+// or print — those documents are standalone artefacts, not in-app UI,
+// so light-only colors are correct and the cascade does not apply.
+// Allowlisted for the hex/SVG checks only; palette-class scan still
+// runs against them (none currently fire).
+const HEX_ALLOW_LIST_PATHS: ReadonlyArray<string> = [
+  'src/storage/exportHtml.ts', // findings-export HTML download
+  'src/redline/redline.ts', // redline-export HTML download
+  'src/negotiation/sideLetter.ts', // side-letter HTML download
+];
 
 function* walk(dir: string): Generator<string> {
   for (const entry of readdirSync(dir)) {
@@ -30,35 +65,74 @@ function* walk(dir: string): Generator<string> {
   }
 }
 
-function isExcluded(rel: string): boolean {
+function isExcluded(rel: string, allowList: ReadonlyArray<string>): boolean {
   const normalized = rel.split(sep).join('/');
-  return ALLOW_LIST_PATHS.some((p) => normalized === p);
+  return allowList.some((p) => normalized === p);
 }
 
-describe('dark-mode regression: no hard-coded palette colors in components', () => {
-  it('finds zero forbidden Tailwind palette classes in app/src outside the allow list', () => {
-    // Vitest cwd in this project is `app/`, so walk `src/` directly.
-    const root = resolve('src');
-    const offenders: Array<{ file: string; line: number; text: string }> = [];
-    for (const path of walk(root)) {
-      if (!/\.(tsx|ts)$/.test(path)) continue;
-      if (/\.test\.tsx?$/.test(path)) continue;
-      if (/\.stories\.tsx?$/.test(path)) continue;
-      const rel = relative(resolve('.'), path);
-      if (isExcluded(rel)) continue;
-      const lines = readFileSync(path, 'utf8').split('\n');
-      lines.forEach((text, i) => {
-        if (FORBIDDEN.test(text)) {
-          offenders.push({ file: rel, line: i + 1, text: text.trim() });
-        }
-      });
-    }
-    const formatted = offenders
-      .map((o) => `${o.file}:${o.line}  ${o.text}`)
-      .join('\n');
+interface Offender {
+  file: string;
+  line: number;
+  text: string;
+}
+
+function scan(
+  pattern: RegExp,
+  allowList: ReadonlyArray<string>,
+): Offender[] {
+  // Vitest cwd in this project is `app/`, so walk `src/` directly.
+  const root = resolve('src');
+  const offenders: Offender[] = [];
+  for (const path of walk(root)) {
+    if (!/\.(tsx|ts)$/.test(path)) continue;
+    if (/\.test\.tsx?$/.test(path)) continue;
+    if (/\.stories\.tsx?$/.test(path)) continue;
+    const rel = relative(resolve('.'), path);
+    if (isExcluded(rel, allowList)) continue;
+    const lines = readFileSync(path, 'utf8').split('\n');
+    lines.forEach((text, i) => {
+      if (pattern.test(text)) {
+        offenders.push({ file: rel, line: i + 1, text: text.trim() });
+      }
+    });
+  }
+  return offenders;
+}
+
+function format(offenders: Offender[]): string {
+  return offenders.map((o) => `${o.file}:${o.line}  ${o.text}`).join('\n');
+}
+
+describe('dark-mode regression: source-level color-literal checks', () => {
+  it('finds zero forbidden Tailwind palette classes outside the allow list', () => {
+    const offenders = scan(PALETTE_CLASS, ALLOW_LIST_PATHS);
     expect(
       offenders,
-      `Found hard-coded Tailwind palette classes:\n${formatted}`,
+      `Found hard-coded Tailwind palette classes:\n${format(offenders)}`,
+    ).toEqual([]);
+  });
+
+  it('finds zero Tailwind arbitrary-value hex literals (bg-[#xxx], text-[#xxx], ...)', () => {
+    const offenders = scan(ARBITRARY_HEX, HEX_ALLOW_LIST_PATHS);
+    expect(
+      offenders,
+      `Found hard-coded hex in Tailwind arbitrary values:\n${format(offenders)}`,
+    ).toEqual([]);
+  });
+
+  it('finds zero inline style hex literals (style={{ color: "#xxx", ... }})', () => {
+    const offenders = scan(INLINE_STYLE_HEX, HEX_ALLOW_LIST_PATHS);
+    expect(
+      offenders,
+      `Found hard-coded hex in inline style props:\n${format(offenders)}`,
+    ).toEqual([]);
+  });
+
+  it('finds zero SVG attribute hex literals (fill="#xxx", stroke="#xxx")', () => {
+    const offenders = scan(SVG_ATTR_HEX, HEX_ALLOW_LIST_PATHS);
+    expect(
+      offenders,
+      `Found hard-coded hex in SVG attributes:\n${format(offenders)}`,
     ).toEqual([]);
   });
 });

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -589,6 +589,34 @@ score: number }` field that the LLM path populates. The audit
 blob:` envelope. Done = `scripts/check-csp.mjs` stays green
       and the dist build serves the model from same-origin.
 
+### Wave 34 dark-mode follow-ups
+
+A static walk of all 40 Storybook stories and their underlying
+components surfaced **zero hard-coded color regressions in app source**:
+the Wave 31-B token cascade plus Wave 32-B's palette-class regression
+test are doing their job. Wave 34-C tightened the regression test to
+also catch arbitrary-value hex (`bg-[#fff]`), inline-style hex
+(`style={{ color: '#xxx' }}`), and SVG attribute hex (`fill="#xxx"`).
+The follow-ups below are genuine UX nits that the static audit cannot
+address — visual or product-level work, not source-color cleanup.
+
+- [ ] PDF page raster is not theme-aware. `pdf.js` rasterizes the
+      document as-is, so a black-ink-on-white-paper lease renders
+      bright in dark mode. Themed pdf rendering would require either
+      a CSS filter (`invert/hue-rotate`) on the canvas or a per-page
+      post-process step. Out of scope for Wave 34; record as a Phase
+      19+ candidate.
+- [ ] Storybook visual snapshot infrastructure (Chromatic / Percy /
+      local Playwright per-story screenshots in light + dark) would
+      promote this audit from "static-grep + manual walk" to "CI-gated
+      pixel diff". Explicit out-of-scope per Wave 34 spec; track here.
+- [ ] Severity-bg contrast review. The `--color-severity-bg-*` tokens
+      use `color-mix(... 22%, --color-paper-raised)` which derives
+      automatically under dark theme; Wave 31-B claimed AA validation
+      but a fresh axe + manual contrast pass against the dark palette
+      would convert "claimed" to "verified". Pair with the deferred
+      Wave 28-F follow-up.
+
 ## Cross-cutting tech debt
 
 - [x] Extract a `usePipeline` hook — App's `handleBytes` was the


### PR DESCRIPTION
## Summary

Static audit of all 40 Storybook stories under `app/src/ui/**/*.stories.tsx` plus their underlying components. **Found zero hard-coded color regressions in app source.** Wave 31-B's token cascade (`[data-theme="dark"]` overrides in `app/src/index.css`) plus Wave 32-B's palette-class regression test have kept every component fully theme-token-driven — every `--color-*` token has a dark counterpart, every component reads tokens (no `bg-white`, no raw hex, no Tailwind arbitrary-value hex, no inline-style hex, no SVG attribute hex).

Wave 34-C therefore ships as **regression-test tightening + audit attestation + zero source fixes**, well below the ≤8 fix cap. Three new static checks lock in the current clean state.

## Regression test extensions (`app/src/test/dark-mode-regression.test.ts`)

| # | Check | Pattern | Allowlist |
|---|-------|---------|-----------|
| 1 | Palette classes (existing, Wave 32-B) | `(bg\|text\|border\|...)-(amber\|stone\|...\|white\|black)(-\d+)?` | empty |
| 2 | Tailwind arbitrary-value hex | `(bg\|text\|border\|...)-\[#[0-9a-fA-F]{3,8}\]` | HTML-export modules |
| 3 | Inline-style hex on color-bearing keys | `(color\|background(Color)?\|fill\|stroke\|borderColor\|outlineColor)\s*[:=]\s*['"\`]#...` | HTML-export modules |
| 4 | SVG attribute hex | `(fill\|stroke)=['"]#...['"]` | HTML-export modules |

Hex-allowlist holds the three modules that emit standalone downloadable HTML (intentionally light-only documents, not in-app UI):

- `src/storage/exportHtml.ts` — findings export
- `src/redline/redline.ts` — redline export
- `src/negotiation/sideLetter.ts` — side-letter export

## Audit table (40 stories)

All 40 stories read "OK / OK / token-driven, no fix" — the codebase is uniformly token-driven. Spot-checked components (`AppHeader`, `FindingsPanel`, `SeverityOverridesPanel`, `Button`, `Badge`, `PdfViewer`) confirmed zero raw color literals.

| # | Story | Light | Dark | Notes |
|---|-------|-------|------|-------|
| 1 | `AnnotationsPanel.stories.tsx` | OK | OK | token-driven |
| 2 | `AuditLogPanel.stories.tsx` | OK | OK | token-driven |
| 3 | `ClauseSimilarityPanel.stories.tsx` | OK | OK | token-driven |
| 4 | `ComparePanel.stories.tsx` | OK | OK | token-driven |
| 5 | `CounterOfferPanel.stories.tsx` | OK | OK | token-driven |
| 6 | `CustomRuleBuilderPanel.stories.tsx` | OK | OK | token-driven |
| 7 | `DeltaPanel.stories.tsx` | OK | OK | token-driven |
| 8 | `FindingsPanel.stories.tsx` | OK | OK | token-driven; severity badges via `--color-severity-*` |
| 9 | `HybridFeedbackButton.stories.tsx` | OK | OK | token-driven |
| 10 | `HybridPrecisionPanel.stories.tsx` | OK | OK | token-driven |
| 11 | `JurisdictionPickerPanel.stories.tsx` | OK | OK | token-driven |
| 12 | `LeaseFactsPanel.stories.tsx` | OK | OK | token-driven |
| 13 | `LibraryCompareForm.stories.tsx` | OK | OK | token-driven |
| 14 | `LibraryPanel.stories.tsx` | OK | OK | token-driven |
| 15 | `LocalePickerPanel.stories.tsx` | OK | OK | token-driven |
| 16 | `MarketplacePanel.stories.tsx` | OK | OK | token-driven |
| 17 | `OcrLanguagePickerPanel.stories.tsx` | OK | OK | token-driven |
| 18 | `OnboardingTour.stories.tsx` | OK | OK | token-driven |
| 19 | `PackDiffPanel.stories.tsx` | OK | OK | token-driven |
| 20 | `PackManagerPanel.stories.tsx` | OK | OK | token-driven |
| 21 | `PdfViewer.stories.tsx` | OK | OK | overlay uses `--color-highlight*`; raw PDF page raster is not theme-aware (filed in BACKLOG) |
| 22 | `PortfolioPanel.stories.tsx` | OK | OK | token-driven |
| 23 | `PortfolioRollupsPanel.stories.tsx` | OK | OK | token-driven |
| 24 | `RedlinePanel.stories.tsx` | OK | OK | token-driven |
| 25 | `SeverityOverridesPanel.stories.tsx` | OK | OK | uses `--color-severity-bg-*` color-mix tokens |
| 26 | `ShareReviewPanel.stories.tsx` | OK | OK | token-driven |
| 27 | `SideLetterPanel.stories.tsx` | OK | OK | inline `border: 1px solid var(--color-rule)` is theme-aware |
| 28 | `SigningKeyPanel.stories.tsx` | OK | OK | token-driven |
| 29 | `StandardSuitePanel.stories.tsx` | OK | OK | token-driven |
| 30 | `system/Badge.stories.tsx` | OK | OK | token-driven |
| 31 | `system/Button.stories.tsx` | OK | OK | token-driven; `focus-ring` utility uses `--ring` / `--ring-offset` |
| 32 | `system/Card.stories.tsx` | OK | OK | token-driven |
| 33 | `system/EmptyState.stories.tsx` | OK | OK | token-driven |
| 34 | `system/Field.stories.tsx` | OK | OK | token-driven |
| 35 | `system/Section.stories.tsx` | OK | OK | token-driven |
| 36 | `system/SectionGroup.stories.tsx` | OK | OK | token-driven |
| 37 | `system/Tokens.stories.tsx` | OK | OK | renders the token palette |
| 38 | `ThemeToggle.stories.tsx` | OK | OK | token-driven |
| 39 | `VersionHistoryPanel.stories.tsx` | OK | OK | token-driven |
| 40 | `WorkflowPanel.stories.tsx` | OK | OK | token-driven |

## Fixes applied

**Zero source-level fixes.** The static audit found no regressions. Three follow-up rows filed in `docs/BACKLOG.md` for visual / product-level nits the static audit cannot address (pdf.js page raster theming, Storybook visual snapshot CI, severity-bg contrast re-validation under dark theme).

See [docs/BACKLOG.md → Wave 34 dark-mode follow-ups](https://github.com/bradygrapentine/lease-analyzer/blob/wave34-C-storybook-darkmode/docs/BACKLOG.md#wave-34-dark-mode-follow-ups).

## Local gates

- `npm run typecheck` — clean
- `npm run lint` — clean (0 warnings)
- `npm test` — 179 files / 1407 passing / 1 todo
- `dark-mode-regression.test.ts` — 4/4 passing (1 existing palette-class check + 3 new hex checks)

## Test plan

- [x] All 4 regression-test branches green locally
- [x] `npm run typecheck && npm run lint && npm test` all green
- [ ] CI verify / smoke / npm-audit / Lighthouse all green
- [ ] Adversarial review (auto on `gh pr ready`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)