### PR TITLE
wave39: tech-debt sweep (2 items)

### DIFF
--- a/app/scripts/check-bundle-budget.mjs
+++ b/app/scripts/check-bundle-budget.mjs
@@ -131,6 +131,16 @@ async function main() {
   // recursively under dist/classifier/ if present. Wave 23-A's
   // build:classifier-assets script writes onnx/model_quantized.onnx
   // into a subdirectory, so a non-recursive walk would under-count.
+  //
+  // Wave 39: skip `onnx-runtime-v4/`. Wave 36-B stages ~75 MiB of ORT
+  // `.wasm`/`.mjs` glue under `dist/classifier/onnx-runtime-v4/` for
+  // same-origin on-demand fetch, but `vite.config.ts` `globIgnores`
+  // explicitly excludes that subtree from the PWA precache. The cap
+  // here is the *precache* contract from Wave 18-B; counting
+  // non-precached bytes against it produces a false-fail on machines
+  // that have classifier assets on disk (101 MiB / 30 MiB) and is
+  // semantically wrong. Walk skips the directory by name.
+  const PRECACHE_SKIP = new Set(['onnx-runtime-v4']);
   async function walkBytes(dir) {
     let total = 0;
     let entries;
@@ -140,6 +150,7 @@ async function main() {
       return 0;
     }
     for (const e of entries) {
+      if (e.isDirectory() && PRECACHE_SKIP.has(e.name)) continue;
       const p = join(dir, e.name);
       if (e.isDirectory()) total += await walkBytes(p);
       else if (e.isFile()) total += (await stat(p)).size;

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -681,29 +681,26 @@ address — visual or product-level work, not source-color cleanup.
       held green since 2026-04-25 — closing the row. If the flake
       returns, reopen with the new failure mode rather than
       reapplying the same fix.
-- [ ] **Tauri CI workflow cleanup.** `docs/CLAUDE.md` lists the Tauri
-      desktop wrapper as "stub dir exists; no code", but
-      `.github/workflows/tauri.yml` still runs
-      `Tauri build (ubuntu-latest / macos-latest / windows-latest)`
-      against the stub. Wave 29 unblock work scoped the trigger to
-      `app/src-tauri/**` + the workflow file (PR #121) so it no
-      longer fires on JS-only PRs, but the underlying choice
-      remains: delete the workflow to match the stub reality, or
-      wire it up to actual Rust source. Surfaced 2026-04-26 while
-      unblocking Wave 28's broken-CI ghost.
-- [ ] **npm-audit triage refresh.** As of 2026-04-26 PR #121, audit
-      reports 4 critical + 9 moderate vulns. Build-only chains
-      (`esbuild` → `vite` → `vitest`, `uuid` → `@storybook/addon-actions`)
-      are tolerable. The runtime-shipping chain
-      `protobufjs` → `onnx-proto` → `onnxruntime-web` (introduced
-      with Phase 18 transformers.js in Wave 22) is the one that
-      deserves a real look — either upgrade `onnxruntime-web` past
-      the affected protobufjs range or document the residual risk.
-      Wave 26-B's `package.json` `overrides` block has aged out;
-      refresh it. Note that during Wave 29 unblock work,
-      `npm-audit` was dropped from required GitHub branch-protection
-      checks — that is **temporary** and should be reinstated as a
-      required check once this row closes.
+- [x] **Tauri CI workflow cleanup.** Resolved by Wave 42 (PR #157,
+      2026-04-28) — chose retire: deleted `.github/workflows/tauri.yml`,
+      removed the `app/src-tauri/` stub, dropped the Tauri reference
+      from `docs/CLAUDE.md`. Decision recorded in
+      `docs/wave42-tauri-decision.md`.
+- [x] **npm-audit triage refresh.** Runtime-shipping vuln chain is
+      **clear** as of Wave 39 (2026-04-28): `npm audit --omit=dev`
+      reports 0 vulnerabilities. The Wave 36 transformers v2→v4
+      migration moved the `onnxruntime-web` chain past the affected
+      `protobufjs` range, so the original concern in this row no
+      longer applies. Remaining 17 build-only vulns (lighthouse →
+      inquirer → external-editor → tmp; storybook → uuid) are
+      tolerated as before. The `package.json` `overrides` block
+      (`serialize-javascript` ^7.0.5) is **still active** —
+      `npm ls serialize-javascript` confirms the override is
+      pinning workbox-build's transitive dep to the secure version,
+      not aged out as previously assumed. Reinstating
+      `npm-audit` as a required branch-protection check is a
+      separate ops task; tracked under "Branch-protection
+      self-healing" below.
 - [ ] **Branch-protection self-healing.** When the Tauri workflow row
       above ships (delete or repair), also clean up the
       `Tauri build (ubuntu-latest / macos-latest)` entries from the


### PR DESCRIPTION
## Item 1 — Fix \`check:budget\` ORT-WASM miscount

**What.** \`scripts/check-bundle-budget.mjs\`'s \`walkBytes(dist/classifier/)\` was including the ~75 MiB \`onnx-runtime-v4/\` subtree, which \`vite.config.ts\` \`globIgnores\` already excludes from the PWA precache. The script measures *on-disk-under-dist*, but the 30 MiB cap is a *precache* contract from Wave 18-B. Walk now skips the \`onnx-runtime-v4/\` directory to align with \`globIgnores\`.

**Why.** Real annoyance × frequency. Wave 38's bundle re-audit flagged this as Follow-up §2: locally \`npm run check:budget\` was reporting 101.5 MiB / 30 MiB cap (false-fail) on any machine with classifier assets staged; CI was passing trivially because \`npm run build\` doesn't run \`build:classifier-assets\`. Either way the gate was useless. Effort is one walk-loop check.

**Verification.** Locally \`npm run check:budget\` now reports OCR + classifier combined = 26.0 MiB (under the 30 MiB cap). CI behavior unchanged — \`dist/classifier/\` is empty in CI, walk returns 0, gate still trivially passes.

**Files.** \`app/scripts/check-bundle-budget.mjs\` (+11 / -0).

## Item 2 — BACKLOG row hygiene

Two rows in \"Cross-cutting tech debt\" that referenced concerns already resolved:

### \"Tauri CI workflow cleanup\" → CLOSED

Resolved by Wave 42 (PR #157, 2026-04-28). Chose the retire path: deleted \`.github/workflows/tauri.yml\`, removed \`app/src-tauri/\` stub, dropped the Tauri reference from \`docs/CLAUDE.md\`. Decision recorded in \`docs/wave42-tauri-decision.md\`.

### \"npm-audit triage refresh\" → CLOSED with evidence

The original concern was the runtime-shipping chain \`protobufjs\` → \`onnx-proto\` → \`onnxruntime-web\`. After Wave 36's transformers v2→v4 migration, \`npm audit --omit=dev\` now returns:

\`\`\`
found 0 vulnerabilities
\`\`\`

The chain moved past the affected \`protobufjs\` range with v4. Remaining 17 build-only vulns (lighthouse → inquirer → external-editor → tmp; storybook → uuid) are tolerated as before — none ship to production. Also corrected the row's claim that the \`serialize-javascript\` \`overrides\` block had \"aged out\": \`npm ls serialize-javascript\` confirms it is **still active**, pinning workbox-build's transitive copy to the secure ^7.0.5 version. Row was wrong; fixed.

**Why.** Stale BACKLOG rows = noise, and they distort the next session's tech-debt scoring. Both fixes are pure documentation truth-up.

**Files.** \`docs/BACKLOG.md\` (+18 / -23).

## Deferred

- **Wave 38 follow-up §1: pdf.worker precached twice.** The fix needs to extract the \`await import('pdfjs-dist/legacy/build/pdf.worker.mjs')\` to a shared helper so Vite emits one chunk, but one of the two import sites is \`app/src/ui/renderPdfPages.ts\` — \`app/src/ui/**\` is W41 territory under hard rule §1.2 of this plan. Defer to a dedicated mini-wave once W41 lands.
- **Branch-protection self-healing.** Removing the dead \`Tauri build (...)\` entries from \`main\`'s required-status-checks list, and reinstating \`npm-audit\` + \`enforce_admins: true\`. This is a \`gh api\` ops change to shared infrastructure, not a code change — separate operational task with explicit user confirmation per global CLAUDE.md.

## Local gates

- \`npm run typecheck\` — clean.
- \`npm run lint\` — clean (0 warnings).
- \`npm test\` — 180 files / 1413 passing / 1 todo.
- \`npm run build\` — succeeds.
- \`npm run check:budget\` — passes (combined 26.0 MiB / 30 MiB cap).
- \`npm audit --omit=dev\` — 0 vulnerabilities.
- \`git diff --stat\` — 2 files (well under §1.5's ≤6 cap).

## Test plan

- [x] No UI files touched (W41 territory off-limits)
- [x] No test files touched (W43 territory off-limits)
- [x] No new dependency edits (no \`npm install\` required)
- [x] Local \`check:budget\` passes locally for the first time post-Wave-36
- [ ] CI verify / smoke / npm-audit / Lighthouse all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)