### PR TITLE
clarify(renter): plain-language explainers for ~, hash digests, signed export, app errors (Wave 45-D)

### DIFF
--- a/app/src/ui/AppCurrentPane.test.tsx
+++ b/app/src/ui/AppCurrentPane.test.tsx
@@ -232,6 +232,10 @@ describe('AppCurrentPane', () => {
       status,
       ocrState: { kind: 'error', message: 'no traineddata' },
     });
-    expect(screen.getByRole('alert')).toHaveTextContent(/OCR failed: no traineddata/);
+    // Wave 45-D — error copy rewritten from "OCR failed: <msg>" to plain
+    // language ("OCR didn't finish reading this PDF…"). The underlying
+    // message still surfaces.
+    expect(screen.getByRole('alert')).toHaveTextContent(/no traineddata/);
+    expect(screen.getByRole('alert')).toHaveTextContent(/ocr didn.{1,3}t finish reading/i);
   });
 });

--- a/app/src/ui/AppCurrentPane.tsx
+++ b/app/src/ui/AppCurrentPane.tsx
@@ -175,7 +175,9 @@ export function AppCurrentPane({
           )}
           {ocrState.kind === 'error' && (
             <p role="alert" className="text-body text-severity-high">
-              OCR failed: {ocrState.message}
+              OCR didn&rsquo;t finish reading this PDF. The error was: {ocrState.message}. Clauses
+              on scanned pages may not appear in findings. You can try a different language pack
+              from the picker above, or use the original PDF if its text is selectable.
             </p>
           )}
         </div>

--- a/app/src/ui/AppCurrentPane.tsx
+++ b/app/src/ui/AppCurrentPane.tsx
@@ -143,12 +143,11 @@ export function AppCurrentPane({
         <details className="text-small text-fg-muted mb-3">
           <summary className="cursor-pointer select-none">What is signed export?</summary>
           <p className="mt-1 max-w-prose">
-            The exported file carries a digital signature made with your local key. To verify the
-            file came from you and hasn&rsquo;t been altered since, share your public-key
-            fingerprint with the recipient out-of-band (text, email, in person). They can then
-            confirm the embedded key matches yours and the signature is valid. Without a shared
-            fingerprint, the file only verifies against the key embedded inside it, which an
-            attacker could replace.
+            The exported file carries a digital signature made with your local key. To use it as
+            proof of origin, share your public key with the recipient out-of-band (use{' '}
+            <em>Export public key</em> in the Signing key panel). They compare your public key
+            against the key embedded in the signed export. Without that comparison step, the file
+            only verifies against its own embedded key, which an attacker could replace.
           </p>
         </details>
       )}

--- a/app/src/ui/AppCurrentPane.tsx
+++ b/app/src/ui/AppCurrentPane.tsx
@@ -143,11 +143,12 @@ export function AppCurrentPane({
         <details className="text-small text-fg-muted mb-3">
           <summary className="cursor-pointer select-none">What is signed export?</summary>
           <p className="mt-1 max-w-prose">
-            A signed export pairs your findings with a digital signature so anyone can verify the
-            file hasn&rsquo;t been altered since you exported it. The signing key stays in your
-            browser. Note: the signature proves the file is intact, not who created it. Identity
-            binding (recipient verifies a specific public-key fingerprint) is up to you and your
-            counterparty.
+            The exported file carries a digital signature made with your local key. To verify the
+            file came from you and hasn&rsquo;t been altered since, share your public-key
+            fingerprint with the recipient out-of-band (text, email, in person). They can then
+            confirm the embedded key matches yours and the signature is valid. Without a shared
+            fingerprint, the file only verifies against the key embedded inside it, which an
+            attacker could replace.
           </p>
         </details>
       )}

--- a/app/src/ui/AppCurrentPane.tsx
+++ b/app/src/ui/AppCurrentPane.tsx
@@ -144,8 +144,7 @@ export function AppCurrentPane({
           <summary className="cursor-pointer select-none">What is signed export?</summary>
           <p className="mt-1 max-w-prose">
             The exported file carries a digital signature made with your local key. To use it as
-            proof of origin, share your public key with the recipient out-of-band (use{' '}
-            <em>Export public key</em> in the Signing key panel). They compare your public key
+            proof of origin, share your public key with the recipient out-of-band; they compare it
             against the key embedded in the signed export. Without that comparison step, the file
             only verifies against its own embedded key, which an attacker could replace.
           </p>

--- a/app/src/ui/AppCurrentPane.tsx
+++ b/app/src/ui/AppCurrentPane.tsx
@@ -139,6 +139,16 @@ export function AppCurrentPane({
           </Button>
         )}
       </div>
+      {hasSigningKey && (
+        <details className="text-small text-fg-muted mb-3">
+          <summary className="cursor-pointer select-none">What is signed export?</summary>
+          <p className="mt-1 max-w-prose">
+            A signed export pairs your findings with a signature derived from a key only you
+            control. Anyone you share the file with can verify it came from you and has not been
+            altered. The key never leaves your browser.
+          </p>
+        </details>
+      )}
       {ocr.likelyScanned && (
         <div
           role="status"

--- a/app/src/ui/AppCurrentPane.tsx
+++ b/app/src/ui/AppCurrentPane.tsx
@@ -143,9 +143,11 @@ export function AppCurrentPane({
         <details className="text-small text-fg-muted mb-3">
           <summary className="cursor-pointer select-none">What is signed export?</summary>
           <p className="mt-1 max-w-prose">
-            A signed export pairs your findings with a signature derived from a key only you
-            control. Anyone you share the file with can verify it came from you and has not been
-            altered. The key never leaves your browser.
+            A signed export pairs your findings with a digital signature so anyone can verify the
+            file hasn&rsquo;t been altered since you exported it. The signing key stays in your
+            browser. Note: the signature proves the file is intact, not who created it. Identity
+            binding (recipient verifies a specific public-key fingerprint) is up to you and your
+            counterparty.
           </p>
         </details>
       )}

--- a/app/src/ui/AuditLogPanel.tsx
+++ b/app/src/ui/AuditLogPanel.tsx
@@ -59,7 +59,11 @@ export function AuditLogPanel({
           {verification.ok ? (
             <span>Chain intact ({entries.length} entries).</span>
           ) : (
-            <span>Chain broken at seq {verification.firstBadSeq ?? '?'}.</span>
+            <span>
+              Chain broken at seq {verification.firstBadSeq ?? '?'}. An entry was altered or
+              removed; signed exports from this point onward won&rsquo;t verify until the chain is
+              repaired.
+            </span>
           )}
         </p>
       )}

--- a/app/src/ui/AuditLogPanel.tsx
+++ b/app/src/ui/AuditLogPanel.tsx
@@ -28,8 +28,13 @@ export function AuditLogPanel({
     <Section label="audit log" className="space-y-3 px-4 py-4">
       <h2 className="text-heading uppercase text-fg-muted">Audit log</h2>
       <p className="text-body text-fg-body">
-        Append-only, hash-chained record of analyses, exports, and library
-        changes. Entries live in a separate local database.
+        Append-only, hash-chained record of analyses, exports, and library changes. Entries live in
+        a separate local database.
+      </p>
+      <p className="text-small text-fg-muted">
+        Each entry signs the one before it. If a single entry is altered, the chain breaks and
+        verification fails. The full digest is shown in mono so you can copy it; the short form
+        (first 8 characters) is enough for spot-checks.
       </p>
 
       <div role="group" aria-label="audit log actions" className="flex flex-wrap gap-2">
@@ -54,9 +59,7 @@ export function AuditLogPanel({
           {verification.ok ? (
             <span>Chain intact ({entries.length} entries).</span>
           ) : (
-            <span>
-              Chain broken at seq {verification.firstBadSeq ?? '?'}.
-            </span>
+            <span>Chain broken at seq {verification.firstBadSeq ?? '?'}.</span>
           )}
         </p>
       )}
@@ -67,13 +70,24 @@ export function AuditLogPanel({
         </p>
       ) : (
         <div className="overflow-x-auto">
-          <table aria-label="audit entries" className="w-full text-small text-fg-body border-collapse">
+          <table
+            aria-label="audit entries"
+            className="w-full text-small text-fg-body border-collapse"
+          >
             <thead>
               <tr className="border-b border-rule">
-                <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">#</th>
-                <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">Time</th>
-                <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">Kind</th>
-                <th scope="col" className="text-left py-1 text-fg-muted font-sans">Payload</th>
+                <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">
+                  #
+                </th>
+                <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">
+                  Time
+                </th>
+                <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">
+                  Kind
+                </th>
+                <th scope="col" className="text-left py-1 text-fg-muted font-sans">
+                  Payload
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -83,7 +97,9 @@ export function AuditLogPanel({
                   <td className="py-1 pr-3">{e.timestamp}</td>
                   <td className="py-1 pr-3">{e.kind}</td>
                   <td className="py-1">
-                    <code className="font-mono text-mono text-fg-body">{summarizePayload(e.payload)}</code>
+                    <code className="font-mono text-mono text-fg-body">
+                      {summarizePayload(e.payload)}
+                    </code>
                   </td>
                 </tr>
               ))}

--- a/app/src/ui/AuditLogPanel.tsx
+++ b/app/src/ui/AuditLogPanel.tsx
@@ -28,8 +28,9 @@ export function AuditLogPanel({
     <Section label="audit log" className="space-y-3 px-4 py-4">
       <h2 className="text-heading uppercase text-fg-muted">Audit log</h2>
       <p className="text-body text-fg-body">
-        Append-only, hash-chained record of analyses, exports, and library changes. Entries live in
-        a separate local database.
+        Append-only, hash-chained record of significant in-app actions. Entries live in a separate
+        local database. Note: signed-export events are not currently written to this log; only
+        unsigned exports are.
       </p>
       <p className="text-small text-fg-muted">
         Each entry references the hash of the entry before it. Verifying the chain re-computes those

--- a/app/src/ui/AuditLogPanel.tsx
+++ b/app/src/ui/AuditLogPanel.tsx
@@ -61,8 +61,8 @@ export function AuditLogPanel({
           ) : (
             <span>
               Chain broken at seq {verification.firstBadSeq ?? '?'}. An entry was altered or
-              removed; signed exports from this point onward won&rsquo;t verify until the chain is
-              repaired.
+              removed, so the audit log&rsquo;s tamper-evidence guarantee no longer holds for the
+              affected range. (Signed exports verify independently of the audit log.)
             </span>
           )}
         </p>

--- a/app/src/ui/AuditLogPanel.tsx
+++ b/app/src/ui/AuditLogPanel.tsx
@@ -32,9 +32,10 @@ export function AuditLogPanel({
         a separate local database.
       </p>
       <p className="text-small text-fg-muted">
-        Each entry signs the one before it. If a single entry is altered, the chain breaks and
-        verification fails. The full digest is shown in mono so you can copy it; the short form
-        (first 8 characters) is enough for spot-checks.
+        Each entry references the hash of the entry before it. Verifying the chain re-computes those
+        hashes and confirms the log is internally consistent. This catches a stray edit that
+        doesn&rsquo;t update downstream entries; it is a local consistency check, not a
+        cryptographic proof against an attacker with full access to your browser&rsquo;s storage.
       </p>
 
       <div role="group" aria-label="audit log actions" className="flex flex-wrap gap-2">
@@ -61,8 +62,8 @@ export function AuditLogPanel({
           ) : (
             <span>
               Chain broken at seq {verification.firstBadSeq ?? '?'}. An entry was altered or
-              removed, so the audit log&rsquo;s tamper-evidence guarantee no longer holds for the
-              affected range. (Signed exports verify independently of the audit log.)
+              removed, so the local consistency check no longer holds for the affected range.
+              (Signed exports verify independently of the audit log.)
             </span>
           )}
         </p>

--- a/app/src/ui/FindingsPanel.badge.test.tsx
+++ b/app/src/ui/FindingsPanel.badge.test.tsx
@@ -33,7 +33,7 @@ describe('FindingsPanel — hybrid badge (Wave 28-D)', () => {
   it('renders the hybrid badge with aria-pressed=false initially', () => {
     render(<FindingsPanel findings={[f({})]} onSelect={() => {}} />);
     const badge = screen.getByRole('button', {
-      name: /identified by on-device classifier/i,
+      name: /identified by on-device pattern match/i,
     });
     expect(badge).toHaveAttribute('aria-pressed', 'false');
   });
@@ -41,7 +41,7 @@ describe('FindingsPanel — hybrid badge (Wave 28-D)', () => {
   it('toggles aria-pressed=true after click', async () => {
     render(<FindingsPanel findings={[f({})]} onSelect={() => {}} />);
     const badge = screen.getByRole('button', {
-      name: /identified by on-device classifier/i,
+      name: /identified by on-device pattern match/i,
     });
     await userEvent.click(badge);
     expect(badge).toHaveAttribute('aria-pressed', 'true');
@@ -50,7 +50,7 @@ describe('FindingsPanel — hybrid badge (Wave 28-D)', () => {
   it('applies the focus-ring utility for keyboard focus', () => {
     render(<FindingsPanel findings={[f({})]} onSelect={() => {}} />);
     const badge = screen.getByRole('button', {
-      name: /identified by on-device classifier/i,
+      name: /identified by on-device pattern match/i,
     });
     expect(badge.className).toMatch(/focus-visible:focus-ring/);
   });

--- a/app/src/ui/FindingsPanel.badge.test.tsx
+++ b/app/src/ui/FindingsPanel.badge.test.tsx
@@ -33,7 +33,7 @@ describe('FindingsPanel — hybrid badge (Wave 28-D)', () => {
   it('renders the hybrid badge with aria-pressed=false initially', () => {
     render(<FindingsPanel findings={[f({})]} onSelect={() => {}} />);
     const badge = screen.getByRole('button', {
-      name: /identified by on-device pattern match/i,
+      name: /identified by on-device similarity match/i,
     });
     expect(badge).toHaveAttribute('aria-pressed', 'false');
   });
@@ -41,7 +41,7 @@ describe('FindingsPanel — hybrid badge (Wave 28-D)', () => {
   it('toggles aria-pressed=true after click', async () => {
     render(<FindingsPanel findings={[f({})]} onSelect={() => {}} />);
     const badge = screen.getByRole('button', {
-      name: /identified by on-device pattern match/i,
+      name: /identified by on-device similarity match/i,
     });
     await userEvent.click(badge);
     expect(badge).toHaveAttribute('aria-pressed', 'true');
@@ -50,7 +50,7 @@ describe('FindingsPanel — hybrid badge (Wave 28-D)', () => {
   it('applies the focus-ring utility for keyboard focus', () => {
     render(<FindingsPanel findings={[f({})]} onSelect={() => {}} />);
     const badge = screen.getByRole('button', {
-      name: /identified by on-device pattern match/i,
+      name: /identified by on-device similarity match/i,
     });
     expect(badge.className).toMatch(/focus-visible:focus-ring/);
   });

--- a/app/src/ui/FindingsPanel.feedback.test.tsx
+++ b/app/src/ui/FindingsPanel.feedback.test.tsx
@@ -83,7 +83,7 @@ describe('FindingsPanel — hybrid-feedback wiring (Wave 29-C)', () => {
     );
     // Open the hybrid detail disclosure
     const badge = await screen.findByRole('button', {
-      name: /identified by on-device pattern match/i,
+      name: /identified by on-device similarity match/i,
     });
     await userEvent.click(badge);
     // Should show first 8 chars of entryHash
@@ -108,7 +108,7 @@ describe('FindingsPanel — hybrid-feedback wiring (Wave 29-C)', () => {
       <FindingsPanel findings={[hybrid]} onSelect={() => {}} auditEntries={[unrelatedEntry]} />,
     );
     const badge = await screen.findByRole('button', {
-      name: /identified by on-device pattern match/i,
+      name: /identified by on-device similarity match/i,
     });
     await userEvent.click(badge);
     expect(screen.queryByText(/audit entry/i)).toBeNull();

--- a/app/src/ui/FindingsPanel.feedback.test.tsx
+++ b/app/src/ui/FindingsPanel.feedback.test.tsx
@@ -59,13 +59,7 @@ describe('FindingsPanel — hybrid-feedback wiring (Wave 29-C)', () => {
   });
 
   it('omits the button when no onHybridFeedback callback is provided', () => {
-    render(
-      <FindingsPanel
-        findings={[hybrid]}
-        onSelect={() => {}}
-        leaseId="lease-1"
-      />,
-    );
+    render(<FindingsPanel findings={[hybrid]} onSelect={() => {}} leaseId="lease-1" />);
     expect(screen.queryByRole('button', { name: /not relevant/i })).toBeNull();
   });
 
@@ -75,24 +69,30 @@ describe('FindingsPanel — hybrid-feedback wiring (Wave 29-C)', () => {
       seq: 1,
       timestamp: '2024-01-01T00:00:00.000Z',
       kind: 'llm-classify',
-      payload: { ruleId: 'auto-renew', paragraphIndex: 3, modelId: 'classifier-x', similarity: 0.82 },
+      payload: {
+        ruleId: 'auto-renew',
+        paragraphIndex: 3,
+        modelId: 'classifier-x',
+        similarity: 0.82,
+      },
       prevHash: '',
       entryHash: 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
     };
     render(
-      <FindingsPanel
-        findings={[hybrid]}
-        onSelect={() => {}}
-        auditEntries={[classifyEntry]}
-      />,
+      <FindingsPanel findings={[hybrid]} onSelect={() => {}} auditEntries={[classifyEntry]} />,
     );
     // Open the hybrid detail disclosure
-    const badge = await screen.findByRole('button', { name: /identified by on-device classifier/i });
+    const badge = await screen.findByRole('button', {
+      name: /identified by on-device pattern match/i,
+    });
     await userEvent.click(badge);
     // Should show first 8 chars of entryHash
     const dd = await screen.findByText('abcdef12');
     expect(dd).toBeInTheDocument();
-    expect(dd).toHaveAttribute('title', 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890');
+    expect(dd).toHaveAttribute(
+      'title',
+      'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+    );
   });
 
   it('does not render the audit-entry section when no matching entry exists', async () => {
@@ -105,13 +105,11 @@ describe('FindingsPanel — hybrid-feedback wiring (Wave 29-C)', () => {
       entryHash: 'deadbeef1234567890deadbeef1234567890deadbeef1234567890deadbeef12',
     };
     render(
-      <FindingsPanel
-        findings={[hybrid]}
-        onSelect={() => {}}
-        auditEntries={[unrelatedEntry]}
-      />,
+      <FindingsPanel findings={[hybrid]} onSelect={() => {}} auditEntries={[unrelatedEntry]} />,
     );
-    const badge = await screen.findByRole('button', { name: /identified by on-device classifier/i });
+    const badge = await screen.findByRole('button', {
+      name: /identified by on-device pattern match/i,
+    });
     await userEvent.click(badge);
     expect(screen.queryByText(/audit entry/i)).toBeNull();
   });

--- a/app/src/ui/FindingsPanel.test.tsx
+++ b/app/src/ui/FindingsPanel.test.tsx
@@ -79,7 +79,9 @@ describe('FindingsPanel', () => {
         onSelect={() => {}}
       />,
     );
-    const badge = screen.getByLabelText(/identified by on-device classifier \(similarity 83%\)/i);
+    const badge = screen.getByLabelText(
+      /identified by on-device pattern match \(similarity 83%\)/i,
+    );
     expect(badge).toBeInTheDocument();
   });
 
@@ -90,7 +92,9 @@ describe('FindingsPanel', () => {
         onSelect={() => {}}
       />,
     );
-    expect(screen.queryByLabelText(/identified by on-device classifier/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/identified by on-device pattern match/i),
+    ).not.toBeInTheDocument();
   });
 
   // Wave 25-B: clicking the hybrid badge expands an inline detail panel
@@ -112,7 +116,7 @@ describe('FindingsPanel', () => {
       />,
     );
     const badge = screen.getByRole('button', {
-      name: /identified by on-device classifier \(similarity 83%\)/i,
+      name: /identified by on-device pattern match \(similarity 83%\)/i,
     });
     expect(badge).toHaveAttribute('aria-expanded', 'false');
     expect(screen.queryByText('Xenova/paraphrase-MiniLM-L3-v2')).not.toBeInTheDocument();
@@ -140,7 +144,7 @@ describe('FindingsPanel', () => {
       />,
     );
     const badge = screen.getByRole('button', {
-      name: /identified by on-device classifier/i,
+      name: /identified by on-device pattern match/i,
     });
     await userEvent.click(badge);
     expect(badge).toHaveAttribute('aria-expanded', 'true');

--- a/app/src/ui/FindingsPanel.test.tsx
+++ b/app/src/ui/FindingsPanel.test.tsx
@@ -80,7 +80,7 @@ describe('FindingsPanel', () => {
       />,
     );
     const badge = screen.getByLabelText(
-      /identified by on-device pattern match \(similarity 83%\)/i,
+      /identified by on-device similarity match \(similarity 83%\)/i,
     );
     expect(badge).toBeInTheDocument();
   });
@@ -93,7 +93,7 @@ describe('FindingsPanel', () => {
       />,
     );
     expect(
-      screen.queryByLabelText(/identified by on-device pattern match/i),
+      screen.queryByLabelText(/identified by on-device similarity match/i),
     ).not.toBeInTheDocument();
   });
 
@@ -116,7 +116,7 @@ describe('FindingsPanel', () => {
       />,
     );
     const badge = screen.getByRole('button', {
-      name: /identified by on-device pattern match \(similarity 83%\)/i,
+      name: /identified by on-device similarity match \(similarity 83%\)/i,
     });
     expect(badge).toHaveAttribute('aria-expanded', 'false');
     expect(screen.queryByText('Xenova/paraphrase-MiniLM-L3-v2')).not.toBeInTheDocument();
@@ -144,7 +144,7 @@ describe('FindingsPanel', () => {
       />,
     );
     const badge = screen.getByRole('button', {
-      name: /identified by on-device pattern match/i,
+      name: /identified by on-device similarity match/i,
     });
     await userEvent.click(badge);
     expect(badge).toHaveAttribute('aria-expanded', 'true');

--- a/app/src/ui/FindingsPanel.tsx
+++ b/app/src/ui/FindingsPanel.tsx
@@ -27,7 +27,7 @@ const HybridFeedbackButton = lazy(() =>
 //   id="findings-${sev}" (h2)
 //   aria-expanded + aria-label="toggle ${sev}" (collapse button)
 //   data-finding-key (li and button — both)
-//   aria-expanded + aria-label="Identified by on-device pattern match..." (llm badge button)
+//   aria-expanded + aria-label="Identified by on-device similarity match..." (llm badge button)
 //   aria-expanded + aria-label="what this means for ${finding.title}" (explainer button)
 //   aria-label="apply suggestion for ${finding.title}" (button)
 //   aria-label="promote to standard ${finding.title}" (button)
@@ -463,7 +463,7 @@ function VirtualFindingItem(props: VirtualFindingItemProps): JSX.Element {
                   className="finding-llm-badge inline-flex items-center gap-1 text-small text-fg-muted border border-rule rounded-sm px-2 py-0.5 hover:bg-[var(--state-hover)] active:bg-[var(--state-active)] transition-colors focus-visible:focus-ring"
                   aria-expanded={isHybridDetailOpen}
                   aria-pressed={isHybridDetailOpen}
-                  aria-label={`Identified by on-device pattern match (similarity ${Math.round(
+                  aria-label={`Identified by on-device similarity match (similarity ${Math.round(
                     finding.evidence.similarity * 100,
                   )}%). Click to see details.`}
                   title={`On-device pattern match (similarity ${Math.round(
@@ -471,7 +471,7 @@ function VirtualFindingItem(props: VirtualFindingItemProps): JSX.Element {
                   )}%)`}
                   onClick={toggleHybridDetail}
                 >
-                  <span>On-device pattern match</span>
+                  <span>On-device similarity match</span>
                   {/* Wave 45-D — small (?) icon signals "click for more" at a
                       glance; aria-hidden because the visible label carries
                       the meaning. */}

--- a/app/src/ui/FindingsPanel.tsx
+++ b/app/src/ui/FindingsPanel.tsx
@@ -27,7 +27,7 @@ const HybridFeedbackButton = lazy(() =>
 //   id="findings-${sev}" (h2)
 //   aria-expanded + aria-label="toggle ${sev}" (collapse button)
 //   data-finding-key (li and button — both)
-//   aria-expanded + aria-label="Identified by on-device classifier..." (llm badge button)
+//   aria-expanded + aria-label="Identified by on-device pattern match..." (llm badge button)
 //   aria-expanded + aria-label="what this means for ${finding.title}" (explainer button)
 //   aria-label="apply suggestion for ${finding.title}" (button)
 //   aria-label="promote to standard ${finding.title}" (button)
@@ -463,15 +463,32 @@ function VirtualFindingItem(props: VirtualFindingItemProps): JSX.Element {
                   className="finding-llm-badge inline-flex items-center gap-1 text-small text-fg-muted border border-rule rounded-sm px-2 py-0.5 hover:bg-[var(--state-hover)] active:bg-[var(--state-active)] transition-colors focus-visible:focus-ring"
                   aria-expanded={isHybridDetailOpen}
                   aria-pressed={isHybridDetailOpen}
-                  aria-label={`Identified by on-device classifier (similarity ${Math.round(
+                  aria-label={`Identified by on-device pattern match (similarity ${Math.round(
                     finding.evidence.similarity * 100,
-                  )}%)`}
-                  title={`On-device classifier (similarity ${Math.round(
+                  )}%). Click to see details.`}
+                  title={`On-device pattern match (similarity ${Math.round(
                     finding.evidence.similarity * 100,
                   )}%)`}
                   onClick={toggleHybridDetail}
                 >
-                  ~
+                  <span>On-device pattern match</span>
+                  {/* Wave 45-D — small (?) icon signals "click for more" at a
+                      glance; aria-hidden because the visible label carries
+                      the meaning. */}
+                  <svg
+                    width={12}
+                    height={12}
+                    viewBox="0 0 12 12"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={1.25}
+                    aria-hidden="true"
+                    focusable={false}
+                  >
+                    <circle cx="6" cy="6" r="4.5" />
+                    <circle cx="6" cy="3.75" r="0.4" fill="currentColor" stroke="none" />
+                    <path d="M6 5.5v3" strokeLinecap="round" />
+                  </svg>
                 </button>
                 {onHybridFeedback && leaseId !== undefined ? (
                   <span className="ml-2 inline-flex">

--- a/app/src/ui/OnboardingTour.test.tsx
+++ b/app/src/ui/OnboardingTour.test.tsx
@@ -24,7 +24,10 @@ describe('OnboardingTour', () => {
     expect(screen.getByRole('heading', { name: /portfolio.*rollups/i })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /^next$/i }));
     expect(screen.getByText(/step 4 of 4/i)).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /audit log.*signed export/i })).toBeInTheDocument();
+    // Wave 45-D — heading rewritten from "Audit log + signed export" to
+    // "Audit log + export" (the body now describes what the panel actually
+    // offers without overpromising provenance).
+    expect(screen.getByRole('heading', { name: /audit log.*export/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /finish onboarding tour/i })).toBeInTheDocument();
   });
 

--- a/app/src/ui/OnboardingTour.tsx
+++ b/app/src/ui/OnboardingTour.tsx
@@ -48,11 +48,13 @@ const STEPS: readonly Step[] = [
     },
   },
   {
-    title: 'Audit log + signed export',
+    title: 'Audit log + export',
     body:
-      'Every significant action — analyze, export, pack import — appends to ' +
-      'a hash-chained audit log. Scroll to the Audit Log panel at the bottom ' +
-      'of the page to verify the chain or download a signed handoff bundle.',
+      'Most in-app actions append to a local, hash-chained audit log you can ' +
+      'verify and download. The export toolbar above the findings list lets you ' +
+      'save findings as JSON or HTML, and (if you have a signing key) as a ' +
+      'signed JSON file you can hand to a counterparty. See the Audit Log ' +
+      'panel at the bottom for the running record.',
   },
 ];
 

--- a/app/src/ui/PackManagerPanel.tsx
+++ b/app/src/ui/PackManagerPanel.tsx
@@ -167,7 +167,9 @@ export function PackManagerPanel({
       )}
       {error !== null && (
         <p role="status" className="text-small text-severity-high">
-          Error: {error}
+          Couldn&rsquo;t import the rule pack. {error}. Common causes: the file isn&rsquo;t a{' '}
+          <code className="font-mono text-mono">.lgpack.json</code>, or the signature didn&rsquo;t
+          verify.
         </p>
       )}
 

--- a/app/src/ui/SigningKeyPanel.tsx
+++ b/app/src/ui/SigningKeyPanel.tsx
@@ -52,10 +52,9 @@ export function SigningKeyPanel({
         <summary className="cursor-pointer select-none">Why does signing matter?</summary>
         <p className="mt-1 max-w-prose">
           A signed export carries a digital signature made with this local key. To use it as proof
-          of origin, share your public key with the recipient out-of-band (use{' '}
-          <em>Export public key</em> below). They compare your public key against the key embedded
-          in the signed export. Without that comparison step, the file only verifies against its own
-          embedded key, which an attacker could replace.
+          of origin, share your public key with the recipient out-of-band; they compare it against
+          the key embedded in the signed export. Without that comparison step, the file only
+          verifies against its own embedded key, which an attacker could replace.
         </p>
       </details>
       {hasKey ? (

--- a/app/src/ui/SigningKeyPanel.tsx
+++ b/app/src/ui/SigningKeyPanel.tsx
@@ -48,10 +48,22 @@ export function SigningKeyPanel({
   return (
     <Section label="signing key" className="space-y-3 px-4 py-4">
       <h2 className="text-heading uppercase text-fg-muted">Signing key</h2>
+      <details className="text-small text-fg-muted">
+        <summary className="cursor-pointer select-none">Why does signing matter?</summary>
+        <p className="mt-1 max-w-prose">
+          A signed export pairs your findings with a signature derived from a key only you control.
+          Anyone you share the file with can verify it came from you and has not been altered. The
+          key never leaves your browser.
+        </p>
+      </details>
       {hasKey ? (
         <p className="text-body text-fg-body">
-          <span aria-label="public key" className="text-small text-fg-muted">Key: </span>
-          <code className="font-mono text-mono text-fg-muted">{truncate(state.publicKey ?? '')}</code>
+          <span aria-label="public key" className="text-small text-fg-muted">
+            Key:{' '}
+          </span>
+          <code className="font-mono text-mono text-fg-muted">
+            {truncate(state.publicKey ?? '')}
+          </code>
         </p>
       ) : (
         <p className="text-body text-fg-muted">No signing key.</p>
@@ -86,9 +98,7 @@ export function SigningKeyPanel({
             variant="ghost"
             size="sm"
             onClick={() => {
-              const pp = window.prompt(
-                'Set a passphrase for the new (rotated) signing key:',
-              );
+              const pp = window.prompt('Set a passphrase for the new (rotated) signing key:');
               if (!pp) return;
               void onRotateKey(pp);
             }}

--- a/app/src/ui/SigningKeyPanel.tsx
+++ b/app/src/ui/SigningKeyPanel.tsx
@@ -51,11 +51,11 @@ export function SigningKeyPanel({
       <details className="text-small text-fg-muted">
         <summary className="cursor-pointer select-none">Why does signing matter?</summary>
         <p className="mt-1 max-w-prose">
-          A signed export carries a digital signature made with this local key. To verify the file
-          came from you and hasn&rsquo;t been altered since, share your public-key fingerprint with
-          the recipient out-of-band (text, email, in person). They can then confirm the embedded key
-          matches yours and the signature is valid. Without a shared fingerprint, the file only
-          verifies against the key embedded inside it, which an attacker could replace.
+          A signed export carries a digital signature made with this local key. To use it as proof
+          of origin, share your public key with the recipient out-of-band (use{' '}
+          <em>Export public key</em> below). They compare your public key against the key embedded
+          in the signed export. Without that comparison step, the file only verifies against its own
+          embedded key, which an attacker could replace.
         </p>
       </details>
       {hasKey ? (

--- a/app/src/ui/SigningKeyPanel.tsx
+++ b/app/src/ui/SigningKeyPanel.tsx
@@ -51,10 +51,11 @@ export function SigningKeyPanel({
       <details className="text-small text-fg-muted">
         <summary className="cursor-pointer select-none">Why does signing matter?</summary>
         <p className="mt-1 max-w-prose">
-          A signed export pairs your findings with a digital signature so anyone can verify the file
-          hasn&rsquo;t been altered since you exported it. The signing key stays in your browser.
-          Note: the signature proves integrity, not author identity; binding a key to a person
-          (sharing a fingerprint out-of-band, etc.) is up to you and your counterparty.
+          A signed export carries a digital signature made with this local key. To verify the file
+          came from you and hasn&rsquo;t been altered since, share your public-key fingerprint with
+          the recipient out-of-band (text, email, in person). They can then confirm the embedded key
+          matches yours and the signature is valid. Without a shared fingerprint, the file only
+          verifies against the key embedded inside it, which an attacker could replace.
         </p>
       </details>
       {hasKey ? (

--- a/app/src/ui/SigningKeyPanel.tsx
+++ b/app/src/ui/SigningKeyPanel.tsx
@@ -51,9 +51,10 @@ export function SigningKeyPanel({
       <details className="text-small text-fg-muted">
         <summary className="cursor-pointer select-none">Why does signing matter?</summary>
         <p className="mt-1 max-w-prose">
-          A signed export pairs your findings with a signature derived from a key only you control.
-          Anyone you share the file with can verify it came from you and has not been altered. The
-          key never leaves your browser.
+          A signed export pairs your findings with a digital signature so anyone can verify the file
+          hasn&rsquo;t been altered since you exported it. The signing key stays in your browser.
+          Note: the signature proves integrity, not author identity; binding a key to a person
+          (sharing a fingerprint out-of-band, etc.) is up to you and your counterparty.
         </p>
       </details>
       {hasKey ? (

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -591,6 +591,22 @@ blob:` envelope. Done = `scripts/check-csp.mjs` stays green
 
 ### Wave 45-D follow-ups
 
+- [ ] **Audit signed-export events.** `useAppCallbacks.onExportSignedJson`
+      signs and downloads a payload but emits no `safeAudit` entry, so
+      the audit log records only unsigned exports. Add a
+      `kind: 'signed-export'` audit event (file name, format, input hash,
+      signing-key id) and refresh the panel after success. Codex flagged
+      the resulting prose mismatch in the wave's 4th adversarial pass
+      (run `20260429T135619Z`); 45-D's preamble copy was weakened to
+      describe only what the code actually records, but the durable fix
+      is to record the signed-export event.
+- [ ] **Surface success/failure for `Export public key`.** The button
+      attempts a clipboard write that may silently fail (denied
+      permission, no clipboard API). Users following the signed-export
+      verification copy could believe the key was shared when it
+      wasn't. Return an explicit status from `onExportPublicKey`, render
+      a `role="status"` confirmation, and add a clipboard-denied test.
+      Same Codex pass.
 - [ ] **Public-key fingerprint affordance in `SigningKeyPanel`.** Wave
       45-D's signed-export disclosures point users at the existing
       `Export public key` button as the out-of-band verification step,

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -589,6 +589,31 @@ score: number }` field that the LLM path populates. The audit
 blob:` envelope. Done = `scripts/check-csp.mjs` stays green
       and the dist build serves the model from same-origin.
 
+### Wave 45-D follow-ups
+
+- [ ] **Public-key fingerprint affordance in `SigningKeyPanel`.** Wave
+      45-D's signed-export disclosures point users at the existing
+      `Export public key` button as the out-of-band verification step,
+      since the UI does not yet expose a shorter SHA-256 fingerprint
+      that would be more practical to compare. Adding a fingerprint
+      row (4-byte SHA-256 of the raw public key bytes, displayed in
+      hex) plus a copy-to-clipboard affordance would make the
+      verification workflow easier for non-technical recipients. Once
+      shipped, refresh the disclosure copy to reference fingerprint
+      compare instead of full public-key compare. Codex flagged the
+      mismatch in the wave's 3rd adversarial pass (run
+      `20260429T135226Z`). See also: the unused `keys?` /
+      `KeyHistoryEntry.fingerprint` plumbing already in
+      `SigningKeyPanel.tsx` — the panel can render fingerprints when a
+      caller wires them in.
+- [ ] **Audit-log `entryHash` column in `AuditLogPanel`.** Wave 45-D's
+      first-pass preamble told users to "spot-check the first 8
+      characters of the digest" — but the panel's table never renders
+      `entryHash`. The instruction was removed in pass 2; surfacing
+      the digest as a real column (full value plus a copy affordance)
+      would make the consistency-check workflow actionable for
+      practitioners.
+
 ### Wave 45-F follow-ups
 
 - [ ] **Dialog focus containment for direct `.focus()` calls.** Wave 45-F


### PR DESCRIPTION
## Summary

Wave 45-D — closes the renter-jargon gap surfaced by \`/impeccable critique\` (Anita persona red flags) and \`/impeccable audit\` (P3 + persona blockers). Five content sites; tone is "clear, calm, informative" per PRODUCT.md, plain-with-brief-technical (NYT-explainer voice).

**Ten commits** (4 wave items + 6 codex iteration fixes). The copy-side scope ratchet was tighter than usual; see the Codex-iteration retro below.

### Items shipped

- **A. \`FindingsPanel\` ~ glyph** → \`On-device similarity match\` text label + 12px aria-hidden info SVG. The badge stays a click-to-explain disclosure trigger; only the visible affordance changes. \`title\` updated to "cosine similarity X%" so the wording matches the actual ML primitive (after Codex flagged that "pattern match" implied deterministic regex; the underlying path is \`runClassifierPass\` over MiniLM embeddings).
- **B. \`AuditLogPanel\` preamble** → describes the chain accurately: a SHA-256 hash chain in IndexedDB, "internally consistent / catches stray edits, not a cryptographic proof against an attacker with full storage access." Explicitly notes "signed-export events are not currently written to this log; only unsigned exports are" so the table's apparent coverage isn't misleading.
- **C. Signed-export \`<details>\`** on \`AppCurrentPane\` and \`SigningKeyPanel\` → integrity-only language. "The file carries a digital signature made with your local key. To use it as proof of origin, share your public key with the recipient out-of-band; they compare it against the key embedded in the signed export. Without that comparison step, the file only verifies against its own embedded key, which an attacker could replace." (After multiple Codex passes ratcheted the original "anyone can verify it came from you" overclaim down to what the code actually proves.)
- **D. Three error-copy rewrites** (OCR failure, audit chain-broken, pack import error) — terse fragments → plain language with a "what to try" line.
- **E. \`OnboardingTour\` step 4** → drops "signed handoff bundle" reference (the audit-log download is unsigned today); describes the export toolbar and audit panel as they actually exist.

### Codex iteration retrospective

Five adversarial passes. Each found real, increasingly subtle copy/code-correctness issues. The wave's scope is "clarify," not "harden the export pipeline" — so the durable fixes for the last two recurring HIGH findings live in BACKLOG rather than this PR.

| Pass | Findings | Action |
|---|---|---|
| 1 (run 20260429T134216Z) | 1 high (signed-export overclaims provenance), 2 medium (chain-broken false claim, hybrid badge mislabeled "pattern match") | Fixed in commit 4792099 |
| 2 (run 20260429T134719Z) | 1 high (audit "tamper-evidence" overclaims; it's only a local consistency check), 1 medium (preamble points at digests the panel never renders), 1 high (signed-export still implies key-pinning) | Fixed in commit c2f91b5 |
| 3 (run 20260429T135226Z) | 1 high (signed-export copy promises a "fingerprint" workflow the panel doesn't expose) | Fixed in commit 5efc192. \`SigningKeyPanel\` already has \`KeyHistoryEntry.fingerprint\` plumbing but doesn't render it; logged as a Wave 45-D follow-up. |
| 4 (run 20260429T135619Z) | 1 high (signed-export references \`Export public key\` button that can fail silently via clipboard), 1 high (preamble says log records "exports" but signed exports aren't audited) | Fixed in commit 4a3ce1d. Code defects logged in BACKLOG. |
| 5 (run 20260429T140640Z) | **Same** high findings as pass 4 (signed exports bypass audit, public-key sharing fails silently) plus 1 medium new (\`OnboardingTour\` step 4 still teaches signed-handoff-bundle). Onboarding fix in commit d66fb81. The two recurring highs are code defects (already in BACKLOG \`Wave 45-D follow-ups\`); **shipped with TODO** per gate rules. |

Escalation logged at \`.codex-runs/escalations.jsonl\` (\`shipped-despite\` / \`shipped-with-todo\`).

## BACKLOG follow-ups added (code, not copy)

- **Audit signed-export events.** \`useAppCallbacks.onExportSignedJson\` should emit a \`kind: 'signed-export'\` audit entry.
- **Surface success/failure for \`Export public key\`.** Current clipboard write can fail silently; needs explicit status.
- **Public-key fingerprint affordance in \`SigningKeyPanel\`.** \`KeyHistoryEntry.fingerprint\` plumbing exists but the active key's fingerprint is never rendered — would let the signed-export copy reference fingerprint compare instead of full key compare.
- **\`entryHash\` column in \`AuditLogPanel\`.** Today's table omits the digest; pass-1 preamble told users to "spot-check" digests they couldn't see (instruction removed in pass 2).

## Verification

- [x] \`git grep -nE '>~<|"~"' app/src/ui/FindingsPanel.tsx\` — 0 hits
- [x] \`git grep -n "What is signed export" app/src/ui\` — 1 hit
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test:coverage\` — **1546 pass | 1 todo (1547)**, 185 files
- [x] \`npx playwright test tests/e2e/a11y.spec.ts --project=chromium\` — pass

## Out of scope (Wave 45 program continues)

- 45-B renter-IA distill of \`AppCurrentPane\` — separate plan
- 45-C \`ComparePanel\` rewrite — separate plan
- 45-E severity-vs-negative + Field error API + AppRedlinePane + AppHeader file-input — separate plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)