### PR TITLE
wave35-A: hybrid-stats report + Wave 35 gate decision (NO-OP)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -24,6 +24,7 @@
     "check:budget": "node scripts/check-bundle-budget.mjs",
     "check:csp": "node scripts/check-csp.mjs",
     "audit:prod": "node scripts/audit-prod.mjs",
+    "hybrid:stats": "node scripts/hybrid-stats-report.mjs",
     "lhci": "lhci autorun",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/app/scripts/hybrid-stats-report.mjs
+++ b/app/scripts/hybrid-stats-report.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// Wave 35 Part A — Node CLI that reads an exported leaseguard.audit.v1
+// JSON file and prints a per-rule precision table. Decides whether the
+// rule pack qualifies for a Wave 35 Part B demotion pass.
+//
+// Usage:
+//   node scripts/hybrid-stats-report.mjs <path/to/audit-export.json>
+//
+// Decision rule: ACT if any rule has fires ≥ 10 AND precision < 0.70.
+
+import { readFileSync } from 'node:fs';
+
+const FIRES_FLOOR = 10;
+const PRECISION_CEILING = 0.7;
+
+export function computeReport(exportObj) {
+  const fires = new Map();
+  const rejects = new Map();
+  for (const e of exportObj.entries ?? []) {
+    if (e.kind === 'llm-classify') {
+      const id = e.payload?.ruleId;
+      if (typeof id === 'string') fires.set(id, (fires.get(id) ?? 0) + 1);
+    } else if (
+      e.kind === 'hybrid-feedback' &&
+      e.payload?.signal === 'not-relevant'
+    ) {
+      const id = e.payload?.ruleId;
+      if (typeof id === 'string') rejects.set(id, (rejects.get(id) ?? 0) + 1);
+    }
+  }
+  const ids = new Set([...fires.keys(), ...rejects.keys()]);
+  const rows = [];
+  for (const ruleId of ids) {
+    const f = fires.get(ruleId) ?? 0;
+    const r = rejects.get(ruleId) ?? 0;
+    const precision = f === 0 ? null : Math.max(0, 1 - r / f);
+    rows.push({ ruleId, fires: f, rejects: r, precision });
+  }
+  rows.sort(
+    (a, b) => b.fires - a.fires || a.ruleId.localeCompare(b.ruleId),
+  );
+  return { rows };
+}
+
+export function decide(report) {
+  const qualifying = report.rows
+    .filter(
+      (r) =>
+        r.fires >= FIRES_FLOOR &&
+        r.precision !== null &&
+        r.precision < PRECISION_CEILING,
+    )
+    .map((r) => r.ruleId);
+  return {
+    action: qualifying.length > 0 ? 'ACT' : 'NO-OP',
+    qualifying,
+  };
+}
+
+export function formatTable(report) {
+  const header =
+    '| ruleId | fires | rejects | precision |\n| --- | --- | --- | --- |';
+  const body = report.rows
+    .map(
+      (r) =>
+        `| ${r.ruleId} | ${r.fires} | ${r.rejects} | ${r.precision === null ? '—' : r.precision.toFixed(2)} |`,
+    )
+    .join('\n');
+  return body.length > 0 ? `${header}\n${body}` : `${header}\n(no rows)`;
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  const path = process.argv[2];
+  if (!path) {
+    console.error('usage: hybrid-stats-report.mjs <audit-export.json>');
+    process.exit(2);
+  }
+  const obj = JSON.parse(readFileSync(path, 'utf8'));
+  const report = computeReport(obj);
+  const decision = decide(report);
+  const totalEntries = obj.entries?.length ?? 0;
+  const feedbackCount =
+    obj.entries?.filter((e) => e.kind === 'hybrid-feedback').length ?? 0;
+  console.log(`Source: ${path}`);
+  console.log(
+    `Total entries: ${totalEntries}  ·  hybrid-feedback: ${feedbackCount}`,
+  );
+  console.log('');
+  console.log(formatTable(report));
+  console.log('');
+  console.log(`Decision: ${decision.action}`);
+  if (decision.qualifying.length > 0) {
+    console.log(`Qualifying rules: ${decision.qualifying.join(', ')}`);
+  }
+}
+

--- a/app/scripts/hybrid-stats-report.test.mjs
+++ b/app/scripts/hybrid-stats-report.test.mjs
@@ -1,0 +1,109 @@
+// Wave 35 Part A — hybrid-stats-report fixture tests.
+import { describe, it, expect } from 'vitest';
+import {
+  computeReport,
+  formatTable,
+  decide,
+} from './hybrid-stats-report.mjs';
+
+const fire = (seq, ruleId) => ({
+  seq,
+  timestamp: '2026-01-01T00:00:00Z',
+  kind: 'llm-classify',
+  payload: { ruleId },
+  prevHash: null,
+  entryHash: 'h',
+});
+
+const reject = (seq, ruleId) => ({
+  seq,
+  timestamp: '2026-01-01T00:00:00Z',
+  kind: 'hybrid-feedback',
+  payload: { ruleId, signal: 'not-relevant' },
+  prevHash: null,
+  entryHash: 'h',
+});
+
+const RICH_FIXTURE = {
+  schema: 'leaseguard.audit.v1',
+  entries: [
+    // 12 fires, 9 rejects → precision 0.25, qualifying.
+    ...Array.from({ length: 12 }, (_, i) => fire(i, 'auto-renewal')),
+    ...Array.from({ length: 9 }, (_, i) => reject(12 + i, 'auto-renewal')),
+    // 5 fires, 0 rejects → precision 1.00, under fires floor.
+    ...Array.from({ length: 5 }, (_, i) => fire(30 + i, 'jury-trial-waiver')),
+  ],
+};
+
+const SPARSE_FIXTURE = {
+  schema: 'leaseguard.audit.v1',
+  entries: [
+    ...Array.from({ length: 3 }, (_, i) => fire(i, 'arbitration-clause')),
+  ],
+};
+
+const EMPTY_FIXTURE = { schema: 'leaseguard.audit.v1', entries: [] };
+
+describe('hybrid-stats-report', () => {
+  it('decides ACT when ≥1 rule has fires≥10 AND precision<0.70', () => {
+    expect(decide(computeReport(RICH_FIXTURE))).toEqual({
+      action: 'ACT',
+      qualifying: ['auto-renewal'],
+    });
+  });
+
+  it('decides NO-OP when no rule clears the fires floor', () => {
+    expect(decide(computeReport(SPARSE_FIXTURE))).toEqual({
+      action: 'NO-OP',
+      qualifying: [],
+    });
+  });
+
+  it('decides NO-OP on an empty audit chain', () => {
+    expect(decide(computeReport(EMPTY_FIXTURE))).toEqual({
+      action: 'NO-OP',
+      qualifying: [],
+    });
+  });
+
+  it('emits a markdown table with one row per rule seen', () => {
+    const md = formatTable(computeReport(RICH_FIXTURE));
+    expect(md).toContain('| ruleId | fires | rejects | precision |');
+    expect(md).toContain('| auto-renewal | 12 | 9 | 0.25 |');
+    expect(md).toContain('| jury-trial-waiver | 5 | 0 | 1.00 |');
+  });
+
+  it('clamps precision to 0 when rejects exceed fires (defensive)', () => {
+    // Rule with 2 fires + 5 rejects (audit predates consumer).
+    const fixture = {
+      schema: 'leaseguard.audit.v1',
+      entries: [
+        ...Array.from({ length: 2 }, (_, i) => fire(i, 'odd-rule')),
+        ...Array.from({ length: 5 }, (_, i) => reject(2 + i, 'odd-rule')),
+      ],
+    };
+    const md = formatTable(computeReport(fixture));
+    expect(md).toContain('| odd-rule | 2 | 5 | 0.00 |');
+  });
+
+  it('ignores hybrid-feedback entries with signals other than not-relevant', () => {
+    const fixture = {
+      schema: 'leaseguard.audit.v1',
+      entries: [
+        fire(0, 'foo'),
+        {
+          seq: 1,
+          timestamp: '2026-01-01T00:00:00Z',
+          kind: 'hybrid-feedback',
+          payload: { ruleId: 'foo', signal: 'helpful' },
+          prevHash: null,
+          entryHash: 'h',
+        },
+      ],
+    };
+    const report = computeReport(fixture);
+    expect(report.rows).toEqual([
+      { ruleId: 'foo', fires: 1, rejects: 0, precision: 1 },
+    ]);
+  });
+});

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -589,6 +589,23 @@ score: number }` field that the LLM path populates. The audit
 blob:` envelope. Done = `scripts/check-csp.mjs` stays green
       and the dist build serves the model from same-origin.
 
+### Wave 35 follow-ups
+
+- [ ] Re-run `npm run hybrid:stats` after meaningful real-world usage
+      accumulates. Wave 35 Part A shipped the tool; Part A's first
+      run was a NO-OP (zero audit entries on the dogfooding
+      machine). Once the audit chain has ≥10 fires for at least one
+      hybrid rule, re-export and re-run. If any rule clears
+      `precision < 0.70`, open the deferred Wave 35 Part B
+      (anchor demotions in `app/src/rules/packV1.ts`).
+- [ ] Pre-existing IDB cleanup race in `App.test.tsx > "clear-all
+      aborts when confirmation is declined"` surfaces as one
+      `Vitest > Unhandled Rejection (InvalidStateError)` per full
+      test run (storage.ts:183 `clearAll`). Tests pass; the
+      rejection is post-test. Reproduces on stock `origin/main` —
+      not introduced by Wave 35. Worth root-causing in a hygiene
+      slot.
+
 ### Wave 34 dark-mode follow-ups
 
 A static walk of all 40 Storybook stories and their underlying

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -203,6 +203,34 @@ spec disables service-worker registration before navigation so the
 SW precache doesn't race with the direct fetch (Chromium throws
 `ERR_CACHE_WRITE_FAILURE` on the 16 MiB file under that race).
 
+## Hybrid quality reporting
+
+The Phase 18 hybrid path emits two audit kinds — `llm-classify` (per
+finding) and `hybrid-feedback` with `signal: 'not-relevant'` (per user
+reject). Wave 30-A's `HybridPrecisionPanel` surfaces per-rule precision
+live in the running app. Wave 35 Part A adds a Node-only offline
+report that runs against an exported audit chain so the precision
+table can be captured for review (e.g. in PR descriptions when
+deciding whether to demote noisy `hybridAnchors`).
+
+Flow:
+
+1. In the running app, click `Export audit log` to download a
+   `leaseguard-audit-*.json` file (schema `leaseguard.audit.v1`).
+2. From `app/`, run:
+
+   ```bash
+   npm run hybrid:stats -- /path/to/leaseguard-audit-2026-04-28.json
+   ```
+
+3. The script prints a per-rule markdown table (`ruleId | fires |
+   rejects | precision`) and a one-line decision: `ACT` if any rule
+   has `fires ≥ 10 AND precision < 0.70`, `NO-OP` otherwise.
+
+The script is pure Node (no jsdom, no browser); the test fixtures live
+in `app/scripts/hybrid-stats-report.test.mjs` and exercise the rich /
+sparse / empty branches plus the defensive precision-clamp path.
+
 ## Run commands
 
 ```bash


### PR DESCRIPTION
## Summary

Wave 35 Part A ships a Node-only CLI (`app/scripts/hybrid-stats-report.mjs`) that reads an exported `leaseguard.audit.v1` JSON and prints a per-rule precision table with an `ACT` / `NO-OP` decision against the gate `fires ≥ 10 AND precision < 0.70`.

Wired as `npm run hybrid:stats -- <path>`. Documented in `docs/TESTING.md` under "Hybrid quality reporting".

## Gate decision: **NO-OP**

Ran against `~/Downloads/leaseguard-audit-2026-04-28.json` (exported from this machine's running app):

```
Source: ~/Downloads/leaseguard-audit-2026-04-28.json
Total entries: 0  ·  hybrid-feedback: 0

| ruleId | fires | rejects | precision |
| --- | --- | --- | --- |
(no rows)

Decision: NO-OP
```

The audit chain is empty — no real-world usage on the dogfooding machine. **Part B (anchor demotions) is therefore deferred** and Wave 35 closes after this PR. Plan §8 explicitly anticipated this as the most likely first-run outcome. No threshold-fudging.

Re-run row filed in `docs/BACKLOG.md` under \`### Wave 35 follow-ups\` so a future session knows to re-export and re-run once the audit chain has accumulated ≥10 fires for at least one hybrid rule.

## What ships

- \`app/scripts/hybrid-stats-report.mjs\` (96 lines) — three pure exports (\`computeReport\`, \`decide\`, \`formatTable\`) + a CLI entrypoint.
- \`app/scripts/hybrid-stats-report.test.mjs\` (109 lines) — six tests across rich / sparse / empty fixtures plus a defensive precision-clamp path and an unrecognised-signal filter.
- \`app/package.json\` — adds \`"hybrid:stats"\` script.
- \`docs/TESTING.md\` — adds "Hybrid quality reporting" section explaining the export-then-report flow.
- \`docs/BACKLOG.md\` — adds \`### Wave 35 follow-ups\` (Part B re-run row + a separately-discovered pre-existing IDB-cleanup race in \`App.test.tsx > "clear-all aborts when confirmation is declined"\`, reproduces on stock \`origin/main\`, not introduced here).

## Local gates

- \`npm run typecheck\` — clean
- \`npm run lint\` — clean (0 warnings)
- \`npm test\` — 180 files / 1413 passing / 1 todo
- \`hybrid-stats-report.test.mjs\` — 6/6 passing

## Test plan

- [x] All Part A unit tests green locally
- [x] Full app test suite still green (180 files, 1413 tests)
- [x] Gate decision captured in this PR body per plan §1.7
- [x] NO-OP rationale documented; re-run row filed in BACKLOG
- [ ] CI verify / smoke / npm-audit / Lighthouse all green
- [ ] Adversarial review (auto on \`gh pr ready\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)