### PR TITLE
docs(design): add PRODUCT.md, DESIGN.md, DESIGN.json + agent pointer

### DIFF
--- a/DESIGN.json
+++ b/DESIGN.json
@@ -1,0 +1,228 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-04-29T00:00:00Z",
+  "title": "Design System: LeaseGuard",
+  "extensions": {
+    "colorMeta": {
+      "paper": {
+        "role": "neutral",
+        "displayName": "Aged Cream",
+        "canonical": "oklch(96.5% 0.018 85)",
+        "tonalRamp": ["#1c170f", "#2f2719", "#473a23", "#65553a", "#8a7a5b", "#b3a583", "#d8cdb1", "#faf6ee"]
+      },
+      "paper-raised": {
+        "role": "neutral",
+        "displayName": "Paper-Raised",
+        "canonical": "oklch(99% 0.005 85)",
+        "tonalRamp": ["#1c170f", "#2f2719", "#473a23", "#65553a", "#8a7a5b", "#b3a583", "#e3dac5", "#ffffff"]
+      },
+      "paper-sunken": {
+        "role": "neutral",
+        "displayName": "Folded Page",
+        "canonical": "oklch(94.5% 0.025 85)",
+        "tonalRamp": ["#1a160e", "#2c2417", "#443821", "#615238", "#867759", "#aea182", "#d2c8ad", "#f3eddc"]
+      },
+      "fg": {
+        "role": "neutral",
+        "displayName": "Ink Black",
+        "canonical": "oklch(22% 0.015 70)",
+        "tonalRamp": ["#100c08", "#1a140e", "#2a2316", "#3d3320", "#5a4a2d", "#7d6940", "#a89060", "#d4bf8c"]
+      },
+      "fg-body": {
+        "role": "neutral",
+        "displayName": "Walnut Body",
+        "canonical": "oklch(33% 0.025 70)",
+        "tonalRamp": ["#1a140d", "#26200f", "#332b16", "#4a3f25", "#685735", "#8c7547", "#b5985e", "#dcc185"]
+      },
+      "fg-muted": {
+        "role": "neutral",
+        "displayName": "Walnut Muted",
+        "canonical": "oklch(50% 0.025 70)",
+        "tonalRamp": ["#1f1a13", "#322b1d", "#4d432d", "#7a6f57", "#9f9075", "#b9aa8e", "#d3c4a8", "#ebdec3"]
+      },
+      "fg-faint": {
+        "role": "neutral",
+        "displayName": "Walnut Faint",
+        "canonical": "oklch(66% 0.022 70)",
+        "tonalRamp": ["#3a3220", "#52472d", "#6b5d3e", "#8a7b58", "#a59a7e", "#bfb59b", "#d6cfb8", "#ebe6d4"]
+      },
+      "rule": {
+        "role": "neutral",
+        "displayName": "Margin Rule",
+        "canonical": "oklch(83% 0.022 80)",
+        "tonalRamp": ["#3a3220", "#544830", "#6f6041", "#8b7c5a", "#a99a78", "#c2b693", "#d6cdb6", "#ebe5d3"]
+      },
+      "rule-subtle": {
+        "role": "neutral",
+        "displayName": "Rule Subtle",
+        "canonical": "oklch(89% 0.018 80)",
+        "tonalRamp": ["#3f3724", "#5a4f35", "#776a48", "#948668", "#b1a487", "#cabfa3", "#dcd3ba", "#e8e0cf"]
+      },
+      "ink": {
+        "role": "primary",
+        "displayName": "Court Slate",
+        "canonical": "oklch(34% 0.05 235)",
+        "tonalRamp": ["#0d1820", "#142733", "#1f3a4d", "#2c5168", "#3d6a85", "#5286a4", "#7ba9c4", "#a9c8da"]
+      },
+      "severity-high": {
+        "role": "secondary",
+        "displayName": "Terracotta Warning",
+        "canonical": "oklch(53% 0.13 35)",
+        "tonalRamp": ["#3a1409", "#5a2014", "#7c2f1e", "#9b3924", "#b1442d", "#c75c45", "#dc8170", "#eeb1a3"]
+      },
+      "severity-medium": {
+        "role": "secondary",
+        "displayName": "Mustard Caution",
+        "canonical": "oklch(63% 0.11 75)",
+        "tonalRamp": ["#3a2806", "#56390b", "#7a5316", "#9b6c20", "#b8862c", "#cea050", "#e0bc7a", "#eed5a8"]
+      },
+      "severity-low": {
+        "role": "secondary",
+        "displayName": "Sage Note",
+        "canonical": "oklch(50% 0.04 145)",
+        "tonalRamp": ["#172519", "#243823", "#34502f", "#465f3f", "#5a7a5a", "#7a9678", "#9eb39b", "#c2cfbf"]
+      },
+      "severity-info": {
+        "role": "secondary",
+        "displayName": "Stone Note",
+        "canonical": "oklch(53% 0.025 240)",
+        "tonalRamp": ["#181d22", "#262d33", "#384149", "#4d5862", "#6b7b8c", "#8a9aab", "#aab6c3", "#c8d0d9"]
+      },
+      "positive": {
+        "role": "tertiary",
+        "displayName": "Positive Green",
+        "canonical": "oklch(50% 0.06 145)",
+        "tonalRamp": ["#142319", "#1f3624", "#2e4d31", "#3e6440", "#4a7a4a", "#6b9468", "#92ad8c", "#bccab4"]
+      },
+      "negative": {
+        "role": "tertiary",
+        "displayName": "Negative Red",
+        "canonical": "oklch(45% 0.15 30)",
+        "tonalRamp": ["#330e07", "#521509", "#71200f", "#8a2818", "#9a3022", "#b54d3d", "#cc7869", "#e0a99d"]
+      },
+      "ring": {
+        "role": "accent",
+        "displayName": "Mustard Focus Ring",
+        "canonical": "oklch(63% 0.11 75)",
+        "tonalRamp": ["#3a2806", "#56390b", "#7a5316", "#9b6c20", "#b8862c", "#cea050", "#e0bc7a", "#eed5a8"]
+      }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Display", "purpose": "Page titles and modal headlines. One per surface." },
+      "heading": { "displayName": "Heading", "purpose": "Panel and section headers; sparing use." },
+      "body": { "displayName": "Body", "purpose": "Findings, document excerpts, plain-language readings. Capped at 65–75ch." },
+      "label": { "displayName": "Label", "purpose": "Form labels, button text, metadata. The chrome layer." },
+      "mono": { "displayName": "Mono", "purpose": "Hashes, IDs, JSON fragments where character integrity matters." }
+    },
+    "shadows": [
+      { "name": "shadow-paper", "value": "0 1px 0 rgba(42, 35, 22, 0.05)", "purpose": "Default 1px hairline lift for raised cards and panels in light mode." },
+      { "name": "shadow-paper-dark", "value": "0 1px 0 rgba(0, 0, 0, 0.45)", "purpose": "Hairline lift on warm-dark paper; deeper so it reads against the dark surface." }
+    ],
+    "motion": [
+      { "name": "transition-colors", "value": "150ms cubic-bezier(0.16, 1, 0.3, 1)", "purpose": "Default ease-out-quart for hover and active color shifts." },
+      { "name": "reduced-motion", "value": "0ms linear", "purpose": "Honor prefers-reduced-motion; disable transitions, keep state changes." }
+    ],
+    "breakpoints": [
+      { "name": "md", "value": "640px" },
+      { "name": "lg", "value": "960px" },
+      { "name": "xl", "value": "1280px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Default Button",
+      "kind": "button",
+      "refersTo": "button-default",
+      "description": "Primary action. Court Slate on Aged Cream, 44px tap target.",
+      "html": "<button class=\"ds-btn-default\">Open lease</button>",
+      "css": ".ds-btn-default { background: #1f3a4d; color: #faf6ee; height: 44px; min-width: 44px; padding: 0 12px; border: none; border-radius: 2px; font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; font-size: 14px; font-weight: 500; letter-spacing: 0.01em; cursor: pointer; transition: background-color 150ms cubic-bezier(0.16, 1, 0.3, 1); display: inline-flex; align-items: center; justify-content: center; } .ds-btn-default:hover { background: #1c3445; } .ds-btn-default:active { background: #182d3c; } .ds-btn-default:focus-visible { outline: 2px solid #1f3a4d; outline-offset: 0; box-shadow: 0 0 0 2px #faf6ee, 0 0 0 4px #b8862c; }"
+    },
+    {
+      "name": "Ghost Button",
+      "kind": "button",
+      "refersTo": "button-ghost",
+      "description": "Quiet secondary action. Transparent bg, mustard-wash hover.",
+      "html": "<button class=\"ds-btn-ghost\">Cancel</button>",
+      "css": ".ds-btn-ghost { background: transparent; color: #4a3f25; height: 44px; min-width: 44px; padding: 0 12px; border: none; border-radius: 2px; font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; font-size: 14px; font-weight: 500; letter-spacing: 0.01em; cursor: pointer; transition: background-color 150ms cubic-bezier(0.16, 1, 0.3, 1); display: inline-flex; align-items: center; justify-content: center; } .ds-btn-ghost:hover { background: rgba(184, 134, 44, 0.08); } .ds-btn-ghost:active { background: rgba(184, 134, 44, 0.16); } .ds-btn-ghost:focus-visible { outline: 2px solid #1f3a4d; outline-offset: 0; }"
+    },
+    {
+      "name": "Subtle Button",
+      "kind": "button",
+      "refersTo": "button-subtle",
+      "description": "Bordered, sunken-paper button. Heavier than ghost, lighter than default.",
+      "html": "<button class=\"ds-btn-subtle\">Compare</button>",
+      "css": ".ds-btn-subtle { background: #f3eddc; color: #4a3f25; height: 44px; min-width: 44px; padding: 0 12px; border: 1px solid #d6cdb6; border-radius: 2px; font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; font-size: 14px; font-weight: 500; letter-spacing: 0.01em; cursor: pointer; transition: background-color 150ms cubic-bezier(0.16, 1, 0.3, 1); display: inline-flex; align-items: center; justify-content: center; } .ds-btn-subtle:hover { background: rgba(184, 134, 44, 0.08); } .ds-btn-subtle:active { background: rgba(184, 134, 44, 0.16); } .ds-btn-subtle:focus-visible { outline: 2px solid #1f3a4d; outline-offset: 0; }"
+    },
+    {
+      "name": "Card",
+      "kind": "card",
+      "refersTo": "card",
+      "description": "Raised paper card. Hairline border, 1px hairline shadow, 16px padding.",
+      "html": "<article class=\"ds-card\"><h3 class=\"ds-card-title\">Auto-renewal clause</h3><p class=\"ds-card-body\">Clause 14.2 renews this lease for a further 12 months unless written notice is given 60 days before expiry.</p></article>",
+      "css": ".ds-card { background: #ffffff; color: #4a3f25; border: 1px solid #d6cdb6; border-radius: 2px; box-shadow: 0 1px 0 rgba(42, 35, 22, 0.05); padding: 16px; max-width: 65ch; } .ds-card-title { margin: 0 0 8px; font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; font-size: 15px; font-weight: 600; line-height: 22px; color: #2a2316; } .ds-card-body { margin: 0; font-family: 'Source Serif 4', 'Iowan Old Style', Georgia, serif; font-size: 14px; line-height: 22px; color: #4a3f25; }"
+    },
+    {
+      "name": "Text Field",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "Label-above input on paper-raised. Court Slate focus outline.",
+      "html": "<label class=\"ds-field\"><span class=\"ds-field-label\">Standard lease name</span><input class=\"ds-field-input\" type=\"text\" placeholder=\"e.g. residential-2024\"/></label>",
+      "css": ".ds-field { display: flex; flex-direction: column; gap: 4px; font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; } .ds-field-label { font-size: 12.5px; line-height: 18px; font-weight: 500; letter-spacing: 0.01em; color: #7a6f57; } .ds-field-input { background: #ffffff; color: #2a2316; border: 1px solid #d6cdb6; border-radius: 2px; padding: 6px 8px; height: 32px; font-family: 'Source Serif 4', 'Iowan Old Style', Georgia, serif; font-size: 14px; line-height: 22px; outline: none; transition: border-color 150ms cubic-bezier(0.16, 1, 0.3, 1); } .ds-field-input::placeholder { color: #a59a7e; } .ds-field-input:focus-visible { outline: 2px solid #1f3a4d; outline-offset: 0; }"
+    },
+    {
+      "name": "Severity Badge — High",
+      "kind": "chip",
+      "refersTo": "card",
+      "description": "High-severity finding marker. Tinted background + icon + label; never color-only.",
+      "html": "<span class=\"ds-sev-high\"><svg class=\"ds-sev-icon\" viewBox=\"0 0 16 16\" aria-hidden=\"true\"><path d=\"M8 1.5l7 12.5H1L8 1.5zm0 4.75v3.5M8 11.5v.5\" fill=\"none\" stroke=\"#2a2316\" stroke-width=\"1.5\" stroke-linecap=\"round\"/></svg><span>High</span></span>",
+      "css": ".ds-sev-high { display: inline-flex; align-items: center; gap: 6px; background: color-mix(in srgb, #b1442d 22%, #ffffff); border: 1px solid color-mix(in srgb, #b1442d 40%, transparent); color: #2a2316; padding: 2px 8px; border-radius: 2px; font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; font-size: 12.5px; line-height: 18px; font-weight: 600; letter-spacing: 0.01em; } .ds-sev-icon { width: 14px; height: 14px; flex-shrink: 0; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Marginalia Edition",
+    "overview": "The lease is the primary text. Findings, redlines, and counter-offers are careful annotations in the margin, written by someone who has read the document slowly and twice. The interface borrows from a lawyer's working copy: cream paper, hairline rules, a single ink color, and severity that shows up where a reader would actually mark it, never as decoration.\n\nThe system is restrained on purpose. Only one accent (Court Slate) carries non-severity emphasis; all other color is functional and earned. Surfaces are layered tonally (paper, paper-raised, paper-sunken) before they are shadowed; ambient shadows exist but stay below the threshold of \"designed.\" Type is a serif body (Source Serif 4) for findings and document content, paired with a system sans for chrome and labels.\n\nWhat this rejects: the friendly-legal genre (LegalZoom mascots, purple gradients), crypto / neon-on-black, the generic SaaS dashboard (hero-metric tiles, rainbow chart palettes, identical card grids), and DocuSign-corporate trust theatre.",
+    "keyCharacteristics": [
+      "Paper-and-ink palette built around warm neutrals.",
+      "Source Serif 4 body type at a 65–75ch measure, never the legal-tool 90ch wall.",
+      "Single accent (Court Slate #1f3a4d) used sparingly; severity carries the rest.",
+      "Tonal layering before shadow; shadows are ambient and quiet.",
+      "Tap targets at 44px (WCAG 2.5.5 AAA) for primary actions, 32px for dense toolbars only.",
+      "Severity is never color-only: every tinted surface pairs with icon + label."
+    ],
+    "rules": [
+      { "name": "The One Voice Rule", "body": "Court Slate is the only non-severity accent. If something needs emphasis and isn't a severity finding, it is Court Slate or it is type weight; it is never a new color.", "section": "colors" },
+      { "name": "The Severity-Earned Rule", "body": "Severity colors appear on severity surfaces only: finding cards, severity badges, severity-filter chips, audit-log entries that reference severity. They never decorate generic UI. Pair every severity surface with an icon and a text label so the signal survives color-blindness and screen readers.", "section": "colors" },
+      { "name": "The No-Pure-Black Rule", "body": "#000 and #fff are forbidden. Even paper-raised carries a faint warm undertone in dark mode. Tinted neutrals only.", "section": "colors" },
+      { "name": "The Serif-for-Substance Rule", "body": "Body type is serif. Document content, findings, and explanations get Source Serif 4. UI chrome (buttons, labels, form fields, navigation) gets the system sans. Don't mix: a serif button or a sans finding both feel wrong.", "section": "typography" },
+      { "name": "The Measure Rule", "body": "Body and findings cap at 65–75ch. Wide-screen practitioner views may show two columns at 65ch each before they break to 90ch.", "section": "typography" },
+      { "name": "The Plain-Reading Rule", "body": "When the rule pack uses a term of art, render the term in the body type; render its plain reading directly beneath in the same size and a slightly lighter weight (Walnut Body). The renter should never need a glossary to understand a finding.", "section": "typography" },
+      { "name": "The Tonal-Before-Shadow Rule", "body": "Always reach for a paper tone first (paper-sunken, paper, paper-raised) before reaching for a shadow. Shadow appears only where tonal layering is insufficient (e.g. an overlay floating above the document plane).", "section": "elevation" },
+      { "name": "The Hairline Rule", "body": "No diffuse glows, no 24px ambient blurs, no glassmorphism. If a surface needs to lift, it lifts by 1px and a tone change.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do use Court Slate (#1f3a4d) as the only non-severity accent.",
+      "Do layer tonally (paper-sunken → paper → paper-raised) before reaching for a shadow.",
+      "Do pair every severity surface with an icon and a text label.",
+      "Do cap body and findings text at 65–75ch.",
+      "Do use Source Serif 4 for findings and document content; system sans for buttons, labels, and chrome.",
+      "Do keep primary tap targets at 44×44 (WCAG 2.5.5 AAA); reserve 32×32 for dense toolbars only.",
+      "Do use the severity-bg-* token pairs for severity row highlights and badges; their color-mix() definition auto-rebalances in dark mode.",
+      "Do honor prefers-reduced-motion; reserve motion for state transitions where it aids comprehension."
+    ],
+    "donts": [
+      "Don't introduce new side-stripe borders. The 3px border-l on the legacy Card primitive is the system's one heritage exception and should be migrated to the severity-bg-* background-tint pattern. New severity surfaces use background tint + icon + label, never a colored side stripe.",
+      "Don't use #000 or #fff literally. Tinted neutrals only.",
+      "Don't use gradient text or background-clip: text for decoration. Emphasis is weight or size.",
+      "Don't add diffuse ambient shadows, glow halos, or glassmorphism blurs. The hairline shadow-paper is the entire elevation vocabulary.",
+      "Don't ship the friendly-legal genre: no mascots, no \"we make legal easy!\" cheer, no rounded purple gradients, no LegalZoom vocabulary.",
+      "Don't ship the SaaS-dashboard reflex: no hero-metric tiles, no rainbow chart palettes, no identical card grids of features.",
+      "Don't ship crypto/neon-on-black: no glowing accents, no animated gradients, no fintech-coded aggression.",
+      "Don't ship DocuSign-corporate: no stock photos of handshakes, no navy-and-yellow trust theatre.",
+      "Don't introduce a serif button or a sans finding-body. Serif for substance, sans for chrome.",
+      "Don't use severity color outside severity surfaces. Mustard is not a \"pop\"; Terracotta is not a \"warm accent.\"",
+      "Don't signal severity by color alone. Always icon + label.",
+      "Don't write modals as a first thought. Inline disclosure and panel state precede dialogs.",
+      "Don't wrap everything in a card. Long-form content, document text, and finding bodies often read better as bare text on the paper surface with rule lines separating sections."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,417 @@
+---
+name: LeaseGuard
+description: Local-first lease analyzer; cream paper, ink rules, severity in the margins.
+colors:
+  paper: "#faf6ee"
+  paper-raised: "#ffffff"
+  paper-sunken: "#f3eddc"
+  fg: "#2a2316"
+  fg-body: "#4a3f25"
+  fg-muted: "#7a6f57"
+  fg-faint: "#a59a7e"
+  rule: "#d6cdb6"
+  rule-subtle: "#e8e0cf"
+  ink: "#1f3a4d"
+  severity-high: "#b1442d"
+  severity-medium: "#b8862c"
+  severity-low: "#5a7a5a"
+  severity-info: "#6b7b8c"
+  positive: "#4a7a4a"
+  negative: "#9a3022"
+  ring: "#b8862c"
+typography:
+  display:
+    fontFamily: "Source Serif 4, Iowan Old Style, Georgia, serif"
+    fontSize: "28px"
+    fontWeight: 600
+    lineHeight: "32px"
+    letterSpacing: "normal"
+  heading:
+    fontFamily: "ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
+    fontSize: "15px"
+    fontWeight: 600
+    lineHeight: "22px"
+    letterSpacing: "normal"
+  body:
+    fontFamily: "Source Serif 4, Iowan Old Style, Georgia, serif"
+    fontSize: "14px"
+    fontWeight: 400
+    lineHeight: "22px"
+    letterSpacing: "normal"
+  label:
+    fontFamily: "ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
+    fontSize: "12.5px"
+    fontWeight: 500
+    lineHeight: "18px"
+    letterSpacing: "0.01em"
+  mono:
+    fontFamily: "JetBrains Mono, ui-monospace, Menlo, monospace"
+    fontSize: "12px"
+    fontWeight: 400
+    lineHeight: "18px"
+    letterSpacing: "normal"
+rounded:
+  sm: "2px"
+  md: "4px"
+spacing:
+  xs: "4px"
+  sm: "8px"
+  md: "12px"
+  lg: "16px"
+  xl: "24px"
+components:
+  button-default:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.paper}"
+    rounded: "{rounded.sm}"
+    padding: "0 12px"
+    height: "44px"
+  button-ghost:
+    backgroundColor: "transparent"
+    textColor: "{colors.fg-body}"
+    rounded: "{rounded.sm}"
+    padding: "0 12px"
+    height: "44px"
+  button-subtle:
+    backgroundColor: "{colors.paper-sunken}"
+    textColor: "{colors.fg-body}"
+    rounded: "{rounded.sm}"
+    padding: "0 12px"
+    height: "44px"
+  button-default-sm:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.paper}"
+    rounded: "{rounded.sm}"
+    padding: "0 8px"
+    height: "32px"
+  card:
+    backgroundColor: "{colors.paper-raised}"
+    textColor: "{colors.fg-body}"
+    rounded: "{rounded.sm}"
+    padding: "16px"
+  input:
+    backgroundColor: "{colors.paper-raised}"
+    textColor: "{colors.fg}"
+    rounded: "{rounded.sm}"
+    padding: "4px 8px"
+    height: "32px"
+---
+
+# Design System: LeaseGuard
+
+## 1. Overview
+
+**Creative North Star: "The Marginalia Edition"**
+
+The lease is the primary text. Findings, redlines, and counter-offers are
+careful annotations in the margin, written by someone who has read the
+document slowly and twice. The interface borrows from a lawyer's working
+copy: cream paper, hairline rules, a single ink color, and severity that
+shows up where a reader would actually mark it, never as decoration.
+
+The system is restrained on purpose. Only one accent (Court Slate) carries
+non-severity emphasis; all other color is functional and earned. Surfaces
+are layered tonally (paper, paper-raised, paper-sunken) before they are
+shadowed; ambient shadows exist but stay below the threshold of "designed."
+Type is a serif body (Source Serif 4) for findings and document content,
+paired with a system sans for chrome and labels. Density is dialled per
+surface: renter views breathe, practitioner panels pack in.
+
+What this rejects, in line with `PRODUCT.md`: the friendly-legal genre
+(LegalZoom mascots, purple gradients), crypto / neon-on-black, the generic
+SaaS dashboard (hero-metric tiles, rainbow chart palettes, identical card
+grids), and DocuSign-corporate trust theatre. None of those vocabularies
+appear here.
+
+**Key Characteristics:**
+
+- Paper-and-ink palette built around `oklch`-equivalent warm neutrals.
+- Source Serif 4 body type at a 65–75ch measure, never the legal-tool 90ch wall.
+- Single accent (Court Slate `#1f3a4d`) used sparingly; severity carries the rest.
+- Tonal layering before shadow; shadows are ambient and quiet.
+- Tap targets at 44px (WCAG 2.5.5 AAA) for primary actions, 32px for dense toolbars only.
+- Severity is never color-only: every tinted surface pairs with icon + label.
+
+## 2. Colors: The Marginalia Palette
+
+A warm-cream paper palette anchored by a single deep ink accent, with four
+functional severity hues borrowed from the natural-pigment side of the
+spectrum (terracotta, mustard, sage, stone).
+
+### Primary
+
+- **Court Slate** (`#1f3a4d`): the system's one true accent. Default
+  buttons, primary links, focus outlines, the pressed-state ring. Not used
+  for severity, not used for decoration. In dark mode it lifts to a steel
+  blue (`#7ba9c4`) so it stays legible on warm-dark paper.
+
+### Secondary (Severity)
+
+Severity colors carry meaning, never style. They appear on badges, row
+backgrounds (via `severity-bg-*` tokens), and finding cards. Always paired
+with an icon and a text label.
+
+- **Terracotta Warning** (`#b1442d`): high-severity findings. Auto-renewal,
+  jury waivers, broad indemnification.
+- **Mustard Caution** (`#b8862c`): medium-severity findings. Also the
+  focus-ring color, tuned to ride above the cream paper.
+- **Sage Note** (`#5a7a5a`): low-severity findings. Acceptable but worth
+  noting.
+- **Stone Note** (`#6b7b8c`): informational, no severity asserted.
+
+### Tertiary (Status)
+
+- **Positive Green** (`#4a7a4a`): successful saves, signed-export
+  confirmation.
+- **Negative Red** (`#9a3022`): destructive confirmation, irrecoverable
+  errors. Distinct from `severity-high` so "the document has a problem"
+  reads differently from "the app has a problem."
+
+### Neutral
+
+- **Aged Cream** (`#faf6ee`): the canvas. Body background, default page.
+- **Folded Page** (`#f3eddc`): sunken surface for inactive controls,
+  toolbars, selected-state ghost buttons.
+- **Paper-Raised** (`#ffffff`): cards, inputs, panels lifted off the page.
+- **Ink Black** (`#2a2316`): primary text and headings.
+- **Walnut Body** (`#4a3f25`): body copy. Slightly warmer and lighter than
+  Ink Black so paragraphs don't read as headlines.
+- **Walnut Muted** (`#7a6f57`): labels, metadata, secondary copy.
+- **Walnut Faint** (`#a59a7e`): captions, the lowest functional text tier.
+- **Margin Rule** (`#d6cdb6`): hairline borders on cards, panels, inputs.
+- **Rule Subtle** (`#e8e0cf`): internal dividers within cards.
+
+### Named Rules
+
+**The One Voice Rule.** Court Slate is the only non-severity accent. If
+something needs emphasis and isn't a severity finding, it is Court Slate
+or it is type weight; it is never a new color.
+
+**The Severity-Earned Rule.** Severity colors appear on severity surfaces
+only: finding cards, severity badges, severity-filter chips, audit-log
+entries that reference severity. They never decorate generic UI. Pair
+every severity surface with an icon and a text label so the signal
+survives color-blindness and screen readers.
+
+**The No-Pure-Black Rule.** `#000` and `#fff` are forbidden. Even
+`paper-raised` carries a faint warm undertone in dark mode. Tinted
+neutrals only.
+
+## 3. Typography
+
+**Display Font:** Source Serif 4 (with Iowan Old Style, Georgia, serif fallback)
+**Body Font:** Source Serif 4 for findings and document content; system
+sans (`ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto`) for
+chrome, labels, buttons.
+**Label/Mono Font:** JetBrains Mono (with `ui-monospace`, Menlo fallback)
+
+**Character.** A modern transitional serif paired with the system sans is
+the default editorial move; it earns its keep here because the document
+itself is the subject. The serif gives findings the gravity of a written
+opinion; the sans keeps chrome quick and unambiguous. Mono appears only
+where character-level precision matters: hash digests, audit-log entries,
+exact rule IDs.
+
+### Hierarchy
+
+- **Display** (Source Serif 4 600, 28px / 32px): page titles, modal
+  headlines. One per surface.
+- **Heading** (system sans 600, 15px / 22px): panel titles, section
+  headers. Sparing use; the document's own headings carry most of the
+  hierarchy.
+- **Body** (Source Serif 4 400, 14px / 22px): finding text, document
+  excerpts, plain-language readings. Capped at 65–75ch.
+- **Label** (system sans 500, 12.5px / 18px, +0.01em): form labels, button
+  text, metadata. The chrome layer.
+- **Mono** (JetBrains Mono 400, 12px / 18px): hashes, IDs, JSON
+  fragments, anything where character integrity matters.
+
+### Named Rules
+
+**The Serif-for-Substance Rule.** Body type is serif. Document content,
+findings, and explanations get Source Serif 4. UI chrome (buttons, labels,
+form fields, navigation) gets the system sans. Don't mix: a serif button
+or a sans finding both feel wrong.
+
+**The Measure Rule.** Body and findings cap at 65–75ch. Wide-screen
+practitioner views may show two columns at 65ch each before they break to
+90ch.
+
+**The Plain-Reading Rule.** When the rule pack uses a term of art, render
+the term in the body type; render its plain reading directly beneath in
+the same size and a slightly lighter weight (Walnut Body). The renter
+should never need a glossary to understand a finding.
+
+## 4. Elevation
+
+The system layers tonally first and shadows second. Three paper tones
+(`paper-sunken` → `paper` → `paper-raised`) carry most of the depth on
+their own. A single ambient shadow (`shadow-paper`) is a hairline
+reinforcing the lift of raised surfaces; it is not a "card shadow" in the
+modern SaaS sense.
+
+In light mode the shadow is a 1px warm hairline (`0 1px 0 rgba(42, 35, 22,
+0.05)`), almost imperceptible at rest, and that's intentional. In dark
+mode it deepens to `0 1px 0 rgba(0, 0, 0, 0.45)` so the raised surface
+reads against the warm-dark page.
+
+### Shadow Vocabulary
+
+- **shadow-paper** (`box-shadow: 0 1px 0 rgba(42, 35, 22, 0.05)`): default
+  for cards and panels at rest. The hairline lift, not a halo.
+
+### Named Rules
+
+**The Tonal-Before-Shadow Rule.** Always reach for a paper tone first
+(`paper-sunken`, `paper`, `paper-raised`) before reaching for a shadow.
+Shadow appears only where tonal layering is insufficient (e.g. an
+overlay floating above the document plane).
+
+**The Hairline Rule.** No diffuse glows, no 24px ambient blurs, no
+glassmorphism. If a surface needs to lift, it lifts by 1px and a tone
+change.
+
+## 5. Components
+
+### Buttons
+
+A three-variant system (`default`, `ghost`, `subtle`), two sizes
+(`md` 44px / `sm` 32px), and an explicit pressed state used for
+toggle-pill filters.
+
+- **Shape:** very lightly rounded (`2px`). The system reads as
+  paper-cut, not pill-shaped.
+- **Default:** Court Slate background, Aged Cream text. The single
+  primary action per surface.
+- **Hover / Active:** background darkens by ~10% / ~20% via `bg-ink/90`
+  and `bg-ink/80`. Color-only motion; no transform.
+- **Focus:** Mustard Caution focus ring (2px, with paper-colored
+  ring-offset) plus a Court Slate outline for double-coverage. Visible,
+  warm, on-brand.
+- **Ghost:** transparent background, Walnut Body text. Hover and active
+  use the warm low-opacity mustard washes (`state-hover` /
+  `state-active`).
+- **Subtle:** Folded Page background with a Margin Rule border. Used
+  where Ghost feels too quiet but Default would be loud.
+- **Pressed (toggle):** an inset Court Slate ring (`ring-1 ring-inset
+  ring-ink`) marks selection. Used by severity filters and view-mode
+  tablists.
+- **Sizes:** `md` is 44×44 minimum (WCAG 2.5.5 AAA); `sm` is 32×32 only
+  for compact-cluster toolbars.
+
+### Cards
+
+- **Corner Style:** `2px` radius. Reads as paper, not pill.
+- **Background:** Paper-Raised on Aged Cream pages. Cards never nest.
+- **Border:** 1px Margin Rule, full perimeter.
+- **Shadow:** `shadow-paper` (the hairline). No diffuse glow.
+- **Internal Padding:** 16px default. Findings cards step up to 20–24px
+  for breathing room.
+- **Severity treatment (current, under refactor):** the existing `Card`
+  primitive paints a 3px Court Slate / Severity left-border stripe when
+  given an `accent` prop. This is the system's one heritage exception;
+  see Don'ts.
+- **Severity treatment (going-forward):** prefer the `severity-bg-*`
+  token pairs (tinted background + matching low-alpha border + icon +
+  label) over a side stripe. They survive color-blind viewing better
+  and don't smuggle decorative chroma into the page edge.
+
+### Inputs / Fields
+
+`Field` wraps `<input>`, `<textarea>`, and `<select>` with a label-above,
+description-below pattern.
+
+- **Style:** Paper-Raised background, 1px Margin Rule border, `2px`
+  radius, padded `4px 8px`. Sized at 32px height for dense form areas;
+  primary forms scale up to 40–44px where the surface allows.
+- **Label:** small system-sans (12.5px / Walnut Muted) above the
+  control. Always present, never inside the field as placeholder-only.
+- **Description:** optional small system-sans (12.5px / Walnut Muted)
+  between label and control.
+- **Focus:** 2px Court Slate outline (no offset; the field itself is
+  raised). The mustard focus ring is reserved for buttons, where the
+  ring-offset technique reads cleanly.
+- **Error:** 1px Negative Red border + 12.5px Negative Red helper text
+  beneath the field. Never a tooltip.
+
+### Severity Badges & Row Highlights
+
+- **Style:** background = `severity-bg-{error|warn|info}`, border =
+  matching `severity-border-*`, foreground = always Ink Black. The
+  `color-mix()` derivation lets dark mode auto-rebalance against
+  `paper-raised`.
+- **Pairing:** every severity badge carries an icon (16px inline SVG)
+  and a one-word label ("High", "Medium", "Low", "Info").
+- **Anti-pattern:** plain Terracotta-on-Cream text without a background
+  tint reads as decoration. Always use the badge / row-highlight token
+  pair.
+
+### Navigation
+
+- **Style:** the app uses panel-tabs and an in-page side rail rather
+  than a global navbar. Tabs are Ghost buttons with the pressed-toggle
+  state above; the side rail is Subtle buttons stacked.
+- **Active:** Court Slate inset ring + heavier label weight (system
+  sans 600).
+- **Mobile:** the rail collapses to a single-row tab strip; tap
+  targets stay at 44px.
+
+### PDF Highlight Layer
+
+- **Fill:** `rgba(255, 235, 59, 0.35)` (light mode) / `rgba(255, 235,
+  59, 0.42)` (dark). The one place the system uses an off-palette
+  color, justified by the highlight metaphor.
+- **Border:** `rgba(255, 193, 7, 0.9)`, 1px. A single visual that says
+  "this is the clause the finding points at."
+
+## 6. Do's and Don'ts
+
+### Do:
+
+- **Do** use Court Slate (`#1f3a4d`) as the only non-severity accent.
+- **Do** layer tonally (`paper-sunken` → `paper` → `paper-raised`) before
+  reaching for a shadow.
+- **Do** pair every severity surface with an icon and a text label.
+- **Do** cap body and findings text at 65–75ch.
+- **Do** use Source Serif 4 for findings and document content; system
+  sans for buttons, labels, and chrome.
+- **Do** keep primary tap targets at 44×44 (WCAG 2.5.5 AAA); reserve
+  32×32 for dense toolbars only.
+- **Do** use the `severity-bg-*` token pairs for severity row highlights
+  and badges; their `color-mix()` definition auto-rebalances in dark
+  mode.
+- **Do** honor `prefers-reduced-motion`; reserve motion for state
+  transitions where it aids comprehension.
+
+### Don't:
+
+- **Don't** introduce new side-stripe borders. The 3px `border-l` on
+  the legacy `Card` primitive is the system's one heritage exception
+  and should be migrated to the `severity-bg-*` background-tint
+  pattern. New severity surfaces use background tint + icon + label,
+  never a colored side stripe.
+- **Don't** use `#000` or `#fff` literally. Tinted neutrals only.
+- **Don't** use gradient text or `background-clip: text` for
+  decoration. Emphasis is weight or size.
+- **Don't** add diffuse ambient shadows, glow halos, or glassmorphism
+  blurs. The hairline `shadow-paper` is the entire elevation
+  vocabulary.
+- **Don't** ship the friendly-legal genre: no mascots, no "we make
+  legal easy!" cheer, no rounded purple gradients, no LegalZoom
+  vocabulary.
+- **Don't** ship the SaaS-dashboard reflex: no hero-metric tiles, no
+  rainbow chart palettes, no identical card grids of features.
+- **Don't** ship crypto/neon-on-black: no glowing accents, no
+  animated gradients, no fintech-coded aggression.
+- **Don't** ship DocuSign-corporate: no stock photos of handshakes,
+  no navy-and-yellow trust theatre.
+- **Don't** introduce a serif button or a sans finding-body. Serif
+  for substance, sans for chrome.
+- **Don't** use severity color outside severity surfaces. Mustard is
+  not a "pop"; Terracotta is not a "warm accent."
+- **Don't** signal severity by color alone. Always icon + label.
+- **Don't** write modals as a first thought. Inline disclosure and
+  panel state precede dialogs.
+- **Don't** wrap everything in a card. Long-form content, document
+  text, and finding bodies often read better as bare text on the
+  paper surface with rule lines separating sections.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,88 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+**Primary: renters pre-signing.** Often anxious, working at home on a laptop in
+the evening, deciding whether to sign a lease they only half-understand. Not
+lawyers. They want to know which clauses actually matter and why, in plain
+language, without sending the PDF to a third party.
+
+**Secondary: practitioners** (small-firm tenant attorneys, paralegals, housing
+counselors) who triage many leases a week, compare against a known-good
+"standard" lease, redline, and export signed findings. They reward density,
+keyboard flow, and audit trails.
+
+The renter is the design north star: if the renter understands the screen, the
+practitioner can always go faster. The reverse is not true.
+
+## Product Purpose
+
+LeaseGuard is a local-first PWA that reads a lease PDF in the browser and
+returns a prioritized, explainable list of clauses that matter. Nothing leaves
+the device: strict `default-src 'self'` CSP, service worker precache, nine
+IndexedDB stores, append-only hash-chained audit log, Ed25519-signed export.
+
+Success is a renter who, in one sitting, identifies the three clauses worth
+pushing back on and feels they understand why. Secondary success is a
+practitioner who can run the same analysis at ten times the speed and trust
+the audit trail in court.
+
+## Brand Personality
+
+Clear, calm, informative. The voice of a careful reader explaining a document,
+not a product trying to impress. Plainspoken where the law is plainspoken;
+precise where it is not. Never cheerful, never alarming, never coy.
+
+Think of a long-form explainer (NYT Cooking's instructional voice, Stripe
+Docs' worked-example tone) rather than a SaaS landing page or a legal-tech
+sales deck.
+
+## Anti-references
+
+- **LegalZoom and the friendly-legal genre.** No mascots, no "we make legal
+  easy!" cheer, no rounded purple gradients. The document is serious; the
+  interface should respect that.
+- **Crypto / neon-on-black.** No glowing accents, no animated gradients, no
+  "fintech-coded" aggression. This is the opposite emotional register.
+- **Generic SaaS dashboard.** No hero-metric tiles, no rainbow chart palettes,
+  no identical card grids of features, no big-blue-CTA-on-white.
+- **DocuSign-corporate.** No stock photos of handshakes, no navy-and-yellow
+  trust theatre.
+
+## Design Principles
+
+1. **Document first, chrome second.** The lease, the finding, the redline are
+   the subjects. UI scaffolding is rule lines and quiet labels, not panels
+   competing for attention.
+2. **Severity is earned, not decorative.** Color carries meaning (high /
+   medium / low / info). Never used to liven up a section. Never the sole
+   signal: pair with icon, label, or position.
+3. **Trust is shown, not claimed.** The local-first guarantee is visible in
+   the UI (offline indicator, audit-log surfacing, signed-export affordance),
+   not asserted in marketing copy on a settings screen.
+4. **Plain language outranks legal language.** Where the rule pack uses a
+   term of art, surface a one-line plain reading next to it. The renter
+   should never need a glossary to understand a finding.
+5. **Density without noise.** Practitioner views can be dense; renter views
+   stay calm. Both share the same tokens, type scale, and severity
+   vocabulary; they differ in information per square inch, not in style.
+
+## Accessibility & Inclusion
+
+- **WCAG 2.2 AA** as the baseline across all flows; AAA contrast on body text
+  and finding bodies where achievable without flattening hierarchy.
+- **Severity is never color-only.** Every severity-tinted surface carries an
+  icon and a text label so red-green color-blind users and screen-reader users
+  get the same signal.
+- **Reduced motion.** Honor `prefers-reduced-motion`. No incidental motion;
+  motion is reserved for state transitions where it aids comprehension
+  (panel mount, redline diff reveal).
+- **Keyboard-first.** Every panel reachable, every finding actionable, every
+  comparison row navigable without a pointer. Focus rings are visible and
+  on-brand (ink, not browser default).
+- **Reading-impairment friendly.** Body type at a comfortable serif size with
+  a 65–75ch measure, not the 90ch+ block walls common in legal tools.

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -216,3 +216,26 @@ shape.
 
 When a task touches one of these, ask before pulling in a dep — they all
 have non-trivial bundle-size or architectural consequences.
+
+## Design Context
+
+Strategic and visual design specs live at the project root and are the
+authoritative reference for any UI work:
+
+- [`PRODUCT.md`](../PRODUCT.md) — register, users, brand personality,
+  anti-references, five design principles, accessibility floor.
+- [`DESIGN.md`](../DESIGN.md) — Stitch-format visual system. North Star
+  is "The Marginalia Edition": cream paper, ink rules, single Court
+  Slate accent, severity in the margins.
+- [`DESIGN.json`](../DESIGN.json) — sidecar with tonal ramps, shadow /
+  motion tokens, and rendered component snippets.
+
+Read DESIGN.md before adding components or color. Eight named rules
+(One Voice, Severity-Earned, No-Pure-Black, Serif-for-Substance,
+Measure, Plain-Reading, Tonal-Before-Shadow, Hairline) are the
+fast-path summary; the Do's and Don'ts list is exhaustive.
+
+The legacy 3px `border-l` severity stripe on `app/src/ui/system/Card.tsx`
+is the system's one heritage side-stripe exception and is scheduled for
+migration to the `severity-bg-*` token pairs (tinted background + icon +
+label). Do not propagate the side-stripe pattern to new components.


### PR DESCRIPTION
## Summary

- Add `PRODUCT.md` (strategic): register=product, renter-primary / practitioner-secondary, four named anti-references, five design principles, WCAG 2.2 AA + AAA-on-text accessibility floor.
- Add `DESIGN.md` (Stitch-format visual spec): North Star **The Marginalia Edition**. Eight named rules (One Voice, Severity-Earned, No-Pure-Black, Serif-for-Substance, Measure, Plain-Reading, Tonal-Before-Shadow, Hairline). Don't list flags `app/src/ui/system/Card.tsx`'s 3px `border-l` severity stripe as the heritage exception scheduled for migration to `severity-bg-*` + icon + label.
- Add `DESIGN.json` sidecar: tonal ramps, shadow / motion tokens, six rendered component snippets, narrative pulled verbatim from DESIGN.md.
- `docs/CLAUDE.md` gains a Design Context pointer so future agent sessions find the spec.

Authored via the impeccable plugin (`/impeccable teach` then `/impeccable document`); the Stitch frontmatter is parseable by impeccable's live panel and external DESIGN.md tooling.

Docs only. No code, no tokens changed. The follow-up polish PR (off-palette `#fff`/`#000` literals + blockquote stripes) lands separately.

## Test plan

- [x] `PRODUCT.md`, `DESIGN.md`, `DESIGN.json`, `docs/CLAUDE.md` render correctly on GitHub
- [x] No source changes; existing CI (typecheck / lint / vitest / e2e / lighthouse / npm-audit) should remain green by default
- [ ] Spot-check that the Stitch frontmatter parses (`yaml.parse(fs.readFileSync('DESIGN.md').split('---')[1])` returns an object)

🤖 Generated with [Claude Code](https://claude.com/claude-code)