### PR TITLE
wave43: ratchet coverage floor to 96/90/93/96

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -100,10 +100,19 @@ export default defineConfig({
         // meaningful error-path and fallback branches. Actuals landed
         // at 97.52 / 90.21 / 94.26 / 97.52; branches cleared the 90.2
         // threshold so the floor steps up 89 → 90.
-        statements: 95,
+        //
+        // Ratcheted 2026-04-28 (Wave 43) per the measure→ratchet plan.
+        // Actuals: 97.56 / 90.29 / 94.27 / 97.56. New floor =
+        // floor(actual) - 1, clamped never to decrease. Branches
+        // headroom is 0.29 (< 2-pt margin per plan §4) so the branch
+        // floor holds at 90; the other three step up. Limiter files
+        // for any future branch push: src/worker/handleRequest.ts
+        // (71.42), src/parser/customRuleDraft.ts (79.41), and
+        // src/ui/renderPdfPages.ts (77.77).
+        statements: 96,
         branches: 90,
-        functions: 91,
-        lines: 95,
+        functions: 93,
+        lines: 96,
       },
     },
   },

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -89,17 +89,19 @@ which is also directly covered.
 ## Coverage thresholds
 
 Defined in `app/vite.config.ts` under `test.coverage.thresholds`.
-Current floors: **stmt 95 / branch 89 / func 91 / line 95**. Actuals
-as of 2026-04-26 (post-Wave-26-A): 97.24 / 89.62 / 93.58 / 97.24.
-Wave 26-A's coverage push closed targeted gaps in `extractPages.ts`
-(branches 43.75 → 60), `handleRequest.ts` (50 → 71.4), and
-`App.tsx` (84.6 → 85), but the new component flow tests in
-`App.test.tsx` exposed previously-unreached App.tsx branches that
-roughly offset the gains in aggregate (89.64 → 89.62). The 89→90
-floor bump SKIPPED per the plan's ≥ 90.5% contingency.
+Current floors: **stmt 96 / branch 90 / func 93 / line 96** (ratcheted
+2026-04-28 in Wave 43). Actuals as of 2026-04-28: 97.56 / 90.29 /
+94.27 / 97.56.
 
-Floors leave ~2 points of headroom on stmt/line, ~2.6 on func, ~0.6
-on branch — branch is the tight one because the two structural
+Ratchet rule: new floor = `floor(actual) - 1`, clamped never to
+decrease. Wave 43 stepped stmt/func/line up to 96/93/96; branch
+headroom (0.29) was below the 2-point margin so the branch floor
+held at 90. Limiter files for any future branch push:
+`src/worker/handleRequest.ts` (71.42), `src/parser/customRuleDraft.ts`
+(79.41), and `src/ui/renderPdfPages.ts` (77.77).
+
+Floors leave ~1.5 points of headroom on stmt/line, ~1.3 on func,
+~0.3 on branch — branch is the tight one because the two structural
 ceilings on the codebase keep it sticky:
 
 - `App.tsx` decomposition (Waves 17–21) trimmed it 1007 → 541 lines;


### PR DESCRIPTION
## Before / after

| Metric | Floor (before) | Actual | Floor (after) | Δ |
|---|---|---|---|---|
| Statements | 95 | 97.56 | **96** | +1 |
| Branches | 90 | 90.29 | **90** | 0 |
| Functions | 91 | 94.27 | **93** | +2 |
| Lines | 95 | 97.56 | **96** | +1 |

Ratchet rule: \`floor(actual) - 1\`, clamped never to decrease. Branches headroom is 0.29 — below the 2-pt margin per plan §4 — so the branch floor holds at 90. The other three step up.

## Headroom

- stmt: 1.56 pts (96 → 97.56)
- branch: 0.29 pts (90 → 90.29) — same as before, by design
- func: 1.27 pts (93 → 94.27)
- line: 1.56 pts (96 → 97.56)

## New tests

None. Plan §1.3 caps a ratchet wave at 5 new test files; this run had clean ratchet headroom on three of four metrics so no test additions were needed. The branch limiter is documented for a future targeted-tests wave.

## Limiter files (lowest-branch coverage)

- \`src/worker/handleRequest.ts\` — 71.42% branches
- \`src/parser/customRuleDraft.ts\` — 79.41% branches
- \`src/ui/renderPdfPages.ts\` — 77.77% branches

Future targets if a wave wants to push branches above 91. Not lifted here (pure ratchet wave; W41 in-flight on \`app/src/ui/**\` so test additions there would create rebase friction).

## Files changed

- \`app/vite.config.ts\` — bumped four threshold numbers + added the 2026-04-28 ratchet note in the comment ledger.
- \`docs/TESTING.md\` — recorded the new floor, date, and limiter files.

## Local gates

- \`npm run typecheck\` — clean.
- \`npm run lint\` — clean (0 warnings).
- \`npm run test:coverage\` (×2 to confirm non-flaky) — both passes; second-run actuals 97.59 / 90.28 / 94.4 / 97.59 confirms 1-pt margin is the right size.
- \`npm run build\` — succeeds.

## Test plan

- [x] Floors raised, not lowered (per hard rule §1.1)
- [x] Coverage gate green twice in a row (jitter check)
- [x] No source-file edits except the coverage block (per hard rule §1.4 — disjoint from W39's territory)
- [x] No test files added or removed
- [x] \`docs/TESTING.md\` reflects new floor + date
- [ ] CI verify / smoke / npm-audit / Lighthouse all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)