### PR TITLE
chore(tokens): tighten off-palette literals + hairline blockquote stripes

### DIFF
--- a/app/src/index.css
+++ b/app/src/index.css
@@ -27,7 +27,7 @@
 @theme {
   /* Surfaces */
   --color-paper: #faf6ee;
-  --color-paper-raised: #ffffff;
+  --color-paper-raised: #fdfcf8;
   --color-paper-sunken: #f3eddc;
 
   /* Text */
@@ -55,9 +55,21 @@
      `bg-[color-mix(...)] text-fg border border-...` triple Wave 28-D
      applied inline to SeverityOverridesPanel. Pair: bg + matching
      low-alpha border. Foreground is always --color-fg (dark ink). */
-  --color-severity-bg-error: color-mix(in srgb, var(--color-severity-high) 22%, var(--color-paper-raised));
-  --color-severity-bg-warn: color-mix(in srgb, var(--color-severity-medium) 22%, var(--color-paper-raised));
-  --color-severity-bg-info: color-mix(in srgb, var(--color-severity-info) 22%, var(--color-paper-raised));
+  --color-severity-bg-error: color-mix(
+    in srgb,
+    var(--color-severity-high) 22%,
+    var(--color-paper-raised)
+  );
+  --color-severity-bg-warn: color-mix(
+    in srgb,
+    var(--color-severity-medium) 22%,
+    var(--color-paper-raised)
+  );
+  --color-severity-bg-info: color-mix(
+    in srgb,
+    var(--color-severity-info) 22%,
+    var(--color-paper-raised)
+  );
   --color-severity-border-error: color-mix(in srgb, var(--color-severity-high) 40%, transparent);
   --color-severity-border-warn: color-mix(in srgb, var(--color-severity-medium) 40%, transparent);
   --color-severity-border-info: color-mix(in srgb, var(--color-severity-info) 40%, transparent);
@@ -111,7 +123,7 @@
    onto <html>. Severity-bg variants auto-shift because color-mix()
    re-evaluates against the overridden --color-paper-raised at use
    time. Contrast validated to WCAG AA in the wave31-B PR description. */
-[data-theme="dark"] {
+[data-theme='dark'] {
   /* Surfaces — warm dark complement of the cream paper palette */
   --color-paper: #15110d;
   --color-paper-raised: #1f1a14;
@@ -145,8 +157,8 @@
   /* Interactive state — re-tuned mustard against deep warm paper */
   --ring: #d6a04a;
   --ring-offset: #15110d;
-  --state-hover: rgba(214, 160, 74, 0.10);
-  --state-active: rgba(214, 160, 74, 0.20);
+  --state-hover: rgba(214, 160, 74, 0.1);
+  --state-active: rgba(214, 160, 74, 0.2);
 
   /* PDF highlight — slightly stronger so it reads on dark paper */
   --color-highlight: rgba(255, 235, 59, 0.42);
@@ -170,7 +182,10 @@
   color: var(--color-fg-body);
   background: var(--color-paper);
 }
-body { margin: 0; min-height: 100dvh; }
+body {
+  margin: 0;
+  min-height: 100dvh;
+}
 
 main {
   max-width: 72rem;
@@ -178,9 +193,15 @@ main {
   padding: 2rem 1rem;
 }
 
-.split { display: grid; gap: 1rem; align-items: start; }
+.split {
+  display: grid;
+  gap: 1rem;
+  align-items: start;
+}
 @media (min-width: 960px) {
-  .split { grid-template-columns: minmax(18rem, 28rem) 1fr; }
+  .split {
+    grid-template-columns: minmax(18rem, 28rem) 1fr;
+  }
 }
 .split aside[aria-label='findings'] {
   position: sticky;

--- a/app/src/redline/redline.ts
+++ b/app/src/redline/redline.ts
@@ -99,8 +99,8 @@ export function buildRedlineHtml(input: BuildRedlineHtmlInput): string {
   @media print {
     body { max-width: none; padding: 0; }
     .para { page-break-inside: avoid; }
-    ins { background: transparent; color: #000; text-decoration: underline; }
-    del { background: transparent; color: #000; text-decoration: line-through; }
+    ins { background: transparent; color: #2a2316; text-decoration: underline; }
+    del { background: transparent; color: #2a2316; text-decoration: line-through; }
   }
 </style>
 </head>

--- a/app/src/ui/AppCurrentPane.tsx
+++ b/app/src/ui/AppCurrentPane.tsx
@@ -140,7 +140,10 @@ export function AppCurrentPane({
         )}
       </div>
       {ocr.likelyScanned && (
-        <div role="status" className="ocr-banner bg-paper-sunken border border-rule rounded-sm p-3 mb-3 space-y-2">
+        <div
+          role="status"
+          className="ocr-banner bg-paper-sunken border border-rule rounded-sm p-3 mb-3 space-y-2"
+        >
           <p className="text-body text-fg-body">
             This PDF looks scanned (avg {Math.round(ocr.avgCharsPerPage)} chars/page). Text
             extraction may be incomplete.
@@ -209,7 +212,7 @@ export function AppCurrentPane({
         <Card as="article" aria-label="selected finding" className="p-4 space-y-2 my-3">
           <h3 className="text-heading uppercase text-fg-muted">{selected.title}</h3>
           <p className="text-body text-fg-body">{selected.explanation}</p>
-          <blockquote className="border-l-2 border-rule pl-3 font-mono text-mono text-fg-muted italic">
+          <blockquote className="border-l border-rule pl-3 font-mono text-mono text-fg-muted italic">
             {selected.snippet}
           </blockquote>
           <span className="text-small text-fg-muted">Page {selected.page}</span>

--- a/app/src/ui/TemplateMatchesPanel.tsx
+++ b/app/src/ui/TemplateMatchesPanel.tsx
@@ -38,7 +38,9 @@ export function TemplateMatchesPanel({
             <li key={m.templateId}>
               <Card className="p-3 space-y-1">
                 <div className="flex items-center gap-2">
-                  <span className="text-body text-fg-body font-sans font-semibold">{m.templateName}</span>
+                  <span className="text-body text-fg-body font-sans font-semibold">
+                    {m.templateName}
+                  </span>
                   <span aria-label={`template status ${badge}`} data-badge={badge}>
                     <Badge variant="outline">{badge}</Badge>
                   </span>
@@ -48,7 +50,7 @@ export function TemplateMatchesPanel({
                 </div>
                 {m.matchedSnippet && m.matchedPage !== null && (
                   <div>
-                    <blockquote className="border-l-2 border-rule pl-3 font-mono text-mono text-fg-muted italic">
+                    <blockquote className="border-l border-rule pl-3 font-mono text-mono text-fg-muted italic">
                       {m.matchedSnippet}
                     </blockquote>
                     <span className="text-small text-fg-muted">Page {m.matchedPage}</span>


### PR DESCRIPTION
## Summary

Surgical pass surfaced by `/impeccable critique` against the freshly written `DESIGN.md`. Four lines of behavioral change across four files; the rest of the diff is `prettier` reformatting `index.css` multi-line color-mix declarations.

- `app/src/index.css`: `--color-paper-raised` `#ffffff` → `#fdfcf8`. Honors the No-Pure-Black rule; raised surfaces now carry the same faint warm undertone as the rest of the paper palette in light mode (dark mode was already tinted).
- `app/src/redline/redline.ts`: print-fallback `ins`/`del` color `#000` → `#2a2316` (the value of `--color-fg`, our Ink Black). Exported redline HTML now matches the in-app palette when printed.
- `app/src/ui/AppCurrentPane.tsx` + `TemplateMatchesPanel.tsx`: blockquote `border-l-2` → `border-l`. Tightens the snippet quote stripe to the 1px Hairline doctrine. Both are non-severity quotes, so the impeccable side-stripe ban does not apply, but the Hairline rule does.

## Out of scope (deliberately deferred to Wave 45)

- `Card.tsx`'s 3px `border-l` severity stripe (the documented heritage exception). Migrates behind a new `<Badge>` primitive that lifts `severity-bg-*` + icon + label into the design system.
- `AppRedlinePane.tsx`'s bare `<details>` → `SectionGroup` pattern.
- `AppHeader.tsx`'s native file-input chrome → mirror the styled `<span>` over `sr-only` `<input>` pattern from `AppFooterControls.tsx`.
- Severity-vs-negative discipline pass (`text-severity-high` on app errors → `text-negative`).
- Renter-IA split of `AppCurrentPane`.

Each of those crosses from polish into refactor (touches tests, changes DOM or the public API of a primitive) and gets its own wave-plan.

## Test plan

- [x] `npm run typecheck` (clean)
- [x] `npm run lint` (0 warnings)
- [x] `npm test` (1518/1518)
- [ ] Visual: confirm the new `paper-raised` is imperceptibly warm against `paper`, not visibly off-white
- [ ] Visual: confirm the redline export still prints with adequate contrast (Ink Black on white paper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)