### PR TITLE
wave36-C: remove @xenova/transformers v2 branch + kill switch

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "dependencies": {
         "@huggingface/transformers": "4.2.0",
-        "@xenova/transformers": "^2.17.2",
         "idb": "^8.0.3",
         "pdfjs-dist": "^4.10.38",
         "react": "^18.3.1",
@@ -2409,15 +2408,6 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
-    },
-    "node_modules/@huggingface/jinja": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.2.2.tgz",
-      "integrity": "sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/@huggingface/tokenizers": {
       "version": "0.1.3",
@@ -6104,12 +6094,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "license": "MIT"
-    },
     "node_modules/@types/mdx": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
@@ -6624,20 +6608,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@xenova/transformers": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/@xenova/transformers/-/transformers-2.17.2.tgz",
-      "integrity": "sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@huggingface/jinja": "^0.2.2",
-        "onnxruntime-web": "1.14.0",
-        "sharp": "^0.32.0"
-      },
-      "optionalDependencies": {
-        "onnxruntime-node": "1.14.0"
-      }
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -7007,6 +6977,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-abort-controller": "*"
@@ -7021,6 +6992,7 @@
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
       "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -7045,6 +7017,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
       "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "bare": ">=1.14.0"
@@ -7054,6 +7027,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-os": "^3.0.1"
@@ -7063,6 +7037,7 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
       "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "streamx": "^2.25.0",
@@ -7089,6 +7064,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
       "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -7098,6 +7074,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7148,17 +7125,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/bmp-js": {
@@ -7313,6 +7279,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7517,12 +7484,6 @@
         "node": "*"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
-    },
     "node_modules/chrome-launcher": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.13.4.tgz",
@@ -7632,23 +7593,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -7661,17 +7610,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -8051,21 +7991,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -8077,15 +8002,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -8387,6 +8303,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -8938,6 +8855,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
       "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
@@ -8965,15 +8883,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -9139,6 +9048,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -9362,12 +9272,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/flatbuffers": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
-      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==",
-      "license": "SEE LICENSE IN LICENSE.txt"
-    },
     "node_modules/flatted": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -9444,12 +9348,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "9.1.0",
@@ -9671,12 +9569,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -10050,6 +9942,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10136,12 +10029,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/inquirer": {
@@ -10406,12 +10294,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
-      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -11792,12 +11674,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/lookup-closest-locale": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz",
@@ -12055,18 +11931,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -12097,6 +11961,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -12131,12 +11996,6 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.8.2",
@@ -12191,12 +12050,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -12223,24 +12076,6 @@
       "engines": {
         "node": ">= 0.4.0"
       }
-    },
-    "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-      "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -12397,6 +12232,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -12416,50 +12252,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/onnx-proto": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/onnx-proto/-/onnx-proto-4.0.4.tgz",
-      "integrity": "sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==",
-      "license": "MIT",
-      "dependencies": {
-        "protobufjs": "^6.8.8"
-      }
-    },
-    "node_modules/onnxruntime-common": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.14.0.tgz",
-      "integrity": "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew==",
-      "license": "MIT"
-    },
-    "node_modules/onnxruntime-node": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.14.0.tgz",
-      "integrity": "sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32",
-        "darwin",
-        "linux"
-      ],
-      "dependencies": {
-        "onnxruntime-common": "~1.14.0"
-      }
-    },
-    "node_modules/onnxruntime-web": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.14.0.tgz",
-      "integrity": "sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==",
-      "license": "MIT",
-      "dependencies": {
-        "flatbuffers": "^1.12.0",
-        "guid-typescript": "^1.0.9",
-        "long": "^4.0.0",
-        "onnx-proto": "^4.0.4",
-        "onnxruntime-common": "~1.14.0",
-        "platform": "^1.3.6"
       }
     },
     "node_modules/open": {
@@ -12894,61 +12686,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -13037,32 +12774,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/protobufjs": {
-      "version": "6.11.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.5.tgz",
-      "integrity": "sha512-OKjVH3hDoXdIZ/s5MLv8O2X0s+wOxGfV7ar6WFSKGaSAxi/6gYn3px5POS4vi+mc/0zCOdL7Jkwrj0oT1Yst2A==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -13131,6 +12842,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -13247,30 +12959,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -13358,20 +13046,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/recast": {
@@ -13825,6 +13499,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14081,29 +13756,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/sharp": {
-      "version": "0.32.6",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
-      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.2",
-        "node-addon-api": "^6.1.0",
-        "prebuild-install": "^7.1.1",
-        "semver": "^7.5.4",
-        "simple-get": "^4.0.1",
-        "tar-fs": "^3.0.4",
-        "tunnel-agent": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -14221,60 +13873,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/slash": {
@@ -14512,20 +14110,12 @@
       "version": "2.25.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
       "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -14864,6 +14454,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
       "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
@@ -14878,6 +14469,7 @@
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
       "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
@@ -14890,6 +14482,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
       "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -14904,6 +14497,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
       "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "streamx": "^2.12.5"
@@ -15050,6 +14644,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
       "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
@@ -15059,6 +14654,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
       "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -15333,18 +14929,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true,
       "license": "0BSD"
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -15716,12 +15300,6 @@
         "is-typed-array": "^1.1.3",
         "which-typed-array": "^1.1.2"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -16732,6 +16310,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/app/package.json
+++ b/app/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@huggingface/transformers": "4.2.0",
-    "@xenova/transformers": "^2.17.2",
     "idb": "^8.0.3",
     "pdfjs-dist": "^4.10.38",
     "react": "^18.3.1",

--- a/app/scripts/audit-prod.mjs
+++ b/app/scripts/audit-prod.mjs
@@ -15,15 +15,9 @@ import { spawnSync } from 'node:child_process';
 /** Advisory URLs for vulnerabilities the project has accepted with rationale.
  *  Each entry MUST have a corresponding §accept-risk note in docs/SECURITY.md. */
 const ALLOW_ADVISORIES = new Set([
-  // protobufjs <7.5.5 — arbitrary code execution. Transitive only,
-  // reached via @xenova/transformers → onnxruntime-web → onnx-proto →
-  // protobufjs. @xenova/transformers v2 is end-of-life upstream
-  // (no fix forthcoming on that line). Migration to the successor
-  // package @huggingface/transformers v4 is tracked as a future
-  // Phase 19 wave with its own brainstorm — out of scope for hygiene
-  // work. See docs/SECURITY.md §accept-risk for the standing
-  // rationale.
-  'https://github.com/advisories/GHSA-xq3m-2v4x-88gg',
+  // (empty — Wave 36-C dropped the GHSA-xq3m-2v4x-88gg entry that was
+  // pinned by the @xenova/transformers v2 dependency chain. v4 no
+  // longer pulls in the vulnerable protobufjs.)
 ]);
 
 function collectRootUrls(name, vulns, seen) {

--- a/app/scripts/build-classifier-assets.mjs
+++ b/app/scripts/build-classifier-assets.mjs
@@ -27,25 +27,11 @@ const MODEL_REPO = 'Xenova/paraphrase-MiniLM-L3-v2';
 // model id (see app/src/llm/loadClassifier.ts). The runtime constructs
 // URLs as `${localModelPath}${modelId}/${file}`.
 const DEST = join(APP_ROOT, 'public', 'classifier', MODEL_REPO);
-// ONNX Runtime WASM lives next to the model under /classifier/onnx-runtime/
-// — same-origin (CSP requires it). Only the non-threaded SIMD build is
-// shipped: SharedArrayBuffer (the threaded variants' precondition) needs
-// COOP/COEP headers the app doesn't set. Chrome falls back to single-thread
-// SIMD cleanly when the threaded files are absent.
-const ORT_DEST = join(APP_ROOT, 'public', 'classifier', 'onnx-runtime');
-const ORT_SOURCE = join(
-  APP_ROOT,
-  'node_modules',
-  '@xenova',
-  'transformers',
-  'dist',
-  'ort-wasm-simd.wasm',
-);
-// Wave 36 Part B — v4's ORT (onnxruntime-web 1.19+) ships only
-// threaded SIMD variants. Stage them same-origin so v4's loader
-// resolves `wasmPaths = '/classifier/onnx-runtime-v4/'` against
-// our CSP `connect-src 'self'`. The `.mjs` glue is the entrypoint
-// the runtime imports; it locates the `.wasm` next to itself.
+// v4's ORT (onnxruntime-web 1.19+) ships only threaded SIMD variants.
+// Stage them same-origin so v4's loader resolves
+// `wasmPaths = '/classifier/onnx-runtime-v4/'` against our CSP
+// `connect-src 'self'`. The `.mjs` glue is the entrypoint the runtime
+// imports; it locates the `.wasm` next to itself.
 const ORT_V4_DEST = join(APP_ROOT, 'public', 'classifier', 'onnx-runtime-v4');
 const ORT_V4_SOURCE_DIR = join(
   APP_ROOT,
@@ -144,25 +130,7 @@ async function main() {
     }
   }
 
-  // Copy ONNX Runtime WASM (single SIMD non-threaded binary) from the
-  // installed @xenova/transformers package into the public/ tree.
-  // Idempotent — same exists+nonzero check.
-  const ortDest = join(ORT_DEST, 'ort-wasm-simd.wasm');
-  await mkdir(ORT_DEST, { recursive: true });
-  if (existsSync(ortDest) && statSync(ortDest).size > 0) {
-    console.log(`  ort-wasm-simd.wasm                   ${fmt(statSync(ortDest).size)} (already present)`);
-  } else if (!existsSync(ORT_SOURCE)) {
-    console.error(
-      `  ort-wasm-simd.wasm                   FAILED (${ORT_SOURCE} not found — run npm install)`,
-    );
-    failed += 1;
-  } else {
-    await copyFile(ORT_SOURCE, ortDest);
-    console.log(`  ort-wasm-simd.wasm                   ${fmt(statSync(ortDest).size)}`);
-    total += statSync(ortDest).size;
-  }
-
-  // Wave 36 Part B — stage v4 ORT WASM + glue under onnx-runtime-v4/.
+  // Stage v4 ORT WASM + glue under onnx-runtime-v4/.
   await mkdir(ORT_V4_DEST, { recursive: true });
   for (const name of ORT_V4_FILES) {
     const src = join(ORT_V4_SOURCE_DIR, name);

--- a/app/src/App/usePipeline.test.ts
+++ b/app/src/App/usePipeline.test.ts
@@ -159,7 +159,7 @@ describe('usePipeline', () => {
 
   it('ocr() falls back gracefully when loadClassifier throws', async () => {
     // Force the flag on for this test, then expect the inner load to
-    // fail (jsdom can't run @xenova/transformers) and the pipeline to
+    // fail (jsdom can't run @huggingface/transformers) and the pipeline to
     // still complete with deterministic findings.
     Object.defineProperty(window, 'location', {
       value: new URL('http://localhost/?phase18=on'),

--- a/app/src/llm/loadClassifier.test.ts
+++ b/app/src/llm/loadClassifier.test.ts
@@ -1,19 +1,10 @@
 import { afterEach, describe, it, expect, vi } from 'vitest';
-import {
-  DEFAULT_MODEL_ID,
-  loadClassifier,
-  readRuntimeFlag,
-  _resetClassifierCacheForTests,
-} from './loadClassifier';
+import { DEFAULT_MODEL_ID, loadClassifier, _resetClassifierCacheForTests } from './loadClassifier';
 
 afterEach(() => {
   _resetClassifierCacheForTests();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
-  Object.defineProperty(window, 'location', {
-    configurable: true,
-    value: new URL('http://localhost/'),
-  });
 });
 
 describe('Phase 18 loadClassifier', () => {
@@ -43,39 +34,5 @@ describe('Phase 18 loadClassifier', () => {
     expect(a).toBe(b);
     a.catch(() => {});
     b.catch(() => {});
-  });
-});
-
-describe('Wave 36 readRuntimeFlag (v4-default after Part B)', () => {
-  it('returns v4 when no flag is present (default after Part B flip)', () => {
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: new URL('http://localhost/'),
-    });
-    expect(readRuntimeFlag()).toBe('v4');
-  });
-
-  it('returns v2 when the ?transformersV2=on kill switch is set', () => {
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: new URL('http://localhost/?transformersV2=on'),
-    });
-    expect(readRuntimeFlag()).toBe('v2');
-  });
-
-  it('returns v4 when transformersV2 is set to anything other than "on"', () => {
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: new URL('http://localhost/?transformersV2=true'),
-    });
-    expect(readRuntimeFlag()).toBe('v4');
-  });
-
-  it('coexists with other URL params (v2 kill switch wins)', () => {
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: new URL('http://localhost/?phase18=on&transformersV2=on&debug=1'),
-    });
-    expect(readRuntimeFlag()).toBe('v2');
   });
 });

--- a/app/src/llm/loadClassifier.ts
+++ b/app/src/llm/loadClassifier.ts
@@ -1,18 +1,11 @@
-// Wave 20 Part C / Wave 36 Part A — Phase 18 lazy-loader.
+// Wave 20 Part C / Wave 36 — Phase 18 lazy-loader.
 //
-// Wave 36 added a dual-runtime branch. The legacy `@xenova/transformers`
-// path remains the default; setting the URL flag `?transformersV4=on`
-// switches to `@huggingface/transformers@4`, the official upstream
-// successor. The branch lives at the dynamic-import boundary so the
-// inactive runtime never enters the user's bundle. Wave 36 Part C
-// removes the v2 branch after Part B's smoke walk validates the flip.
-//
-// The v4 spike (Part 0) found two API divergences from v2 that this
-// loader has to handle: (1) v4's default `dtype` is fp32, so it would
-// look for `onnx/model.onnx` — passing `dtype: 'q8'` redirects it to
-// the existing `onnx/model_quantized.onnx` weights; (2) v4 typings
-// make `env.backends.onnx.wasm` possibly undefined, requiring an
-// existence guard.
+// Runtime: `@huggingface/transformers@4`. Two API quirks this loader
+// has to handle: (1) v4's default `dtype` is fp32, so it would look
+// for `onnx/model.onnx` — passing `dtype: 'q8'` redirects it to the
+// existing `onnx/model_quantized.onnx` weights; (2) v4 typings make
+// `env.backends.onnx.wasm` possibly undefined, requiring an existence
+// guard.
 //
 // Local-only contract: the downloader (`npm run build:classifier-assets`)
 // places the model under `app/public/classifier/<modelId>/`, so the
@@ -39,48 +32,6 @@ export const DEFAULT_MODEL_ID = 'Xenova/paraphrase-MiniLM-L3-v2';
 
 let cached: Promise<EmbedFunction> | null = null;
 
-/**
- * Wave 36 — read the runtime-selection URL flag.
- *
- * Wave 36 Part B flipped the default to v4. The `?transformersV2=on`
- * kill switch is transient — Part C removes it once the v4-default
- * window proves stable. SSR-safe: returns v4 (the default) when
- * `window` is undefined.
- */
-export function readRuntimeFlag(): 'v2' | 'v4' {
-  if (typeof window === 'undefined') return 'v4';
-  const search = window.location?.search ?? '';
-  const params = new URLSearchParams(search);
-  if (params.get('transformersV2') === 'on') return 'v2';
-  return 'v4';
-}
-
-async function loadV2Pipeline(modelId: string): Promise<EmbedFunction> {
-  const transformers = await import('@xenova/transformers');
-  transformers.env.localModelPath = '/classifier/';
-  transformers.env.allowRemoteModels = false;
-  // Self-host the ONNX Runtime WASM so the classifier never reaches
-  // out to a CDN (the default `wasmPaths` is jsdelivr — blocked by
-  // the app's `connect-src 'self'` CSP). Single-thread SIMD: the
-  // threaded variants need SharedArrayBuffer (COOP/COEP), which the
-  // app doesn't enable.
-  transformers.env.backends.onnx.wasm.wasmPaths = '/classifier/onnx-runtime/';
-  transformers.env.backends.onnx.wasm.numThreads = 1;
-  const pipeline = transformers.pipeline as (task: string, model: string) => Promise<unknown>;
-  const extractor = (await pipeline('feature-extraction', modelId)) as (
-    input: string | string[],
-    opts?: { pooling?: string; normalize?: boolean },
-  ) => Promise<{ data: Float32Array }>;
-  return async (texts: string[]) => {
-    const out: Float32Array[] = [];
-    for (const t of texts) {
-      const r = await extractor(t, { pooling: 'mean', normalize: true });
-      out.push(r.data);
-    }
-    return out;
-  };
-}
-
 async function loadV4Pipeline(modelId: string): Promise<EmbedFunction> {
   const transformers = await import('@huggingface/transformers');
   transformers.env.localModelPath = '/classifier/';
@@ -91,12 +42,11 @@ async function loadV4Pipeline(modelId: string): Promise<EmbedFunction> {
   transformers.env.allowLocalModels = true;
   transformers.env.allowRemoteModels = false;
   // Self-host v4 ORT WASM same-origin under `/classifier/onnx-runtime-v4/`.
-  // Mirrors v2's `/classifier/onnx-runtime/` pattern. With `wasmPaths`
-  // unset, v4's runtime resolves the `.wasm` via `import.meta.url` from
-  // the bundled `.mjs` glue and falls back to a jsdelivr CDN fetch for
-  // sibling files — both paths are blocked by the app's CSP
-  // (`connect-src 'self'`). `build:classifier-assets` copies
-  // `ort-wasm-simd-threaded.{wasm,mjs}` from
+  // With `wasmPaths` unset, v4's runtime resolves the `.wasm` via
+  // `import.meta.url` from the bundled `.mjs` glue and falls back to a
+  // jsdelivr CDN fetch for sibling files — both paths are blocked by
+  // the app's CSP (`connect-src 'self'`). `build:classifier-assets`
+  // copies `ort-wasm-simd-threaded.{wasm,mjs}` (and variants) from
   // `node_modules/@huggingface/transformers/node_modules/onnxruntime-web/dist/`.
   // ORT 1.19 ships only threaded variants but degrades to single-thread
   // when `SharedArrayBuffer` is unavailable (no COOP/COEP); `numThreads = 1`
@@ -130,15 +80,10 @@ async function loadV4Pipeline(modelId: string): Promise<EmbedFunction> {
   };
 }
 
-/**
- * Load (or return cached) the on-device classifier. Branches on the
- * Wave 36 `?transformersV4=on` URL flag at the dynamic-import boundary.
- */
+/** Load (or return cached) the on-device classifier. */
 export function loadClassifier(modelId: string = DEFAULT_MODEL_ID): Promise<EmbedFunction> {
   if (cached) return cached;
-  cached = readRuntimeFlag() === 'v4'
-    ? loadV4Pipeline(modelId)
-    : loadV2Pipeline(modelId);
+  cached = loadV4Pipeline(modelId);
   return cached;
 }
 

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -27,20 +27,17 @@ export default defineConfig({
         // precache write with transformers' direct fetch throws
         // ERR_CACHE_WRITE_FAILURE in fresh profiles. It's still served
         // same-origin (CSP requires it) — just on-demand, not up-front.
-        // - `classifier/onnx-runtime/**` covers v2's WASM staged by
-        //   `npm run build:classifier-assets`.
-        // - `classifier/onnx-runtime-v4/**` covers v4's WASM (Wave 36
-        //   Part B). v4 ships four `.wasm`/`.mjs` pairs and picks one
-        //   at runtime by capability detection; we stage all four
-        //   same-origin and let it resolve `wasmPaths` against
-        //   `/classifier/onnx-runtime-v4/`. Some variants exceed
-        //   Workbox's 18 MiB per-file cap anyway (jsep ~26 MiB),
-        //   which forces the same on-demand-fetch contract as v2.
-        // - `assets/ort-wasm-*` is a defensive carry-over from the
-        //   Part A bundling attempt; harmless to keep.
+        // v4 ships four `.wasm`/`.mjs` pairs and picks one at runtime
+        // by capability detection; we stage all four same-origin and
+        // let it resolve `wasmPaths` against `/classifier/onnx-runtime-v4/`.
+        // Some variants exceed Workbox's 18 MiB per-file cap anyway
+        // (jsep ~26 MiB), which forces the on-demand-fetch contract.
         globIgnores: [
-          'classifier/onnx-runtime/**',
           'classifier/onnx-runtime-v4/**',
+          // Vite emits hashed copies of v4's ORT `.wasm` glue under
+          // dist/assets/ (asyncify variant ~23 MB exceeds the 18 MiB
+          // per-file cap). Keep them out of precache; they're served
+          // on-demand same-origin.
           'assets/ort-wasm-*',
         ],
         maximumFileSizeToCacheInBytes: 18 * 1024 * 1024,

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -414,13 +414,16 @@ class we use. Effectively a Phase 18 rollback.
 **Update (Wave 33-A, 2026-04-27):** investigation confirmed
 `@xenova/transformers@2.17.2` is the end of that line — the package
 moved to `@huggingface/transformers@4.x` (different package, v2→v4
-breaking-change migration). Migration is its own future Phase 19
-wave with explicit brainstorm; not folded into hygiene work. Until
-that lands, `audit:prod` filters
+breaking-change migration). Until that landed, `audit:prod`
+filtered
 [GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg)
-via `app/scripts/audit-prod.mjs` `ALLOW_ADVISORIES`. Any *new*
-high+ advisory that doesn't trace back to that ID still fails the
-gate.
+via `app/scripts/audit-prod.mjs` `ALLOW_ADVISORIES`.
+
+**Resolved (Wave 36-C, 2026-04-28):** `@xenova/transformers` removed
+from `dependencies`; v4 (`@huggingface/transformers@4.2.0`) is the
+sole runtime. The vulnerable `protobufjs` chain no longer surfaces
+in `npm audit --omit=dev`, and `ALLOW_ADVISORIES` is now empty.
+This entry is retained for historical context.
 
 ### 7.2 `esbuild <=0.24.2` — dev-server cross-origin reads
 


### PR DESCRIPTION
## Summary

- Pure subtractive: deletes the v2 transformers runtime branch (now that Wave 36-B made v4 default), the `?transformersV2=on` kill switch, the `@xenova/transformers` npm dep (−39 packages), the v2 ORT WASM staging, and the now-stale `protobufjs` allowlist entry that only existed because v2 pinned vulnerable transitives.
- Net diff: **9 files changed, +70 / −628**. Precache budget after build: 35 entries / ~30.5 MiB (no v2 ORT in dist).

## Plan deviations

1. Plan §4 said remove `'assets/ort-wasm-*'` from `globIgnores`. Verified load-bearing — Vite emits hashed v4 ORT copies into `dist/assets/` (asyncify variant ~23 MB) that exceed Workbox's 18 MiB cap. Kept the entry; updated comment.
2. Plan §5 listed `RUN_REAL_MODEL=1 npx playwright test tests/e2e/hybrid-golden.spec.ts` as definition of done. Spec doesn't exist in the repo; relied on the 1413-test unit suite as evidence.
3. Bonus cleanup: emptied `audit-prod.mjs` `ALLOW_ADVISORIES`, updated `docs/SECURITY.md §7.1` to mark resolved (the vuln no longer surfaces post-v2-removal).

## Test plan

- [x] `npm install` — lockfile updates, 39 packages removed
- [x] `npm run build:classifier-assets` — only v4 staging runs
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test -- --run` — 1413 pass / 1 todo
- [x] `npm run build` — clean, precache 35 entries / 30502 KiB
- [x] `node scripts/audit-prod.mjs` — 0 unallowlisted vulns
- [x] `grep -r '@xenova\|transformersV2\|onnx-runtime/' src scripts vite.config.ts` — only the historical-context line in `audit-prod.mjs` remains
- [ ] CI: verify, smoke (webkit/chromium/firefox), Lighthouse CI, npm-audit