### PR TITLE
feat(system): Dialog + FileButton primitives + BulkImport progressive live region (Wave 45-F)

### DIFF
--- a/app/src/App.panels.test.tsx
+++ b/app/src/App.panels.test.tsx
@@ -303,7 +303,9 @@ describe('App panel wire-ups', () => {
         },
       ],
     };
-    const input = screen.getByLabelText(/import rule pack/i) as HTMLInputElement;
+    // Wave 45-F — FileButton: walk button→sibling-input.
+    const input = screen.getByRole('button', { name: /import rule pack/i })
+      .nextElementSibling as HTMLInputElement;
     await userEvent.upload(
       input,
       new File([JSON.stringify(pack)], 'custom.lgpack.json', { type: 'application/json' }),
@@ -437,7 +439,9 @@ describe('App panel wire-ups', () => {
         },
       ],
     };
-    const input = screen.getByLabelText(/pack file to diff/i) as HTMLInputElement;
+    // Wave 45-F — FileButton: walk button→sibling-input.
+    const input = screen.getByRole('button', { name: /pack file to diff/i })
+      .nextElementSibling as HTMLInputElement;
     await userEvent.upload(
       input,
       new File([JSON.stringify(pack)], 'diff.lgpack.json', { type: 'application/json' }),
@@ -480,7 +484,9 @@ describe('App panel wire-ups', () => {
     const fileB = new File([bytesB as BlobPart], 'bulk-b.pdf', {
       type: 'application/pdf',
     });
-    const input = screen.getByLabelText(/bulk import files/i) as HTMLInputElement;
+    // Wave 45-F — FileButton: walk button→sibling-input.
+    const input = screen.getByRole('button', { name: /bulk import files/i })
+      .nextElementSibling as HTMLInputElement;
     await userEvent.upload(input, [fileA, fileB]);
     await waitFor(async () => {
       expect((await listLeases()).length).toBe(2);
@@ -698,7 +704,9 @@ describe('App panel wire-ups', () => {
       'verify',
     ])) as CryptoKeyPair;
     const envelope = await signPack(pack, kp.privateKey, kp.publicKey);
-    const input = screen.getByLabelText(/import rule pack/i) as HTMLInputElement;
+    // Wave 45-F — FileButton: walk button→sibling-input.
+    const input = screen.getByRole('button', { name: /import rule pack/i })
+      .nextElementSibling as HTMLInputElement;
     await userEvent.upload(
       input,
       new File([JSON.stringify(envelope)], 'signed.lgpack.json', {
@@ -812,7 +820,9 @@ describe('App panel wire-ups', () => {
       ...envelope,
       payload: envelope.payload.replace('Tampered', 'TamperedX'),
     };
-    const input = screen.getByLabelText(/import rule pack/i) as HTMLInputElement;
+    // Wave 45-F — FileButton: walk button→sibling-input.
+    const input = screen.getByRole('button', { name: /import rule pack/i })
+      .nextElementSibling as HTMLInputElement;
     await userEvent.upload(
       input,
       new File([JSON.stringify(tampered)], 'tampered.lgpack.json', {

--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -369,7 +369,10 @@ describe('App', () => {
     const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('pw');
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
 
-    const importInput = screen.getByLabelText(/import encrypted archive/i) as HTMLInputElement;
+    // Wave 45-F — FileButton hides the input from the a11y tree; the
+    // button carries the accessible name. Walk to the sibling input.
+    const importInput = screen.getByRole('button', { name: /import encrypted archive/i })
+      .nextElementSibling as HTMLInputElement;
     await userEvent.upload(importInput, archiveFile);
     await waitFor(async () => {
       expect((await listLeases()).length).toBe(1);

--- a/app/src/ui/AppFooterControls.test.tsx
+++ b/app/src/ui/AppFooterControls.test.tsx
@@ -20,36 +20,42 @@ function renderFooter(props: Partial<React.ComponentProps<typeof AppFooterContro
 describe('AppFooterControls', () => {
   it('renders the three controls (export, import file input, clear)', () => {
     renderFooter();
-    expect(screen.getByLabelText(/import encrypted archive/i)).toBeInTheDocument();
-    // Two buttons: export archive + clear all. Their labels come from i18n.
-    expect(screen.getAllByRole('button')).toHaveLength(2);
+    expect(screen.getByRole('button', { name: /import encrypted archive/i })).toBeInTheDocument();
+    // Wave 45-F — three buttons: export archive + import-archive (FileButton)
+    // + clear all. Pre-45-F there were two buttons + a label-wrapped input.
+    expect(screen.getAllByRole('button')).toHaveLength(3);
   });
 
   it('fires onExportArchive when the export button is clicked', async () => {
     const onExportArchive = vi.fn();
     renderFooter({ onExportArchive });
-    const buttons = screen.getAllByRole('button');
-    await userEvent.click(buttons[0]!);
+    // Match the visible label (i18n string from footer.archive.export).
+    await userEvent.click(screen.getByRole('button', { name: /export.*archive/i }));
     expect(onExportArchive).toHaveBeenCalledTimes(1);
   });
 
   it('fires onClearAll when the clear button is clicked', async () => {
     const onClearAll = vi.fn();
     renderFooter({ onClearAll });
-    const buttons = screen.getAllByRole('button');
-    // Second button is clear-all per render order.
-    await userEvent.click(buttons[1]!);
+    // i18n label from footer.clearAll.
+    await userEvent.click(screen.getByRole('button', { name: /clear/i }));
     expect(onClearAll).toHaveBeenCalledTimes(1);
   });
 
   it('fires onImportArchive with the selected file', async () => {
     const onImportArchive = vi.fn();
     renderFooter({ onImportArchive });
-    const input = screen.getByLabelText(/import encrypted archive/i) as HTMLInputElement;
+    // Wave 45-F — FileButton's hidden input is no longer reachable via
+    // getByLabelText (the button carries the accessible name now). Query
+    // the input directly.
+    const input = document.querySelector<HTMLInputElement>(
+      'input[type="file"][accept*="lgarchive"]',
+    );
+    expect(input).not.toBeNull();
     const file = new File([new Uint8Array([0])], 'a.lgarchive', {
       type: 'application/octet-stream',
     });
-    await userEvent.upload(input, file);
+    await userEvent.upload(input!, file);
     expect(onImportArchive).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/src/ui/AppFooterControls.tsx
+++ b/app/src/ui/AppFooterControls.tsx
@@ -5,6 +5,7 @@
 import type { ChangeEvent } from 'react';
 import { useI18n } from '../i18n/I18nContext';
 import { Button } from './system/Button';
+import { FileButton } from './system/FileButton';
 
 interface AppFooterControlsProps {
   onExportArchive: () => void | Promise<void>;
@@ -23,19 +24,24 @@ export function AppFooterControls({
       <Button variant="subtle" size="sm" onClick={() => void onExportArchive()}>
         {t('footer.archive.export')}
       </Button>
-      <label className="inline-flex items-center gap-2 text-small text-fg-muted cursor-pointer">
-        <span className="sr-only">Import encrypted archive</span>
-        <span className="inline-flex h-7 items-center px-2 rounded-sm border border-rule bg-paper-raised text-small text-fg-body hover:bg-paper-sunken transition-colors">
-          Import encrypted archive
-        </span>
-        <input
-          type="file"
-          accept=".lgarchive,application/octet-stream"
-          aria-label="import encrypted archive"
-          className="sr-only"
-          onChange={(e) => void onImportArchive(e)}
-        />
-      </label>
+      <FileButton
+        variant="subtle"
+        size="sm"
+        accept=".lgarchive,application/octet-stream"
+        aria-label="import encrypted archive"
+        onFiles={(files) => {
+          // Adapter: the existing onImportArchive expects a ChangeEvent because
+          // it was wired against a raw <input type="file">. Synthesize a
+          // minimal compatible event so we don't ripple this rename out.
+          const synthetic = {
+            target: { files },
+            currentTarget: { files },
+          } as unknown as ChangeEvent<HTMLInputElement>;
+          void onImportArchive(synthetic);
+        }}
+      >
+        Import encrypted archive
+      </FileButton>
       <Button variant="ghost" size="sm" onClick={onClearAll}>
         {t('footer.clearAll')}
       </Button>

--- a/app/src/ui/AppFooterControls.tsx
+++ b/app/src/ui/AppFooterControls.tsx
@@ -28,7 +28,6 @@ export function AppFooterControls({
         variant="subtle"
         size="sm"
         accept=".lgarchive,application/octet-stream"
-        aria-label="import encrypted archive"
         onFiles={(files) => {
           // Adapter: the existing onImportArchive expects a ChangeEvent because
           // it was wired against a raw <input type="file">. Synthesize a

--- a/app/src/ui/AppLibraryAndPacksPane.tsx
+++ b/app/src/ui/AppLibraryAndPacksPane.tsx
@@ -203,13 +203,12 @@ export function AppLibraryAndPacksPane({
               variant="subtle"
               size="sm"
               accept=".lgpack.json,application/json"
-              aria-label="pack file to diff"
               onFiles={(files) => {
                 const f = files[0];
                 if (f) void packs.comparePackFile(f);
               }}
             >
-              Choose pack file
+              Pack file to diff
             </FileButton>
             {packs.packDiff && <PackDiffPanel diff={packs.packDiff} />}
           </Section>

--- a/app/src/ui/AppLibraryAndPacksPane.tsx
+++ b/app/src/ui/AppLibraryAndPacksPane.tsx
@@ -47,6 +47,7 @@ import { SigningKeyPanel } from './SigningKeyPanel';
 import { ComparePanel } from './ComparePanel';
 import { Section } from './system/Section';
 import { SectionGroup } from './system/SectionGroup';
+import { FileButton } from './system/FileButton';
 import { SECTION_GROUPS } from './AppLibraryAndPacksPaneSections';
 import type { LeaseRecord, LeaseMetadata } from '../storage/storage';
 import type { ClauseTemplate } from '../templates/types';
@@ -123,11 +124,7 @@ export function AppLibraryAndPacksPane({
 
   return (
     <div className="space-y-3">
-      <SectionGroup
-        id={thisLease.id}
-        title={thisLease.title}
-        defaultOpen={thisLease.defaultOpen}
-      >
+      <SectionGroup id={thisLease.id} title={thisLease.title} defaultOpen={thisLease.defaultOpen}>
         <div className="divide-y divide-rule">
           <LibraryCompareForm leases={library} onCompare={onCompare} />
           <details className="px-4 py-3">
@@ -198,26 +195,27 @@ export function AppLibraryAndPacksPane({
           <Section label="diff rule pack" className="space-y-3 px-4 py-4">
             <h2 className="text-heading uppercase text-fg-muted">Diff rule pack</h2>
             <p className="text-body text-fg-body">
-              Load a <code className="font-mono text-mono text-fg-muted">.lgpack.json</code> file to see how it differs from the currently active rule
-              set. Nothing is saved until you import it via the pack manager above.
+              Load a <code className="font-mono text-mono text-fg-muted">.lgpack.json</code> file to
+              see how it differs from the currently active rule set. Nothing is saved until you
+              import it via the pack manager above.
             </p>
-            <label className="inline-flex flex-col gap-1">
-              <span className="sr-only">Pack file to diff</span>
-              <input
-                type="file"
-                accept=".lgpack.json,application/json"
-                aria-label="pack file to diff"
-                className="text-small text-fg-body file:mr-2 file:h-7 file:px-2 file:rounded-sm file:border file:border-rule file:bg-paper-raised file:text-small file:text-fg-body file:cursor-pointer hover:file:bg-paper-sunken"
-                onChange={(e) => {
-                  const f = e.target.files?.[0];
-                  e.target.value = '';
-                  if (f) void packs.comparePackFile(f);
-                }}
-              />
-            </label>
+            <FileButton
+              variant="subtle"
+              size="sm"
+              accept=".lgpack.json,application/json"
+              aria-label="pack file to diff"
+              onFiles={(files) => {
+                const f = files[0];
+                if (f) void packs.comparePackFile(f);
+              }}
+            >
+              Choose pack file
+            </FileButton>
             {packs.packDiff && <PackDiffPanel diff={packs.packDiff} />}
           </Section>
-          <BulkImportPanel onImport={(files, onProgress) => packs.bulkImportFiles(files, onProgress)} />
+          <BulkImportPanel
+            onImport={(files, onProgress) => packs.bulkImportFiles(files, onProgress)}
+          />
         </div>
       </SectionGroup>
 

--- a/app/src/ui/BulkImportPanel.test.tsx
+++ b/app/src/ui/BulkImportPanel.test.tsx
@@ -11,9 +11,10 @@ function makeFile(name: string): File {
 }
 
 describe('BulkImportPanel', () => {
-  it('renders a file input with the expected accessible label', () => {
+  it('renders the import button with the expected accessible name', () => {
     render(<BulkImportPanel onImport={vi.fn()} />);
-    expect(screen.getByLabelText(/bulk import files/i)).toBeInTheDocument();
+    // Wave 45-F — accessible name now matches visible text per WCAG 2.5.3.
+    expect(screen.getByRole('button', { name: /bulk import files/i })).toBeInTheDocument();
   });
 
   it('streams per-file status and renders a summary when done', async () => {

--- a/app/src/ui/BulkImportPanel.test.tsx
+++ b/app/src/ui/BulkImportPanel.test.tsx
@@ -27,7 +27,9 @@ describe('BulkImportPanel', () => {
     );
 
     render(<BulkImportPanel onImport={onImport} />);
-    const input = screen.getByLabelText(/bulk import files/i) as HTMLInputElement;
+    // Wave 45-F — FileButton's hidden input no longer carries the
+    // accessible name; query directly.
+    const input = document.querySelector<HTMLInputElement>('input[type="file"][accept*="pdf"]')!;
     await user.upload(input, [makeFile('a.pdf'), makeFile('b.pdf')]);
 
     await waitFor(() =>
@@ -59,7 +61,9 @@ describe('BulkImportPanel', () => {
     );
 
     render(<BulkImportPanel onImport={onImport} />);
-    const input = screen.getByLabelText(/bulk import files/i) as HTMLInputElement;
+    // Wave 45-F — FileButton's hidden input no longer carries the
+    // accessible name; query directly.
+    const input = document.querySelector<HTMLInputElement>('input[type="file"][accept*="pdf"]')!;
     const zipFile = new File([new Uint8Array([0])], 'batch.zip', { type: 'application/zip' });
     await user.upload(input, [zipFile]);
 
@@ -85,14 +89,19 @@ describe('BulkImportPanel', () => {
       },
     );
     render(<BulkImportPanel onImport={onImport} />);
-    const input = screen.getByLabelText(/bulk import files/i) as HTMLInputElement;
+    // Wave 45-F — FileButton's hidden input no longer carries the
+    // accessible name; query directly.
+    const input = document.querySelector<HTMLInputElement>('input[type="file"][accept*="pdf"]')!;
     await user.upload(input, [makeFile('a.pdf'), makeFile('b.pdf'), makeFile('c.pdf')]);
     // The live-region is distinct from the terminal summary (different label).
     const live = await screen.findByLabelText(/bulk import live progress/i);
     expect(live).toHaveAttribute('aria-live', 'polite');
     expect(live).toHaveAttribute('aria-atomic', 'false');
+    // Live region announces running counts only — no "X of Y" denominator,
+    // since Y is unknowable for zip inputs while streaming. After the batch
+    // completes the verb flips from "Processing…" to "Processed…".
     await waitFor(() =>
-      expect(live).toHaveTextContent(/Processed 3 of 3 · imported 1 · skipped 1 · errors 1/),
+      expect(live).toHaveTextContent(/Processed… imported 1 · skipped 1 · errors 1/),
     );
   });
 
@@ -110,7 +119,9 @@ describe('BulkImportPanel', () => {
       },
     );
     render(<BulkImportPanel onImport={onImport} />);
-    const input = screen.getByLabelText(/bulk import files/i) as HTMLInputElement;
+    // Wave 45-F — FileButton's hidden input no longer carries the
+    // accessible name; query directly.
+    const input = document.querySelector<HTMLInputElement>('input[type="file"][accept*="pdf"]')!;
     await user.upload(input, [makeFile('oops.pdf')]);
     await waitFor(() => expect(screen.getByText(/boom/)).toBeInTheDocument());
   });

--- a/app/src/ui/BulkImportPanel.test.tsx
+++ b/app/src/ui/BulkImportPanel.test.tsx
@@ -74,6 +74,28 @@ describe('BulkImportPanel', () => {
     expect(screen.getByText(/corrupted PDF/)).toBeInTheDocument();
   });
 
+  it('renders a progressive aria-live announcement during streaming', async () => {
+    const user = userEvent.setup();
+    const onImport = vi.fn(
+      async (_files: File[], onProgress: (r: BulkResult) => void): Promise<BulkSummary> => {
+        onProgress({ fileName: 'a.pdf', hash: 'h1', status: 'ok', leaseId: 'id-a' });
+        onProgress({ fileName: 'b.pdf', hash: 'h2', status: 'skipped' });
+        onProgress({ fileName: 'c.pdf', hash: 'h3', status: 'error', error: 'broken' });
+        return { ok: 1, skipped: 1, errors: 1 };
+      },
+    );
+    render(<BulkImportPanel onImport={onImport} />);
+    const input = screen.getByLabelText(/bulk import files/i) as HTMLInputElement;
+    await user.upload(input, [makeFile('a.pdf'), makeFile('b.pdf'), makeFile('c.pdf')]);
+    // The live-region is distinct from the terminal summary (different label).
+    const live = await screen.findByLabelText(/bulk import live progress/i);
+    expect(live).toHaveAttribute('aria-live', 'polite');
+    expect(live).toHaveAttribute('aria-atomic', 'false');
+    await waitFor(() =>
+      expect(live).toHaveTextContent(/Processed 3 of 3 · imported 1 · skipped 1 · errors 1/),
+    );
+  });
+
   it('surfaces errors per file', async () => {
     const user = userEvent.setup();
     const onImport = vi.fn(

--- a/app/src/ui/BulkImportPanel.tsx
+++ b/app/src/ui/BulkImportPanel.tsx
@@ -81,11 +81,20 @@ export function BulkImportPanel({ onImport }: BulkImportPanelProps): JSX.Element
         (() => {
           // Wave 45-F — running summary above the table so SRs hear progress
           // as rows arrive, not only at the closing terminal summary below.
-          const total = rows.length;
+          //
+          // We deliberately do NOT announce a "X of Y" denominator while
+          // streaming. Y is unknowable for `.zip` inputs (the archive count
+          // is not bounded until the workflow walks every entry), and the
+          // existing rows-replacement pattern means rows.length tracks
+          // results-so-far, not the original batch size. Announcing
+          // "Processed 1 of 1" while more entries are still arriving would
+          // mislead screen-reader users into thinking the batch is done.
+          // The terminal `<p role="status">` summary below carries the
+          // final batch counts when busy flips false.
           const ok = rows.filter((r) => r.status === 'ok').length;
           const skipped = rows.filter((r) => r.status === 'skipped').length;
           const errors = rows.filter((r) => r.status === 'error').length;
-          const processed = ok + skipped + errors;
+          const verb = busy ? 'Processing' : 'Processed';
           return (
             <p
               aria-live="polite"
@@ -93,7 +102,7 @@ export function BulkImportPanel({ onImport }: BulkImportPanelProps): JSX.Element
               aria-label="bulk import live progress"
               className="text-small text-fg-muted"
             >
-              Processed {processed} of {total} · imported {ok} · skipped {skipped} · errors {errors}
+              {verb}… imported {ok} · skipped {skipped} · errors {errors}
             </p>
           );
         })()}

--- a/app/src/ui/BulkImportPanel.tsx
+++ b/app/src/ui/BulkImportPanel.tsx
@@ -70,11 +70,10 @@ export function BulkImportPanel({ onImport }: BulkImportPanelProps): JSX.Element
         size="md"
         accept="application/pdf,application/zip,.pdf,.zip"
         multiple
-        aria-label="bulk import files"
         disabled={busy}
         onFiles={(list) => void onFiles(list)}
       >
-        Choose PDFs or .zip
+        Bulk import files
       </FileButton>
 
       {rows.length > 0 &&

--- a/app/src/ui/BulkImportPanel.tsx
+++ b/app/src/ui/BulkImportPanel.tsx
@@ -1,10 +1,12 @@
 // Wave 27-C — design pass rewrite.
+// Wave 45-F — progressive aria-live announcement during streaming.
 // Semantic attributes preserved verbatim:
-//   aria-label="bulk import"             (section)
-//   aria-label="bulk import files"       (file input)
-//   aria-label="bulk import progress"    (table)
-//   data-testid={`bulk-status-${i}`}     (td)
-//   role="status" aria-label="bulk import summary"  (p)
+//   aria-label="bulk import"                          (section)
+//   aria-label="bulk import files"                    (file input — now FileButton)
+//   aria-label="bulk import progress"                 (table)
+//   aria-live="polite" + aria-label="bulk import live progress" (running summary)
+//   data-testid={`bulk-status-${i}`}                  (td)
+//   role="status" aria-label="bulk import summary"    (p — terminal summary)
 //
 import { useState } from 'react';
 import type { BulkResult, BulkSummary } from '../workflow/bulkImport';
@@ -74,6 +76,27 @@ export function BulkImportPanel({ onImport }: BulkImportPanelProps): JSX.Element
       >
         Choose PDFs or .zip
       </FileButton>
+
+      {rows.length > 0 &&
+        (() => {
+          // Wave 45-F — running summary above the table so SRs hear progress
+          // as rows arrive, not only at the closing terminal summary below.
+          const total = rows.length;
+          const ok = rows.filter((r) => r.status === 'ok').length;
+          const skipped = rows.filter((r) => r.status === 'skipped').length;
+          const errors = rows.filter((r) => r.status === 'error').length;
+          const processed = ok + skipped + errors;
+          return (
+            <p
+              aria-live="polite"
+              aria-atomic="false"
+              aria-label="bulk import live progress"
+              className="text-small text-fg-muted"
+            >
+              Processed {processed} of {total} · imported {ok} · skipped {skipped} · errors {errors}
+            </p>
+          );
+        })()}
 
       {rows.length > 0 && (
         <div className="overflow-x-auto">

--- a/app/src/ui/BulkImportPanel.tsx
+++ b/app/src/ui/BulkImportPanel.tsx
@@ -6,10 +6,10 @@
 //   data-testid={`bulk-status-${i}`}     (td)
 //   role="status" aria-label="bulk import summary"  (p)
 //
-import { useRef, useState } from 'react';
-import type { ChangeEvent } from 'react';
+import { useState } from 'react';
 import type { BulkResult, BulkSummary } from '../workflow/bulkImport';
 import { Section } from './system/Section';
+import { FileButton } from './system/FileButton';
 
 export interface BulkImportPanelProps {
   /**
@@ -28,15 +28,10 @@ export function BulkImportPanel({ onImport }: BulkImportPanelProps): JSX.Element
   const [rows, setRows] = useState<Row[]>([]);
   const [busy, setBusy] = useState(false);
   const [summary, setSummary] = useState<BulkSummary | null>(null);
-  const inputRef = useRef<HTMLInputElement | null>(null);
 
-  async function onFileChange(e: ChangeEvent<HTMLInputElement>): Promise<void> {
-    const list = e.target.files;
-    if (!list || list.length === 0) return;
+  async function onFiles(list: FileList): Promise<void> {
+    if (list.length === 0) return;
     const files = Array.from(list);
-    // Reset the input so re-selecting the same batch re-fires.
-    e.target.value = '';
-
     setBusy(true);
     setSummary(null);
     // For PDF inputs we get one progress event per file; for `.zip` inputs
@@ -63,39 +58,52 @@ export function BulkImportPanel({ onImport }: BulkImportPanelProps): JSX.Element
     <Section label="bulk import" className="space-y-3 px-4 py-4">
       <h2 className="text-heading uppercase text-fg-muted">Bulk import</h2>
       <p className="text-body text-fg-body">
-        Select multiple PDF leases — or a single <code className="font-mono text-mono text-fg-muted">.zip</code> of PDFs — to analyze and save in
-        one pass. Exact duplicates (by content hash) are skipped automatically. Top-level zip
-        entries only; nested folders are ignored.
+        Select multiple PDF leases — or a single{' '}
+        <code className="font-mono text-mono text-fg-muted">.zip</code> of PDFs — to analyze and
+        save in one pass. Exact duplicates (by content hash) are skipped automatically. Top-level
+        zip entries only; nested folders are ignored.
       </p>
-      <label className="inline-flex flex-col gap-1">
-        <span className="sr-only">Bulk import files</span>
-        <input
-          ref={inputRef}
-          type="file"
-          accept="application/pdf,application/zip,.pdf,.zip"
-          multiple
-          aria-label="bulk import files"
-          disabled={busy}
-          className="text-small text-fg-body file:mr-2 file:h-7 file:px-2 file:rounded-sm file:border file:border-rule file:bg-paper-raised file:text-small file:text-fg-body file:cursor-pointer hover:file:bg-paper-sunken"
-          onChange={(e) => void onFileChange(e)}
-        />
-      </label>
+      <FileButton
+        variant="subtle"
+        size="md"
+        accept="application/pdf,application/zip,.pdf,.zip"
+        multiple
+        aria-label="bulk import files"
+        disabled={busy}
+        onFiles={(list) => void onFiles(list)}
+      >
+        Choose PDFs or .zip
+      </FileButton>
 
       {rows.length > 0 && (
         <div className="overflow-x-auto">
-          <table aria-label="bulk import progress" className="w-full text-small text-fg-body border-collapse">
+          <table
+            aria-label="bulk import progress"
+            className="w-full text-small text-fg-body border-collapse"
+          >
             <thead>
               <tr className="border-b border-rule">
-                <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">File</th>
-                <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">Status</th>
-                <th scope="col" className="text-left py-1 text-fg-muted font-sans">Detail</th>
+                <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">
+                  File
+                </th>
+                <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">
+                  Status
+                </th>
+                <th scope="col" className="text-left py-1 text-fg-muted font-sans">
+                  Detail
+                </th>
               </tr>
             </thead>
             <tbody>
               {rows.map((r, i) => (
-                <tr key={`${r.fileName}-${i}`} className="even:bg-paper-sunken border-b border-rule-subtle">
+                <tr
+                  key={`${r.fileName}-${i}`}
+                  className="even:bg-paper-sunken border-b border-rule-subtle"
+                >
                   <td className="py-1 pr-3">{r.fileName}</td>
-                  <td className="py-1 pr-3" data-testid={`bulk-status-${i}`}>{labelFor(r.status)}</td>
+                  <td className="py-1 pr-3" data-testid={`bulk-status-${i}`}>
+                    {labelFor(r.status)}
+                  </td>
                   <td className="py-1">
                     <small className="font-mono text-mono text-fg-muted">{detailFor(r)}</small>
                   </td>

--- a/app/src/ui/OnboardingTour.tsx
+++ b/app/src/ui/OnboardingTour.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
+import { Dialog } from './system/Dialog';
 
 export type OnboardingViewMode = 'current' | 'portfolio' | 'redline';
 
@@ -69,80 +70,67 @@ export function OnboardingTour({
     onDismiss();
   }, [onDismiss]);
 
-  useEffect(() => {
-    if (dismissedAt !== null) return;
-    function onKeyDown(e: KeyboardEvent): void {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        handleDismiss();
-      }
-    }
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [dismissedAt, handleDismiss]);
-
   if (dismissedAt !== null) return null;
 
   const step = STEPS[stepIndex];
   if (!step) return null;
   const hint = step.hint?.(viewMode) ?? null;
 
+  // Wave 45-F — Dialog primitive owns the focus trap, initial focus, return
+  // focus, and Esc handler. Tour content stays in this component.
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="onboarding-tour-title"
-      className="onboarding-tour"
-      tabIndex={-1}
+    <Dialog
+      open={dismissedAt === null}
+      onDismiss={handleDismiss}
+      titleId="onboarding-tour-title"
+      className="onboarding-tour__panel"
     >
-      <div className="onboarding-tour__panel">
-        <h2 id="onboarding-tour-title">{step.title}</h2>
-        <p>{step.body}</p>
-        {hint !== null && (
-          <p className="onboarding-tour__hint" role="note">
-            {hint}
-          </p>
-        )}
-        <p className="onboarding-tour__progress" aria-label={`step ${stepIndex + 1} of ${total}`}>
-          Step {stepIndex + 1} of {total}
+      <h2 id="onboarding-tour-title">{step.title}</h2>
+      <p>{step.body}</p>
+      {hint !== null && (
+        <p className="onboarding-tour__hint" role="note">
+          {hint}
         </p>
-        <div className="onboarding-tour__actions">
+      )}
+      <p className="onboarding-tour__progress" aria-label={`step ${stepIndex + 1} of ${total}`}>
+        Step {stepIndex + 1} of {total}
+      </p>
+      <div className="onboarding-tour__actions">
+        <button
+          type="button"
+          tabIndex={0}
+          onClick={handleDismiss}
+          aria-label="skip onboarding tour"
+        >
+          Skip
+        </button>
+        <button
+          type="button"
+          tabIndex={0}
+          onClick={() => setStepIndex((i) => Math.max(0, i - 1))}
+          disabled={isFirst}
+        >
+          Back
+        </button>
+        {isLast ? (
           <button
             type="button"
             tabIndex={0}
             onClick={handleDismiss}
-            aria-label="skip onboarding tour"
+            aria-label="finish onboarding tour"
           >
-            Skip
+            Done
           </button>
+        ) : (
           <button
             type="button"
             tabIndex={0}
-            onClick={() => setStepIndex((i) => Math.max(0, i - 1))}
-            disabled={isFirst}
+            onClick={() => setStepIndex((i) => Math.min(total - 1, i + 1))}
           >
-            Back
+            Next
           </button>
-          {isLast ? (
-            <button
-              type="button"
-              tabIndex={0}
-              onClick={handleDismiss}
-              aria-label="finish onboarding tour"
-            >
-              Done
-            </button>
-          ) : (
-            <button
-              type="button"
-              tabIndex={0}
-              onClick={() => setStepIndex((i) => Math.min(total - 1, i + 1))}
-            >
-              Next
-            </button>
-          )}
-        </div>
+        )}
       </div>
-    </div>
+    </Dialog>
   );
 }

--- a/app/src/ui/PackManagerPanel.test.tsx
+++ b/app/src/ui/PackManagerPanel.test.tsx
@@ -132,7 +132,8 @@ describe('PackManagerPanel', () => {
     );
     expect(screen.getByText(/LG built-in/)).toBeInTheDocument();
     expect(screen.getByText(/no additional packs installed/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/import rule pack/i)).toBeInTheDocument();
+    // Wave 45-F — accessible name = visible text per WCAG 2.5.3.
+    expect(screen.getByRole('button', { name: /import rule pack/i })).toBeInTheDocument();
   });
 
   it('does not call onImport when the user cancels (no file selected)', async () => {

--- a/app/src/ui/PackManagerPanel.test.tsx
+++ b/app/src/ui/PackManagerPanel.test.tsx
@@ -106,7 +106,9 @@ describe('PackManagerPanel', () => {
         onDelete={() => {}}
       />,
     );
-    const input = screen.getByLabelText(/import rule pack/i) as HTMLInputElement;
+    // Wave 45-F — FileButton's hidden input is no longer the labelable
+    // surface (the button is); query the hidden input directly.
+    const input = document.querySelector<HTMLInputElement>('input[type="file"][accept*="lgpack"]')!;
     const file = new File(['{"schema":"leaseguard.rulepack.v1"}'], 'example.lgpack.json', {
       type: 'application/json',
     });
@@ -145,7 +147,9 @@ describe('PackManagerPanel', () => {
         onDelete={() => {}}
       />,
     );
-    const input = screen.getByLabelText(/import rule pack/i) as HTMLInputElement;
+    // Wave 45-F — FileButton's hidden input is no longer the labelable
+    // surface (the button is); query the hidden input directly.
+    const input = document.querySelector<HTMLInputElement>('input[type="file"][accept*="lgpack"]')!;
     // Simulate a change event with no files.
     input.dispatchEvent(new Event('change', { bubbles: true }));
     expect(onImport).not.toHaveBeenCalled();
@@ -162,9 +166,7 @@ describe('PackManagerPanel', () => {
         onDelete={() => {}}
       />,
     );
-    expect(
-      screen.getByLabelText(/signature status: community/i),
-    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/signature status: community/i)).toBeInTheDocument();
   });
 
   it('renders the supplied signature badge per pack', () => {
@@ -183,15 +185,9 @@ describe('PackManagerPanel', () => {
         }}
       />,
     );
-    expect(
-      screen.getByLabelText(/signature status: verified/i),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByLabelText(/signature status: invalid signature/i),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByLabelText(/signature status: community/i),
-    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/signature status: verified/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/signature status: invalid signature/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/signature status: community/i)).toBeInTheDocument();
   });
 
   it('renders an "unknown" badge for unknown status', () => {
@@ -206,9 +202,7 @@ describe('PackManagerPanel', () => {
         signatureStatusByPackId={{ p1: 'unknown' }}
       />,
     );
-    expect(
-      screen.getByLabelText(/signature status: unknown/i),
-    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/signature status: unknown/i)).toBeInTheDocument();
   });
 
   it('surfaces import errors via a status message', async () => {
@@ -223,7 +217,9 @@ describe('PackManagerPanel', () => {
         onDelete={() => {}}
       />,
     );
-    const input = screen.getByLabelText(/import rule pack/i) as HTMLInputElement;
+    // Wave 45-F — FileButton's hidden input is no longer the labelable
+    // surface (the button is); query the hidden input directly.
+    const input = document.querySelector<HTMLInputElement>('input[type="file"][accept*="lgpack"]')!;
     const file = new File(['junk'], 'bad.lgpack.json', { type: 'application/json' });
     await userEvent.upload(input, file);
     expect(await screen.findByRole('status')).toHaveTextContent(/bad schema/);

--- a/app/src/ui/PackManagerPanel.tsx
+++ b/app/src/ui/PackManagerPanel.tsx
@@ -150,15 +150,13 @@ export function PackManagerPanel({
       </ul>
 
       <div className="space-y-1">
-        <p className="text-small text-fg-muted font-sans">Import rule pack</p>
         <FileButton
           variant="subtle"
           size="md"
           accept=".lgpack.json,application/json"
-          aria-label="Import rule pack"
           onFiles={(files) => void handleFiles(files)}
         >
-          Choose pack file
+          Import rule pack
         </FileButton>
       </div>
 

--- a/app/src/ui/PackManagerPanel.tsx
+++ b/app/src/ui/PackManagerPanel.tsx
@@ -8,15 +8,12 @@
 //   role="status"                                    (p — status/error messages)
 //   aria-expanded={browseOpen}                       (button — marketplace toggle)
 //
-import { useRef, useState } from 'react';
-import type { ChangeEvent } from 'react';
+import { useState } from 'react';
 import type { RulePackFile } from '../rules/packSchema';
-import {
-  MarketplacePanel,
-  type MarketplacePanelProps,
-} from './MarketplacePanel';
+import { MarketplacePanel, type MarketplacePanelProps } from './MarketplacePanel';
 import { Section } from './system/Section';
 import { Button } from './system/Button';
+import { FileButton } from './system/FileButton';
 
 /**
  * Signature trust vocabulary surfaced in the panel. Intentionally a
@@ -80,15 +77,12 @@ export function PackManagerPanel({
   signatureStatusByPackId,
   marketplace,
 }: PackManagerPanelProps): JSX.Element {
-  const inputRef = useRef<HTMLInputElement | null>(null);
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [browseOpen, setBrowseOpen] = useState(false);
 
-  async function handleFile(e: ChangeEvent<HTMLInputElement>): Promise<void> {
-    const file = e.target.files?.[0];
-    // Reset so selecting the same file twice re-triggers onChange.
-    e.target.value = '';
+  async function handleFiles(files: FileList): Promise<void> {
+    const file = files[0];
     if (!file) return;
     setStatus(null);
     setError(null);
@@ -108,10 +102,12 @@ export function PackManagerPanel({
           <strong className="text-fg-body">{builtInName}</strong> <em>(built-in)</em>
         </li>
         {installed.map((p) => {
-          const sig: PackSignatureBadge =
-            signatureStatusByPackId?.[p.id] ?? 'community';
+          const sig: PackSignatureBadge = signatureStatusByPackId?.[p.id] ?? 'community';
           return (
-            <li key={p.id} className="rounded-sm border border-rule bg-paper-raised shadow-paper px-3 py-2 flex items-start gap-2">
+            <li
+              key={p.id}
+              className="rounded-sm border border-rule bg-paper-raised shadow-paper px-3 py-2 flex items-start gap-2"
+            >
               <label className="flex items-center gap-2 flex-1 min-w-0 cursor-pointer">
                 <input
                   type="checkbox"
@@ -154,23 +150,28 @@ export function PackManagerPanel({
       </ul>
 
       <div className="space-y-1">
-        <label htmlFor="pack-import-input" className="text-small text-fg-muted font-sans">
-          Import rule pack
-        </label>
-        <input
-          id="pack-import-input"
-          ref={inputRef}
-          type="file"
+        <p className="text-small text-fg-muted font-sans">Import rule pack</p>
+        <FileButton
+          variant="subtle"
+          size="md"
           accept=".lgpack.json,application/json"
-          className="block text-small text-fg-body file:mr-2 file:h-7 file:px-2 file:rounded-sm file:border file:border-rule file:bg-paper-raised file:text-small file:text-fg-body file:cursor-pointer hover:file:bg-paper-sunken"
-          onChange={(e) => {
-            void handleFile(e);
-          }}
-        />
+          aria-label="Import rule pack"
+          onFiles={(files) => void handleFiles(files)}
+        >
+          Choose pack file
+        </FileButton>
       </div>
 
-      {status !== null && <p role="status" className="text-small text-positive">{status}</p>}
-      {error !== null && <p role="status" className="text-small text-severity-high">Error: {error}</p>}
+      {status !== null && (
+        <p role="status" className="text-small text-positive">
+          {status}
+        </p>
+      )}
+      {error !== null && (
+        <p role="status" className="text-small text-severity-high">
+          Error: {error}
+        </p>
+      )}
 
       {marketplace !== undefined && (
         <div className="border-t border-rule pt-3 space-y-2">

--- a/app/src/ui/system/Dialog.stories.tsx
+++ b/app/src/ui/system/Dialog.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useRef, useState } from 'react';
+import { Dialog } from './Dialog';
+import { Button } from './Button';
+
+const meta: Meta<typeof Dialog> = {
+  title: 'System/Dialog',
+  component: Dialog,
+};
+export default meta;
+type Story = StoryObj<typeof Dialog>;
+
+function DialogDemo({
+  closeOnBackdropClick = false,
+  initialFocusOnConfirm = false,
+}: {
+  closeOnBackdropClick?: boolean;
+  initialFocusOnConfirm?: boolean;
+}): JSX.Element {
+  const [open, setOpen] = useState(true);
+  const confirmRef = useRef<HTMLButtonElement>(null);
+  return (
+    <div>
+      <Button onClick={() => setOpen(true)}>Open dialog</Button>
+      <Dialog
+        open={open}
+        onDismiss={() => setOpen(false)}
+        titleId="story-dlg-title"
+        descriptionId="story-dlg-desc"
+        initialFocusRef={initialFocusOnConfirm ? confirmRef : undefined}
+        closeOnBackdropClick={closeOnBackdropClick}
+      >
+        <h2 id="story-dlg-title" className="text-display font-display text-fg mb-2">
+          Confirm action
+        </h2>
+        <p id="story-dlg-desc" className="text-body text-fg-body mb-4">
+          This action cannot be undone. The lease will be removed from your library.
+        </p>
+        <div className="flex gap-2 justify-end">
+          <Button variant="ghost" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button ref={confirmRef} onClick={() => setOpen(false)}>
+            Remove lease
+          </Button>
+        </div>
+      </Dialog>
+    </div>
+  );
+}
+
+export const Default: Story = { render: () => <DialogDemo /> };
+export const InitialFocusOnConfirm: Story = {
+  render: () => <DialogDemo initialFocusOnConfirm />,
+};
+export const CloseOnBackdropClick: Story = {
+  render: () => <DialogDemo closeOnBackdropClick />,
+};

--- a/app/src/ui/system/Dialog.test.tsx
+++ b/app/src/ui/system/Dialog.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { useRef, useState } from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { expectAxeClean } from '../../test/axe';
+import { Dialog } from './Dialog';
+
+function Harness({
+  closeOnBackdropClick = false,
+  withInitialFocusRef = false,
+}: {
+  closeOnBackdropClick?: boolean;
+  withInitialFocusRef?: boolean;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const initialFocusRef = useRef<HTMLButtonElement>(null);
+  return (
+    <div>
+      <button type="button" onClick={() => setOpen(true)}>
+        open dialog
+      </button>
+      <Dialog
+        open={open}
+        onDismiss={() => setOpen(false)}
+        titleId="dlg-title"
+        descriptionId="dlg-desc"
+        initialFocusRef={withInitialFocusRef ? initialFocusRef : undefined}
+        closeOnBackdropClick={closeOnBackdropClick}
+      >
+        <h2 id="dlg-title">Confirm action</h2>
+        <p id="dlg-desc">This action cannot be undone.</p>
+        <button type="button">Cancel</button>
+        <button type="button" ref={initialFocusRef}>
+          Confirm
+        </button>
+        <button type="button" onClick={() => setOpen(false)}>
+          Close
+        </button>
+      </Dialog>
+    </div>
+  );
+}
+
+describe('Dialog', () => {
+  it('renders nothing when open is false', () => {
+    render(<Harness />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders dialog with aria-modal + labelledby + describedby when open', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('button', { name: 'open dialog' }));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'dlg-title');
+    expect(dialog).toHaveAttribute('aria-describedby', 'dlg-desc');
+  });
+
+  it('moves focus into the dialog on mount (defaults to dialog root)', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('button', { name: 'open dialog' }));
+    // Microtask deferred — wait for it.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const dialog = screen.getByRole('dialog');
+    expect(document.activeElement).toBe(dialog);
+  });
+
+  it('honors initialFocusRef when provided', async () => {
+    const user = userEvent.setup();
+    render(<Harness withInitialFocusRef />);
+    await user.click(screen.getByRole('button', { name: 'open dialog' }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Confirm' }));
+  });
+
+  it('Esc dismisses by default', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('button', { name: 'open dialog' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('returns focus to the trigger after dismiss', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const trigger = screen.getByRole('button', { name: 'open dialog' });
+    await user.click(trigger);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(document.activeElement).not.toBe(trigger);
+    await user.keyboard('{Escape}');
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('Tab cycles within the dialog', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('button', { name: 'open dialog' }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const cancel = screen.getByRole('button', { name: 'Cancel' });
+    const close = screen.getByRole('button', { name: 'Close' });
+    cancel.focus();
+    expect(document.activeElement).toBe(cancel);
+    // Tab through Cancel → Confirm → Close → wraps back to Cancel
+    await user.tab();
+    await user.tab();
+    expect(document.activeElement).toBe(close);
+    await user.tab();
+    expect(document.activeElement).toBe(cancel);
+  });
+
+  it('backdrop click dismisses only when closeOnBackdropClick is true', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<Harness />);
+    await user.click(screen.getByRole('button', { name: 'open dialog' }));
+    // Find the fixed backdrop (the outer flex container).
+    const dialog = screen.getByRole('dialog');
+    const backdrop = dialog.parentElement as HTMLElement;
+    await user.click(backdrop);
+    expect(screen.queryByRole('dialog')).toBeInTheDocument(); // default: no dismiss
+    rerender(<Harness closeOnBackdropClick />);
+    // The first dialog is still open; close it via Esc and reopen with new prop.
+    await user.keyboard('{Escape}');
+    await user.click(screen.getByRole('button', { name: 'open dialog' }));
+    const newDialog = screen.getByRole('dialog');
+    const newBackdrop = newDialog.parentElement as HTMLElement;
+    await user.click(newBackdrop);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('has no a11y violations', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Harness />);
+    await user.click(screen.getByRole('button', { name: 'open dialog' }));
+    await expectAxeClean(container);
+  });
+});

--- a/app/src/ui/system/Dialog.tsx
+++ b/app/src/ui/system/Dialog.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef, type ReactNode, type RefObject } from 'react';
+import { useFocusTrap } from './useFocusTrap';
+
+interface DialogProps {
+  open: boolean;
+  onDismiss: () => void;
+  /** aria-labelledby target. Required for accessible name. */
+  titleId: string;
+  /** aria-describedby target, optional. */
+  descriptionId?: string;
+  /**
+   * Initial focus target on mount. Defaults to the dialog root (which is
+   * tabIndex={-1} so it can receive focus programmatically).
+   */
+  initialFocusRef?: RefObject<HTMLElement>;
+  /** Whether Esc dismisses. Default: true. */
+  closeOnEscape?: boolean;
+  /**
+   * Backdrop click dismiss. Default: false. LeaseGuard is a lawyerly app;
+   * dialogs are not consumer-soft "tap-anywhere-to-close" surfaces.
+   */
+  closeOnBackdropClick?: boolean;
+  className?: string;
+  children: ReactNode;
+}
+
+// Wave 45-F — codifies the WAI-ARIA APG dialog contract: focus trap,
+// initial focus, return focus, Esc handler, focus ring, reduced-motion
+// honored. Used today by OnboardingTour; future dialogs inherit the
+// contract by construction.
+export function Dialog({
+  open,
+  onDismiss,
+  titleId,
+  descriptionId,
+  initialFocusRef,
+  closeOnEscape = true,
+  closeOnBackdropClick = false,
+  className = '',
+  children,
+}: DialogProps): JSX.Element | null {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  // Focus trap inside the dialog while open.
+  useFocusTrap(dialogRef, open);
+
+  // Esc handler.
+  useEffect(() => {
+    if (!open || !closeOnEscape) return;
+    function onKeyDown(e: KeyboardEvent): void {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onDismiss();
+      }
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [open, closeOnEscape, onDismiss]);
+
+  // Initial focus + return focus.
+  useEffect(() => {
+    if (!open) return;
+    triggerRef.current = document.activeElement as HTMLElement | null;
+    const target = initialFocusRef?.current ?? dialogRef.current;
+    if (target) {
+      // Defer one microtask so the DOM is mounted before focus moves.
+      Promise.resolve().then(() => target.focus());
+    }
+    return () => {
+      const trigger = triggerRef.current;
+      if (trigger && typeof trigger.focus === 'function') {
+        trigger.focus();
+      }
+    };
+  }, [open, initialFocusRef]);
+
+  if (!open) return null;
+
+  function onBackdropClick(e: React.MouseEvent<HTMLDivElement>): void {
+    if (!closeOnBackdropClick) return;
+    if (e.target === e.currentTarget) onDismiss();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-fg/40 p-4"
+      onClick={onBackdropClick}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
+        className={`bg-paper-raised border border-rule rounded-sm shadow-paper p-4 max-w-lg w-full focus-visible:focus-ring ${className}`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/app/src/ui/system/FileButton.stories.tsx
+++ b/app/src/ui/system/FileButton.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FileButton } from './FileButton';
+
+const meta: Meta<typeof FileButton> = {
+  title: 'System/FileButton',
+  component: FileButton,
+  args: {
+    onFiles: () => {},
+    children: 'Import lease',
+    'aria-label': 'Import lease',
+  },
+};
+export default meta;
+type Story = StoryObj<typeof FileButton>;
+
+export const DefaultMd: Story = { args: { variant: 'subtle', size: 'md' } };
+export const Sm: Story = { args: { variant: 'subtle', size: 'sm' } };
+export const Ghost: Story = { args: { variant: 'ghost', size: 'sm', children: 'Pick file' } };
+export const Multiple: Story = {
+  args: { multiple: true, accept: '.pdf', children: 'Import multiple' },
+};
+export const Disabled: Story = { args: { disabled: true, children: 'Import (disabled)' } };

--- a/app/src/ui/system/FileButton.test.tsx
+++ b/app/src/ui/system/FileButton.test.tsx
@@ -5,14 +5,20 @@ import { expectAxeClean } from '../../test/axe';
 import { FileButton } from './FileButton';
 
 describe('FileButton', () => {
-  it('renders the visible label', () => {
-    render(<FileButton onFiles={() => {}}>Import lease</FileButton>);
-    expect(screen.getByText('Import lease')).toBeInTheDocument();
+  it('renders the visible label as a focusable button', () => {
+    render(
+      <FileButton aria-label="Import lease" onFiles={() => {}}>
+        Import lease
+      </FileButton>,
+    );
+    const btn = screen.getByRole('button', { name: 'Import lease' });
+    expect(btn).toBeInTheDocument();
+    expect(btn).not.toHaveAttribute('aria-hidden');
   });
 
   it('exposes a hidden file input with the configured accept and multiple', () => {
     const { container } = render(
-      <FileButton accept=".pdf" multiple onFiles={() => {}}>
+      <FileButton accept=".pdf" multiple aria-label="Pick" onFiles={() => {}}>
         Pick
       </FileButton>,
     );
@@ -20,19 +26,21 @@ describe('FileButton', () => {
     expect(input).not.toBeNull();
     expect(input).toHaveAttribute('accept', '.pdf');
     expect(input).toHaveAttribute('multiple');
-    // Visually hidden but still in the accessibility tree (not aria-hidden).
-    expect(input.className).toContain('sr-only');
+    // Hidden from layout AND a11y tree.
+    expect(input).toHaveAttribute('aria-hidden', 'true');
+    expect(input.style.display).toBe('none');
+    expect(input.tabIndex).toBe(-1);
   });
 
   it('calls onFiles when a file is picked', async () => {
     const user = userEvent.setup();
     const onFiles = vi.fn();
-    render(
-      <FileButton onFiles={onFiles} aria-label="Import lease">
+    const { container } = render(
+      <FileButton aria-label="Import lease" onFiles={onFiles}>
         Import
       </FileButton>,
     );
-    const input = screen.getByLabelText('Import lease') as HTMLInputElement;
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
     const file = new File(['content'], 'lease.pdf', { type: 'application/pdf' });
     await user.upload(input, file);
     expect(onFiles).toHaveBeenCalledTimes(1);
@@ -41,56 +49,72 @@ describe('FileButton', () => {
     expect(fileList[0]?.name).toBe('lease.pdf');
   });
 
-  it('size md hits the 44px AAA tap-target floor; sm hits 32px', () => {
-    const { rerender, container } = render(
-      <FileButton size="md" onFiles={() => {}}>
-        Md
-      </FileButton>,
-    );
-    expect((container.firstChild as HTMLElement).className).toContain('h-11');
-    rerender(
-      <FileButton size="sm" onFiles={() => {}}>
-        Sm
-      </FileButton>,
-    );
-    expect((container.firstChild as HTMLElement).className).toContain('h-8');
-  });
-
-  it('disabled state disables the input + visually-disables the label', () => {
+  it('clicking the visible button forwards click to the hidden input', async () => {
+    const user = userEvent.setup();
     const onFiles = vi.fn();
     const { container } = render(
-      <FileButton disabled onFiles={onFiles} aria-label="Import">
-        Import
-      </FileButton>,
-    );
-    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
-    expect(input).toBeDisabled();
-    expect(container.firstChild as HTMLElement).toHaveAttribute('aria-disabled', 'true');
-  });
-
-  it('forwards aria-describedby to the input', () => {
-    const { container } = render(
-      <FileButton aria-describedby="hint" aria-label="Pick" onFiles={() => {}}>
+      <FileButton aria-label="Pick" onFiles={onFiles}>
         Pick
       </FileButton>,
     );
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;
-    expect(input).toHaveAttribute('aria-describedby', 'hint');
+    const clickSpy = vi.spyOn(input, 'click');
+    await user.click(screen.getByRole('button', { name: 'Pick' }));
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it('size md hits the 44px AAA tap-target floor; sm hits 32px', () => {
+    const { rerender } = render(
+      <FileButton size="md" aria-label="Md" onFiles={() => {}}>
+        Md
+      </FileButton>,
+    );
+    const btnMd = screen.getByRole('button', { name: 'Md' });
+    expect(btnMd.className).toContain('h-11');
+    rerender(
+      <FileButton size="sm" aria-label="Sm" onFiles={() => {}}>
+        Sm
+      </FileButton>,
+    );
+    const btnSm = screen.getByRole('button', { name: 'Sm' });
+    expect(btnSm.className).toContain('h-8');
+  });
+
+  it('disabled state disables both the button and the input', () => {
+    const { container } = render(
+      <FileButton disabled aria-label="Import" onFiles={() => {}}>
+        Import
+      </FileButton>,
+    );
+    const btn = screen.getByRole('button', { name: 'Import' });
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(btn).toBeDisabled();
+    expect(input).toBeDisabled();
+  });
+
+  it('forwards aria-describedby to the button', () => {
+    render(
+      <FileButton aria-describedby="hint" aria-label="Pick" onFiles={() => {}}>
+        Pick
+      </FileButton>,
+    );
+    const btn = screen.getByRole('button', { name: 'Pick' });
+    expect(btn).toHaveAttribute('aria-describedby', 'hint');
   });
 
   it('has no a11y violations across variants and sizes', async () => {
     const { container } = render(
       <div>
-        <FileButton onFiles={() => {}} aria-label="default-md">
+        <FileButton aria-label="default-md" onFiles={() => {}}>
           Default md
         </FileButton>
-        <FileButton variant="ghost" size="sm" onFiles={() => {}} aria-label="ghost-sm">
+        <FileButton variant="ghost" size="sm" aria-label="ghost-sm" onFiles={() => {}}>
           Ghost sm
         </FileButton>
-        <FileButton variant="subtle" size="md" onFiles={() => {}} aria-label="subtle-md">
+        <FileButton variant="subtle" size="md" aria-label="subtle-md" onFiles={() => {}}>
           Subtle md
         </FileButton>
-        <FileButton disabled onFiles={() => {}} aria-label="disabled">
+        <FileButton disabled aria-label="disabled" onFiles={() => {}}>
           Disabled
         </FileButton>
       </div>,

--- a/app/src/ui/system/FileButton.test.tsx
+++ b/app/src/ui/system/FileButton.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { expectAxeClean } from '../../test/axe';
+import { FileButton } from './FileButton';
+
+describe('FileButton', () => {
+  it('renders the visible label', () => {
+    render(<FileButton onFiles={() => {}}>Import lease</FileButton>);
+    expect(screen.getByText('Import lease')).toBeInTheDocument();
+  });
+
+  it('exposes a hidden file input with the configured accept and multiple', () => {
+    const { container } = render(
+      <FileButton accept=".pdf" multiple onFiles={() => {}}>
+        Pick
+      </FileButton>,
+    );
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input).toHaveAttribute('accept', '.pdf');
+    expect(input).toHaveAttribute('multiple');
+    // Visually hidden but still in the accessibility tree (not aria-hidden).
+    expect(input.className).toContain('sr-only');
+  });
+
+  it('calls onFiles when a file is picked', async () => {
+    const user = userEvent.setup();
+    const onFiles = vi.fn();
+    render(
+      <FileButton onFiles={onFiles} aria-label="Import lease">
+        Import
+      </FileButton>,
+    );
+    const input = screen.getByLabelText('Import lease') as HTMLInputElement;
+    const file = new File(['content'], 'lease.pdf', { type: 'application/pdf' });
+    await user.upload(input, file);
+    expect(onFiles).toHaveBeenCalledTimes(1);
+    const fileList = onFiles.mock.calls[0]?.[0] as FileList;
+    expect(fileList.length).toBe(1);
+    expect(fileList[0]?.name).toBe('lease.pdf');
+  });
+
+  it('size md hits the 44px AAA tap-target floor; sm hits 32px', () => {
+    const { rerender, container } = render(
+      <FileButton size="md" onFiles={() => {}}>
+        Md
+      </FileButton>,
+    );
+    expect((container.firstChild as HTMLElement).className).toContain('h-11');
+    rerender(
+      <FileButton size="sm" onFiles={() => {}}>
+        Sm
+      </FileButton>,
+    );
+    expect((container.firstChild as HTMLElement).className).toContain('h-8');
+  });
+
+  it('disabled state disables the input + visually-disables the label', () => {
+    const onFiles = vi.fn();
+    const { container } = render(
+      <FileButton disabled onFiles={onFiles} aria-label="Import">
+        Import
+      </FileButton>,
+    );
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(input).toBeDisabled();
+    expect(container.firstChild as HTMLElement).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('forwards aria-describedby to the input', () => {
+    const { container } = render(
+      <FileButton aria-describedby="hint" aria-label="Pick" onFiles={() => {}}>
+        Pick
+      </FileButton>,
+    );
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(input).toHaveAttribute('aria-describedby', 'hint');
+  });
+
+  it('has no a11y violations across variants and sizes', async () => {
+    const { container } = render(
+      <div>
+        <FileButton onFiles={() => {}} aria-label="default-md">
+          Default md
+        </FileButton>
+        <FileButton variant="ghost" size="sm" onFiles={() => {}} aria-label="ghost-sm">
+          Ghost sm
+        </FileButton>
+        <FileButton variant="subtle" size="md" onFiles={() => {}} aria-label="subtle-md">
+          Subtle md
+        </FileButton>
+        <FileButton disabled onFiles={() => {}} aria-label="disabled">
+          Disabled
+        </FileButton>
+      </div>,
+    );
+    await expectAxeClean(container);
+  });
+});

--- a/app/src/ui/system/FileButton.tsx
+++ b/app/src/ui/system/FileButton.tsx
@@ -18,11 +18,14 @@ interface FileButtonProps {
   /** Optional aria-describedby target. */
   'aria-describedby'?: string;
   /**
-   * Accessible name. Required because the button forwards click to a
-   * hidden input — screen readers should hear what the button does, not
-   * just the visible decoration text.
+   * Optional accessible-name override. **Avoid using this** unless the
+   * override contains the visible button text — WCAG 2.5.3 (Label in
+   * Name, Level A) requires the accessible name to start with or contain
+   * the visible text so voice-control users can activate the button by
+   * speaking the words they see. By default the visible children are
+   * the accessible name, which is what you want.
    */
-  'aria-label': string;
+  'aria-label'?: string;
   className?: string;
 }
 

--- a/app/src/ui/system/FileButton.tsx
+++ b/app/src/ui/system/FileButton.tsx
@@ -17,8 +17,12 @@ interface FileButtonProps {
   onFiles: (files: FileList) => void;
   /** Optional aria-describedby target. */
   'aria-describedby'?: string;
-  /** Optional aria-label override; defaults to the visible children text. */
-  'aria-label'?: string;
+  /**
+   * Accessible name. Required because the button forwards click to a
+   * hidden input — screen readers should hear what the button does, not
+   * just the visible decoration text.
+   */
+  'aria-label': string;
   className?: string;
 }
 
@@ -42,10 +46,12 @@ const SIZE: Record<Size, string> = {
   md: 'h-11 min-w-11 px-3 text-body rounded-sm',
 };
 
-// Wave 45-F — Button-sized file-input affordance. Visually identical to
-// <Button>, but a hidden <input type="file"> sits inside so click /
-// keyboard activation opens the system file picker. Closes the four h-7
-// (28px) reinvented file-input sites the audit flagged.
+// Wave 45-F — Button-sized file-input affordance. The VISIBLE <button> is
+// the focus surface (gets the focus ring, keyboard activation, and
+// accessible name); the <input type="file"> is hidden via display:none
+// and triggered via ref.click() when the button is activated. This is
+// the inverse of the naive sr-only-input pattern, which leaves focus
+// invisible to sighted keyboard users.
 export function FileButton({
   children,
   accept,
@@ -60,20 +66,29 @@ export function FileButton({
 }: FileButtonProps): JSX.Element {
   const inputRef = useRef<HTMLInputElement>(null);
   return (
-    <label
-      className={`inline-flex items-center justify-center font-sans transition-colors cursor-pointer ${VARIANT[variant]} ${SIZE[size]} ${disabled ? 'opacity-60 cursor-not-allowed' : ''} ${className}`}
-      aria-disabled={disabled || undefined}
-    >
-      {children}
+    <>
+      <button
+        type="button"
+        disabled={disabled}
+        aria-label={ariaLabel}
+        aria-describedby={ariaDescribedBy}
+        onClick={() => inputRef.current?.click()}
+        className={`inline-flex items-center justify-center font-sans transition-colors ${VARIANT[variant]} ${SIZE[size]} ${disabled ? 'opacity-60 cursor-not-allowed' : ''} ${className}`}
+      >
+        {children}
+      </button>
       <input
         ref={inputRef}
         type="file"
         accept={accept}
         multiple={multiple}
         disabled={disabled}
-        aria-label={ariaLabel}
-        aria-describedby={ariaDescribedBy}
-        className="sr-only"
+        // Hidden from layout AND tab order — the button is the focus
+        // surface. tabIndex={-1} is belt-and-braces in case any future
+        // browser exposes display:none inputs (none do today).
+        tabIndex={-1}
+        aria-hidden="true"
+        style={{ display: 'none' }}
         onChange={(e) => {
           const files = e.currentTarget.files;
           if (files && files.length > 0) {
@@ -83,6 +98,6 @@ export function FileButton({
           e.currentTarget.value = '';
         }}
       />
-    </label>
+    </>
   );
 }

--- a/app/src/ui/system/FileButton.tsx
+++ b/app/src/ui/system/FileButton.tsx
@@ -1,0 +1,88 @@
+import { useRef, type ReactNode } from 'react';
+
+type Variant = 'default' | 'ghost' | 'subtle';
+type Size = 'sm' | 'md';
+
+interface FileButtonProps {
+  /** Visible label inside the button. */
+  children: ReactNode;
+  /** Forwarded to the underlying input. */
+  accept?: string;
+  multiple?: boolean;
+  disabled?: boolean;
+  /** Variant + size matching Button. Defaults to subtle / md. */
+  variant?: Variant;
+  size?: Size;
+  /** Called with the FileList when files are picked. */
+  onFiles: (files: FileList) => void;
+  /** Optional aria-describedby target. */
+  'aria-describedby'?: string;
+  /** Optional aria-label override; defaults to the visible children text. */
+  'aria-label'?: string;
+  className?: string;
+}
+
+const VARIANT: Record<Variant, string> = {
+  default:
+    'bg-ink text-paper hover:bg-ink/90 active:bg-ink/80 ' +
+    'focus-visible:outline focus-visible:outline-2 focus-visible:outline-ink ' +
+    'focus-visible:focus-ring',
+  ghost:
+    'bg-transparent text-fg-body hover:bg-[var(--state-hover)] active:bg-[var(--state-active)] ' +
+    'focus-visible:outline focus-visible:outline-2 focus-visible:outline-ink ' +
+    'focus-visible:focus-ring',
+  subtle:
+    'bg-paper-sunken text-fg-body border border-rule hover:bg-[var(--state-hover)] active:bg-[var(--state-active)] ' +
+    'focus-visible:outline focus-visible:outline-2 focus-visible:outline-ink ' +
+    'focus-visible:focus-ring',
+};
+
+const SIZE: Record<Size, string> = {
+  sm: 'h-8 min-w-8 px-2 text-small rounded-sm',
+  md: 'h-11 min-w-11 px-3 text-body rounded-sm',
+};
+
+// Wave 45-F — Button-sized file-input affordance. Visually identical to
+// <Button>, but a hidden <input type="file"> sits inside so click /
+// keyboard activation opens the system file picker. Closes the four h-7
+// (28px) reinvented file-input sites the audit flagged.
+export function FileButton({
+  children,
+  accept,
+  multiple,
+  disabled,
+  variant = 'subtle',
+  size = 'md',
+  onFiles,
+  className = '',
+  'aria-describedby': ariaDescribedBy,
+  'aria-label': ariaLabel,
+}: FileButtonProps): JSX.Element {
+  const inputRef = useRef<HTMLInputElement>(null);
+  return (
+    <label
+      className={`inline-flex items-center justify-center font-sans transition-colors cursor-pointer ${VARIANT[variant]} ${SIZE[size]} ${disabled ? 'opacity-60 cursor-not-allowed' : ''} ${className}`}
+      aria-disabled={disabled || undefined}
+    >
+      {children}
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        multiple={multiple}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        aria-describedby={ariaDescribedBy}
+        className="sr-only"
+        onChange={(e) => {
+          const files = e.currentTarget.files;
+          if (files && files.length > 0) {
+            onFiles(files);
+          }
+          // Reset so picking the same file again still fires onChange.
+          e.currentTarget.value = '';
+        }}
+      />
+    </label>
+  );
+}

--- a/app/src/ui/system/useFocusTrap.test.tsx
+++ b/app/src/ui/system/useFocusTrap.test.tsx
@@ -84,6 +84,33 @@ describe('useFocusTrap', () => {
     expect(document.activeElement).toBe(first);
   });
 
+  it('skips elements hidden via display:none, hidden attribute, or aria-hidden (Codex regression)', async () => {
+    const user = userEvent.setup();
+    render(
+      <Trap>
+        <button type="button">first</button>
+        <button type="button" style={{ display: 'none' }}>
+          display-none
+        </button>
+        <button type="button" hidden>
+          hidden-attr
+        </button>
+        <button type="button" aria-hidden="true">
+          aria-hidden
+        </button>
+        <button type="button">last</button>
+      </Trap>,
+    );
+    const first = screen.getByRole('button', { name: 'first' });
+    const last = screen.getByRole('button', { name: 'last' });
+    last.focus();
+    await user.tab();
+    // Hidden buttons must be skipped — wrap goes straight to first.
+    expect(document.activeElement).toBe(first);
+    await user.tab({ shift: true });
+    expect(document.activeElement).toBe(last);
+  });
+
   it('Shift+Tab from the container itself wraps to the last focusable (Codex regression)', async () => {
     const user = userEvent.setup();
     render(

--- a/app/src/ui/system/useFocusTrap.test.tsx
+++ b/app/src/ui/system/useFocusTrap.test.tsx
@@ -83,4 +83,26 @@ describe('useFocusTrap', () => {
     await user.tab();
     expect(document.activeElement).toBe(first);
   });
+
+  it('Shift+Tab from the container itself wraps to the last focusable (Codex regression)', async () => {
+    const user = userEvent.setup();
+    render(
+      <Trap>
+        <button type="button">first</button>
+        <button type="button">last</button>
+      </Trap>,
+    );
+    const trap = screen.getByTestId('trap');
+    const first = screen.getByRole('button', { name: 'first' });
+    const last = screen.getByRole('button', { name: 'last' });
+    trap.focus();
+    expect(document.activeElement).toBe(trap);
+    await user.tab({ shift: true });
+    // Without the wrap fix, focus would have escaped to outside-before.
+    expect(document.activeElement).toBe(last);
+    // And forward Tab from the root container goes to the first.
+    trap.focus();
+    await user.tab();
+    expect(document.activeElement).toBe(first);
+  });
 });

--- a/app/src/ui/system/useFocusTrap.test.tsx
+++ b/app/src/ui/system/useFocusTrap.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { useRef, type ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { useFocusTrap } from './useFocusTrap';
+
+function Trap({ active = true, children }: { active?: boolean; children: ReactNode }): JSX.Element {
+  const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(ref, active);
+  return (
+    <div>
+      <button type="button">outside-before</button>
+      <div ref={ref} tabIndex={-1} data-testid="trap">
+        {children}
+      </div>
+      <button type="button">outside-after</button>
+    </div>
+  );
+}
+
+describe('useFocusTrap', () => {
+  it('Tab from last focusable cycles to first', async () => {
+    const user = userEvent.setup();
+    render(
+      <Trap>
+        <button type="button">first</button>
+        <button type="button">middle</button>
+        <button type="button">last</button>
+      </Trap>,
+    );
+    const first = screen.getByRole('button', { name: 'first' });
+    const last = screen.getByRole('button', { name: 'last' });
+    last.focus();
+    expect(document.activeElement).toBe(last);
+    await user.tab();
+    expect(document.activeElement).toBe(first);
+  });
+
+  it('Shift+Tab from first focusable cycles to last', async () => {
+    const user = userEvent.setup();
+    render(
+      <Trap>
+        <button type="button">first</button>
+        <button type="button">last</button>
+      </Trap>,
+    );
+    const first = screen.getByRole('button', { name: 'first' });
+    const last = screen.getByRole('button', { name: 'last' });
+    first.focus();
+    expect(document.activeElement).toBe(first);
+    await user.tab({ shift: true });
+    expect(document.activeElement).toBe(last);
+  });
+
+  it('does not trap when active is false', async () => {
+    const user = userEvent.setup();
+    render(
+      <Trap active={false}>
+        <button type="button">inside</button>
+      </Trap>,
+    );
+    const inside = screen.getByRole('button', { name: 'inside' });
+    inside.focus();
+    await user.tab();
+    // With trap inactive, Tab proceeds to the outside-after button.
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'outside-after' }));
+  });
+
+  it('skips disabled buttons', async () => {
+    const user = userEvent.setup();
+    render(
+      <Trap>
+        <button type="button">first</button>
+        <button type="button" disabled>
+          disabled-middle
+        </button>
+        <button type="button">last</button>
+      </Trap>,
+    );
+    const first = screen.getByRole('button', { name: 'first' });
+    const last = screen.getByRole('button', { name: 'last' });
+    last.focus();
+    await user.tab();
+    expect(document.activeElement).toBe(first);
+  });
+});

--- a/app/src/ui/system/useFocusTrap.ts
+++ b/app/src/ui/system/useFocusTrap.ts
@@ -35,13 +35,23 @@ export function useFocusTrap(containerRef: RefObject<HTMLElement>, active: boole
       const last = focusable[focusable.length - 1];
       if (!first || !last) return;
       const active = document.activeElement as HTMLElement | null;
+      // Treat the root container itself as a wrap boundary. When initial
+      // focus lands on the dialog root (Dialog default), Shift+Tab from
+      // there must wrap to the last focusable, not fall through to the
+      // background. Forward Tab from the root goes to the first
+      // focusable. (Codex caught this gap in the original logic, which
+      // only wrapped on first/last/outside-root.)
+      const onRoot = active === root;
       if (e.shiftKey) {
-        if (active === first || !root?.contains(active)) {
+        if (onRoot || active === first || !root?.contains(active)) {
           e.preventDefault();
           last.focus();
         }
       } else {
-        if (active === last || !root?.contains(active)) {
+        if (onRoot) {
+          e.preventDefault();
+          first.focus();
+        } else if (active === last || !root?.contains(active)) {
           e.preventDefault();
           first.focus();
         }

--- a/app/src/ui/system/useFocusTrap.ts
+++ b/app/src/ui/system/useFocusTrap.ts
@@ -82,6 +82,16 @@ export function useFocusTrap(containerRef: RefObject<HTMLElement>, active: boole
       }
     }
 
+    // KNOWN GAP (Wave 45-F follow-up): we only intercept Tab/Shift+Tab.
+    // App-level keyboard shortcuts that call .focus() directly (e.g.
+    // App.tsx's `/` / Cmd+F findings-search shortcut) can still move
+    // focus into the background while a Dialog is open. A focusin
+    // guard that bounces stray focus inside is the standard fix, but
+    // it interacts badly with the existing App-level test setup where
+    // OnboardingTour is mounted by default and tests interact with
+    // surrounding panels. The proper resolution is either (a) inert
+    // the background while Dialog is open, or (b) seed the tour as
+    // dismissed in test beforeEach. Tracked in BACKLOG.
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [active, containerRef]);

--- a/app/src/ui/system/useFocusTrap.ts
+++ b/app/src/ui/system/useFocusTrap.ts
@@ -1,0 +1,54 @@
+import { useEffect, type RefObject } from 'react';
+
+// Wave 45-F — focus-trap hook for the Dialog primitive. Cycles Tab /
+// Shift-Tab within the container's focusable descendants, recomputed on
+// DOM mutations so dynamic content (stepper next/back, error states) stays
+// trapped. Exits the trap automatically when `active` flips false.
+//
+// Not exported from `system/index.ts`: this is internal to Dialog.
+export function useFocusTrap(containerRef: RefObject<HTMLElement>, active: boolean): void {
+  useEffect(() => {
+    if (!active) return;
+    const root = containerRef.current;
+    if (!root) return;
+
+    function getFocusable(): HTMLElement[] {
+      if (!root) return [];
+      const selector =
+        'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+      return Array.from(root.querySelectorAll<HTMLElement>(selector)).filter((el) => {
+        // Filter out hidden / display:none nodes so Tab cycling skips them.
+        return !el.hasAttribute('aria-hidden') || el.getAttribute('aria-hidden') !== 'true';
+      });
+    }
+
+    function onKeyDown(e: KeyboardEvent): void {
+      if (e.key !== 'Tab') return;
+      const focusable = getFocusable();
+      if (focusable.length === 0) {
+        // Nothing focusable — keep focus on the container itself.
+        e.preventDefault();
+        root?.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (!first || !last) return;
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        if (active === first || !root?.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last || !root?.contains(active)) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [active, containerRef]);
+}

--- a/app/src/ui/system/useFocusTrap.ts
+++ b/app/src/ui/system/useFocusTrap.ts
@@ -12,14 +12,38 @@ export function useFocusTrap(containerRef: RefObject<HTMLElement>, active: boole
     const root = containerRef.current;
     if (!root) return;
 
+    function isVisible(el: HTMLElement): boolean {
+      // Walk the element + ancestors checking for hidden / aria-hidden /
+      // inert / display:none / visibility:hidden|collapse. We avoid
+      // offsetParent / getClientRects because jsdom doesn't implement
+      // layout, so those return false-negatives for every test-rendered
+      // element. Inline-style checks work the same in jsdom and real
+      // browsers, and getComputedStyle (when available) catches CSS
+      // applied via stylesheet.
+      const hasComputedStyle =
+        typeof window !== 'undefined' && typeof window.getComputedStyle === 'function';
+      let cur: HTMLElement | null = el;
+      while (cur && cur !== root) {
+        if (cur.hasAttribute('hidden')) return false;
+        if (cur.getAttribute('aria-hidden') === 'true') return false;
+        if (cur.hasAttribute('inert')) return false;
+        if (cur.style.display === 'none') return false;
+        if (cur.style.visibility === 'hidden' || cur.style.visibility === 'collapse') return false;
+        if (hasComputedStyle) {
+          const style = window.getComputedStyle(cur);
+          if (style.display === 'none') return false;
+          if (style.visibility === 'hidden' || style.visibility === 'collapse') return false;
+        }
+        cur = cur.parentElement;
+      }
+      return true;
+    }
+
     function getFocusable(): HTMLElement[] {
       if (!root) return [];
       const selector =
         'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
-      return Array.from(root.querySelectorAll<HTMLElement>(selector)).filter((el) => {
-        // Filter out hidden / display:none nodes so Tab cycling skips them.
-        return !el.hasAttribute('aria-hidden') || el.getAttribute('aria-hidden') !== 'true';
-      });
+      return Array.from(root.querySelectorAll<HTMLElement>(selector)).filter(isVisible);
     }
 
     function onKeyDown(e: KeyboardEvent): void {

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -589,6 +589,20 @@ score: number }` field that the LLM path populates. The audit
 blob:` envelope. Done = `scripts/check-csp.mjs` stays green
       and the dist build serves the model from same-origin.
 
+### Wave 45-F follow-ups
+
+- [ ] **Dialog focus containment for direct `.focus()` calls.** Wave 45-F
+      added a Tab-only focus trap to `useFocusTrap`. App-level keyboard
+      shortcuts that call `.focus()` directly (notably `App.tsx`'s `/` /
+      Cmd+F findings-search shortcut) can still escape the trap. Two
+      paths: (a) inert the background while a Dialog is open via the
+      `inert` attribute (Chrome 102+ / Firefox 112+ / Safari 15.5+), or
+      (b) seed the OnboardingTour as dismissed in App test setup so a
+      focusin-guard can be reintroduced without breaking tests. Codex
+      flagged this in the wave's adversarial review (run
+      `20260429T124811Z`); shipped with this gap because mustFix=0 and
+      the proper fix is non-trivial.
+
 ### Wave 35 follow-ups
 
 - [ ] Re-run `npm run hybrid:stats` after meaningful real-world usage


### PR DESCRIPTION
## Summary

Wave 45-F closes the two P1 a11y findings from \`/impeccable audit\` (audit total **17/20**) by codifying the missing patterns as design-system primitives rather than fixing them inline.

**Five items, eight commits** (5 wave items + 3 codex-iteration fixes), one PR.

### A. \`<Dialog>\` primitive (commit b5c1c7c → 8ed714d)
Codifies the WAI-ARIA APG dialog contract — focus trap, Esc handler, return focus, ARIA wiring, focus ring — once, so future dialogs inherit by construction.

- \`useFocusTrap\` hook: Tab/Shift+Tab cycle within container; container itself is a wrap boundary (Codex regression fix).
- Visibility filter walks element + ancestors checking \`hidden\`, \`aria-hidden\`, \`inert\`, inline \`display:none\`/\`visibility\`, plus \`getComputedStyle\` (catches CSS-stylesheet-applied hiding). jsdom-friendly.
- Dialog primitive: \`role="dialog"\`, \`aria-modal\`, \`aria-labelledby\`, optional \`initialFocusRef\`, \`closeOnEscape\`, \`closeOnBackdropClick\` (default false).
- Initial focus moves to \`initialFocusRef.current\` else dialog root; \`document.activeElement\` cached at open and restored on dismiss.

### B. OnboardingTour migration
\`OnboardingTour.tsx\` now consumes Dialog. The hand-rolled dialog wrapper, the component-local Esc useEffect, and the manual ARIA scaffolding are gone. All 11 existing tests pass without modification.

### C. \`<FileButton>\` primitive
Button-sized file-input affordance. Visible \`<button>\` is the focus surface (gets focus ring + accessible name + keyboard activation); the input is \`display:none\` and triggered via ref. WCAG 2.5.3 Label-in-Name: accessible name defaults to visible text; the optional \`aria-label\` override is discouraged unless it contains the visible text.

### D. Four file-input migrations
\`AppFooterControls\`, \`BulkImportPanel\`, \`AppLibraryAndPacksPane\`, \`PackManagerPanel\` migrated. Visible labels updated to be self-describing ("Bulk import files", "Pack file to diff", "Import rule pack", "Import encrypted archive"). All h-7 (28px) reinvented file-input button styling is gone — primary actions hit 44×44, secondary at 32×32.

### E. BulkImport progressive aria-live
\`<p aria-live="polite" aria-atomic="false" aria-label="bulk import live progress">\` above the table, announcing running counts as files stream in. Drops the misleading "X of Y" denominator (Y is unknowable for zip inputs while streaming). Verb flips between "Processing…" and "Processed…" based on busy state.

## Adversarial review

Four Codex passes; final summary at \`.codex-runs/20260429T124811Z-summary.json\`.

| Pass | Findings | Action |
|---|---|---|
| 1 (run 20260429T122233Z) | 1 high (FileButton focus invisible), 1 medium (BulkImport "X of Y" misleading) | Fixed in commit 3ea929b |
| 2 (run 20260429T123211Z) | 1 high (focus trap escapes via Shift-Tab from container) | Fixed in commit 8ed714d |
| 3 (run 20260429T123726Z) | 2 medium (WCAG 2.5.3 label-in-name divergence; hidden-node filter incomplete) | Fixed in commit ac0f0cf |
| 4 (run 20260429T124811Z) | 1 medium (Tab-only trap allows escape via direct .focus() like App.tsx \`/\` shortcut) | **Shipped with todo** in commit 51fcf0f. Reverting the focusin-guard fix because it interacts with OnboardingTour-mounted-by-default in the App test bed, breaking ~7 unrelated flows. Tracked in BACKLOG \`Wave 45-F follow-ups\`. Two paths to close: inert the background, or seed tour-dismissed in App test beforeEach. Both exceed wave scope. |

Escalation logged at \`.codex-runs/escalations.jsonl\` (\`shipped-despite\` / \`shipped-with-todo\`).

## Verification

- [x] \`git grep -nE "h-7\\\b|file:h-7" app/src/ui\` — 0 hits
- [x] \`git grep -n 'role="dialog"' app/src/ui\` — 1 hit (the new primitive)
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test:coverage\` — **1546 pass | 1 todo (1547)**, 185 files, all coverage thresholds met
- [x] \`npx playwright test tests/e2e/a11y.spec.ts --project=chromium\` — pass (real-browser axe per the Wave 45-A lesson)
- [x] All-stories axe sweep — Dialog and FileButton stories add to coverage with zero new violations

## Out of scope (Wave 45 program continues)

- 45-B renter-IA distill of \`AppCurrentPane\` — separate plan
- 45-C \`ComparePanel\` rewrite — separate plan
- 45-D renter copy clarify — separate plan
- 45-E severity-vs-negative + Field error API + AppRedlinePane + AppHeader file-input mirror — separate plan (will consume the new \`<FileButton>\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)