### PR TITLE
wave36-B: flip default to v4; same-origin ORT WASM staging

### DIFF
--- a/app/scripts/build-classifier-assets.mjs
+++ b/app/scripts/build-classifier-assets.mjs
@@ -41,6 +41,35 @@ const ORT_SOURCE = join(
   'dist',
   'ort-wasm-simd.wasm',
 );
+// Wave 36 Part B — v4's ORT (onnxruntime-web 1.19+) ships only
+// threaded SIMD variants. Stage them same-origin so v4's loader
+// resolves `wasmPaths = '/classifier/onnx-runtime-v4/'` against
+// our CSP `connect-src 'self'`. The `.mjs` glue is the entrypoint
+// the runtime imports; it locates the `.wasm` next to itself.
+const ORT_V4_DEST = join(APP_ROOT, 'public', 'classifier', 'onnx-runtime-v4');
+const ORT_V4_SOURCE_DIR = join(
+  APP_ROOT,
+  'node_modules',
+  '@huggingface',
+  'transformers',
+  'node_modules',
+  'onnxruntime-web',
+  'dist',
+);
+// ORT 1.19 ships four `.wasm`/`.mjs` pairs. Its loader picks one at
+// runtime based on capability detection (asyncify is the fallback when
+// neither JSPI nor SAB is available — Chromium without COOP/COEP). We
+// stage all four so whichever it picks resolves same-origin.
+const ORT_V4_FILES = [
+  'ort-wasm-simd-threaded.wasm',
+  'ort-wasm-simd-threaded.mjs',
+  'ort-wasm-simd-threaded.asyncify.wasm',
+  'ort-wasm-simd-threaded.asyncify.mjs',
+  'ort-wasm-simd-threaded.jsep.wasm',
+  'ort-wasm-simd-threaded.jsep.mjs',
+  'ort-wasm-simd-threaded.jspi.wasm',
+  'ort-wasm-simd-threaded.jspi.mjs',
+];
 
 
 const HF_BASE = `https://huggingface.co/${MODEL_REPO}/resolve/main`;
@@ -131,6 +160,26 @@ async function main() {
     await copyFile(ORT_SOURCE, ortDest);
     console.log(`  ort-wasm-simd.wasm                   ${fmt(statSync(ortDest).size)}`);
     total += statSync(ortDest).size;
+  }
+
+  // Wave 36 Part B — stage v4 ORT WASM + glue under onnx-runtime-v4/.
+  await mkdir(ORT_V4_DEST, { recursive: true });
+  for (const name of ORT_V4_FILES) {
+    const src = join(ORT_V4_SOURCE_DIR, name);
+    const dst = join(ORT_V4_DEST, name);
+    const label = `  ${name.padEnd(36, ' ')} `;
+    if (existsSync(dst) && statSync(dst).size > 0) {
+      console.log(`${label}${fmt(statSync(dst).size)} (already present)`);
+      continue;
+    }
+    if (!existsSync(src)) {
+      console.error(`${label}FAILED (${src} not found — run npm install)`);
+      failed += 1;
+      continue;
+    }
+    await copyFile(src, dst);
+    console.log(`${label}${fmt(statSync(dst).size)}`);
+    total += statSync(dst).size;
   }
 
   console.log('');

--- a/app/src/llm/loadClassifier.test.ts
+++ b/app/src/llm/loadClassifier.test.ts
@@ -46,36 +46,36 @@ describe('Phase 18 loadClassifier', () => {
   });
 });
 
-describe('Wave 36 readRuntimeFlag', () => {
-  it('returns v2 when no flag is present', () => {
+describe('Wave 36 readRuntimeFlag (v4-default after Part B)', () => {
+  it('returns v4 when no flag is present (default after Part B flip)', () => {
     Object.defineProperty(window, 'location', {
       configurable: true,
       value: new URL('http://localhost/'),
     });
-    expect(readRuntimeFlag()).toBe('v2');
-  });
-
-  it('returns v4 when ?transformersV4=on is set', () => {
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: new URL('http://localhost/?transformersV4=on'),
-    });
     expect(readRuntimeFlag()).toBe('v4');
   });
 
-  it('returns v2 when transformersV4 is set to anything other than "on"', () => {
+  it('returns v2 when the ?transformersV2=on kill switch is set', () => {
     Object.defineProperty(window, 'location', {
       configurable: true,
-      value: new URL('http://localhost/?transformersV4=true'),
+      value: new URL('http://localhost/?transformersV2=on'),
     });
     expect(readRuntimeFlag()).toBe('v2');
   });
 
-  it('coexists with other URL params', () => {
+  it('returns v4 when transformersV2 is set to anything other than "on"', () => {
     Object.defineProperty(window, 'location', {
       configurable: true,
-      value: new URL('http://localhost/?phase18=on&transformersV4=on&debug=1'),
+      value: new URL('http://localhost/?transformersV2=true'),
     });
     expect(readRuntimeFlag()).toBe('v4');
+  });
+
+  it('coexists with other URL params (v2 kill switch wins)', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: new URL('http://localhost/?phase18=on&transformersV2=on&debug=1'),
+    });
+    expect(readRuntimeFlag()).toBe('v2');
   });
 });

--- a/app/src/llm/loadClassifier.ts
+++ b/app/src/llm/loadClassifier.ts
@@ -39,12 +39,20 @@ export const DEFAULT_MODEL_ID = 'Xenova/paraphrase-MiniLM-L3-v2';
 
 let cached: Promise<EmbedFunction> | null = null;
 
-/** Wave 36 — read the runtime-selection URL flag. */
+/**
+ * Wave 36 — read the runtime-selection URL flag.
+ *
+ * Wave 36 Part B flipped the default to v4. The `?transformersV2=on`
+ * kill switch is transient — Part C removes it once the v4-default
+ * window proves stable. SSR-safe: returns v4 (the default) when
+ * `window` is undefined.
+ */
 export function readRuntimeFlag(): 'v2' | 'v4' {
-  if (typeof window === 'undefined') return 'v2';
+  if (typeof window === 'undefined') return 'v4';
   const search = window.location?.search ?? '';
   const params = new URLSearchParams(search);
-  return params.get('transformersV4') === 'on' ? 'v4' : 'v2';
+  if (params.get('transformersV2') === 'on') return 'v2';
+  return 'v4';
 }
 
 async function loadV2Pipeline(modelId: string): Promise<EmbedFunction> {
@@ -76,16 +84,26 @@ async function loadV2Pipeline(modelId: string): Promise<EmbedFunction> {
 async function loadV4Pipeline(modelId: string): Promise<EmbedFunction> {
   const transformers = await import('@huggingface/transformers');
   transformers.env.localModelPath = '/classifier/';
+  // v4 requires `allowLocalModels` to be explicitly true when
+  // `allowRemoteModels` is false; v2 defaulted to true. Without this,
+  // v4's PretrainedModel.from_pretrained throws "both local and remote
+  // models are disabled" before reaching the loader.
+  transformers.env.allowLocalModels = true;
   transformers.env.allowRemoteModels = false;
-  // v4 self-hosts ORT WASM via Vite asset emission (dist/assets/
-  // ort-wasm-*.wasm). `wasmPaths` is left unset so v4's runtime
-  // resolves the file via `import.meta.url`, which Vite rewrites to
-  // the hashed asset path at build time. Per the Part 0 spike, ORT
-  // 1.26 ships only threaded WASM variants but degrades to
-  // single-thread when `SharedArrayBuffer` is unavailable (the
-  // COOP/COEP-not-set case). `numThreads = 1` reinforces that.
+  // Self-host v4 ORT WASM same-origin under `/classifier/onnx-runtime-v4/`.
+  // Mirrors v2's `/classifier/onnx-runtime/` pattern. With `wasmPaths`
+  // unset, v4's runtime resolves the `.wasm` via `import.meta.url` from
+  // the bundled `.mjs` glue and falls back to a jsdelivr CDN fetch for
+  // sibling files — both paths are blocked by the app's CSP
+  // (`connect-src 'self'`). `build:classifier-assets` copies
+  // `ort-wasm-simd-threaded.{wasm,mjs}` from
+  // `node_modules/@huggingface/transformers/node_modules/onnxruntime-web/dist/`.
+  // ORT 1.19 ships only threaded variants but degrades to single-thread
+  // when `SharedArrayBuffer` is unavailable (no COOP/COEP); `numThreads = 1`
+  // reinforces that.
   const wasmEnv = transformers.env.backends.onnx.wasm;
   if (wasmEnv) {
+    wasmEnv.wasmPaths = '/classifier/onnx-runtime-v4/';
     wasmEnv.numThreads = 1;
   }
   const pipeline = transformers.pipeline as (

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -29,12 +29,20 @@ export default defineConfig({
         // same-origin (CSP requires it) — just on-demand, not up-front.
         // - `classifier/onnx-runtime/**` covers v2's WASM staged by
         //   `npm run build:classifier-assets`.
-        // - `assets/ort-wasm-*` (Wave 36 Part A) covers v4's WASM
-        //   auto-emitted by Vite from the `@huggingface/transformers`
-        //   static imports. v4 ships only threaded variants (Wave 36
-        //   Part 0 spike); the `asyncify` variant is what Vite picks
-        //   for non-SAB envs.
-        globIgnores: ['classifier/onnx-runtime/**', 'assets/ort-wasm-*'],
+        // - `classifier/onnx-runtime-v4/**` covers v4's WASM (Wave 36
+        //   Part B). v4 ships four `.wasm`/`.mjs` pairs and picks one
+        //   at runtime by capability detection; we stage all four
+        //   same-origin and let it resolve `wasmPaths` against
+        //   `/classifier/onnx-runtime-v4/`. Some variants exceed
+        //   Workbox's 18 MiB per-file cap anyway (jsep ~26 MiB),
+        //   which forces the same on-demand-fetch contract as v2.
+        // - `assets/ort-wasm-*` is a defensive carry-over from the
+        //   Part A bundling attempt; harmless to keep.
+        globIgnores: [
+          'classifier/onnx-runtime/**',
+          'classifier/onnx-runtime-v4/**',
+          'assets/ort-wasm-*',
+        ],
         maximumFileSizeToCacheInBytes: 18 * 1024 * 1024,
         navigateFallback: 'index.html',
       },


### PR DESCRIPTION
## Summary
- Stage v4 ORT WASM (`ort-wasm-simd-threaded.{,asyncify,jsep,jspi}.{wasm,mjs}`) under `public/classifier/onnx-runtime-v4/` via `build:classifier-assets`, mirroring v2's `onnx-runtime/` pattern.
- Set `env.backends.onnx.wasm.wasmPaths = '/classifier/onnx-runtime-v4/'` in `loadV4Pipeline` so v4 resolves WASM same-origin (CSP `connect-src 'self'` blocks the jsdelivr CDN default that surfaced when `wasmPaths` was unset).
- Flip default runtime to v4; keep `?transformersV2=on` as transient kill switch (Part C removes both).
- Add `classifier/onnx-runtime-v4/**` to Workbox `globIgnores` — on-demand fetch, same as v2.

## Test plan
- [x] `npm test` (180 files, 1417 pass + 1 todo)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean (precache 31.3 MiB)
- [x] `RUN_REAL_MODEL=1 npx playwright test tests/e2e/hybrid-golden.spec.ts` — model boots end-to-end, hybrid finding emitted with v4 modelId
- [ ] CI smoke + Lighthouse + npm-audit green

🤖 Generated with [Claude Code](https://claude.com/claude-code)