### PR TITLE
wave(46): program closeout — signed-export audit + clipboard status + Dialog inert + fingerprint affordance

### DIFF
--- a/app/src/App/useAppCallbacks.test.ts
+++ b/app/src/App/useAppCallbacks.test.ts
@@ -30,7 +30,11 @@ function fakeSigningKey(overrides: Partial<Record<string, unknown>> = {}) {
     publicKey: null,
     createKey: vi.fn(),
     exportKeyToClipboard: vi.fn(),
-    signAndDownloadFindings: vi.fn(async () => undefined),
+    signAndDownloadFindings: vi.fn(async () => ({
+      fileName: 'L-findings.signed.json',
+      inputHash: null,
+      signingKeyId: null,
+    })),
     ...overrides,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
@@ -230,6 +234,120 @@ describe('useAppCallbacks', () => {
     expect(deps.pipeline.setError).toHaveBeenCalledWith(
       expect.stringMatching(/Signing failed: decrypt failed/),
     );
+    promptSpy.mockRestore();
+  });
+
+  it('onExportSignedJson emits a safeAudit signed-export event with file/hash/keyId after a successful sign', async () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('passphrase');
+    const signingKey = fakeSigningKey({
+      signAndDownloadFindings: vi.fn(async () => ({
+        fileName: 'Lease-findings.signed.json',
+        inputHash: 'deadbeef',
+        signingKeyId: 'cafef00d',
+      })),
+    });
+    const deps = makeDeps({
+      pipeline: fakePipeline({
+        status: {
+          kind: 'analyzed',
+          fileName: 'Lease.pdf',
+          result: {
+            doc: { pages: [], paragraphs: [], sections: [], raw: '' },
+            findings: [],
+          },
+          bytes: new Uint8Array([1, 2, 3]),
+        },
+      }),
+      signingKey,
+    });
+    const { result } = renderHook(() => useAppCallbacks(deps));
+    await act(async () => {
+      await result.current.onExportSignedJson();
+    });
+    expect(deps.safeAudit).toHaveBeenCalledWith({
+      kind: 'signed-export',
+      payload: {
+        fileName: 'Lease-findings.signed.json',
+        format: 'json',
+        inputHash: 'deadbeef',
+        signingKeyId: 'cafef00d',
+      },
+    });
+    expect(deps.refreshAuditLog).toHaveBeenCalled();
+    promptSpy.mockRestore();
+  });
+
+  it('onExportSignedJson signed-export audit payload carries null inputHash + signingKeyId when unknown', async () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('passphrase');
+    const signingKey = fakeSigningKey({
+      signAndDownloadFindings: vi.fn(async () => ({
+        fileName: 'L-findings.signed.json',
+        inputHash: null,
+        signingKeyId: null,
+      })),
+    });
+    const deps = makeDeps({
+      pipeline: fakePipeline({
+        status: {
+          kind: 'analyzed',
+          fileName: 'L.pdf',
+          result: {
+            doc: { pages: [], paragraphs: [], sections: [], raw: '' },
+            findings: [],
+          },
+          bytes: null,
+        },
+      }),
+      signingKey,
+    });
+    const { result } = renderHook(() => useAppCallbacks(deps));
+    await act(async () => {
+      await result.current.onExportSignedJson();
+    });
+    const call = deps.safeAudit.mock.calls.find(
+      (c: unknown[]) => (c[0] as { kind?: string }).kind === 'signed-export',
+    );
+    expect(call?.[0]).toEqual({
+      kind: 'signed-export',
+      payload: {
+        fileName: 'L-findings.signed.json',
+        format: 'json',
+        inputHash: null,
+        signingKeyId: null,
+      },
+    });
+    promptSpy.mockRestore();
+  });
+
+  it('onExportSignedJson does not emit an audit event when signing throws', async () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('passphrase');
+    const signingKey = fakeSigningKey({
+      signAndDownloadFindings: vi.fn(async () => {
+        throw new Error('decrypt failed');
+      }),
+    });
+    const deps = makeDeps({
+      pipeline: fakePipeline({
+        status: {
+          kind: 'analyzed',
+          fileName: 'L.pdf',
+          result: {
+            doc: { pages: [], paragraphs: [], sections: [], raw: '' },
+            findings: [],
+          },
+          bytes: null,
+        },
+      }),
+      signingKey,
+    });
+    const { result } = renderHook(() => useAppCallbacks(deps));
+    await act(async () => {
+      await result.current.onExportSignedJson();
+    });
+    const audited = deps.safeAudit.mock.calls.some(
+      (c: unknown[]) => (c[0] as { kind?: string }).kind === 'signed-export',
+    );
+    expect(audited).toBe(false);
     promptSpy.mockRestore();
   });
 

--- a/app/src/App/useAppCallbacks.ts
+++ b/app/src/App/useAppCallbacks.ts
@@ -118,17 +118,27 @@ export function useAppCallbacks(deps: UseAppCallbacksDeps): UseAppCallbacksApi {
     const passphrase = window.prompt('Passphrase to unlock the signing key:');
     if (!passphrase) return;
     try {
-      await signingKey.signAndDownloadFindings({
+      const result = await signingKey.signAndDownloadFindings({
         fileName: status.fileName,
         doc: status.result.doc,
         findings: status.result.findings,
         bytes: status.bytes,
         passphrase,
       });
+      await safeAudit({
+        kind: 'signed-export',
+        payload: {
+          fileName: result.fileName,
+          format: 'json',
+          inputHash: result.inputHash,
+          signingKeyId: result.signingKeyId,
+        },
+      });
+      void refreshAuditLog();
     } catch (err) {
       pipeline.setError(`Signing failed: ${friendlyError(err)}`);
     }
-  }, [pipeline, signingKey]);
+  }, [pipeline, signingKey, safeAudit, refreshAuditLog]);
 
   return {
     handleBytes,

--- a/app/src/App/useSigningKey.test.ts
+++ b/app/src/App/useSigningKey.test.ts
@@ -1,7 +1,41 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { useSigningKey } from './useSigningKey';
 import { _resetSigningDbForTests } from '../security/signingKeys';
+
+// Swallow benign IDB teardown rejections (InvalidStateError / code 11)
+// that fire when a fire-and-forget refresh resolves after the next
+// test's beforeEach nulls the cached db promise. Mirrors the guard in
+// App.test.tsx.
+function isBenignIdbTeardownError(err: unknown): boolean {
+  const e = err as { name?: string; code?: number } | null;
+  if (!e) return false;
+  if (e.name === 'InvalidStateError') return true;
+  if (e.code === 11) return true;
+  return false;
+}
+interface NodeProcessLike {
+  on(event: 'unhandledRejection', fn: (err: unknown) => void): void;
+  off(event: 'unhandledRejection', fn: (err: unknown) => void): void;
+}
+const proc = (globalThis as unknown as { process?: NodeProcessLike }).process;
+const onUnhandled = (err: unknown): void => {
+  if (!isBenignIdbTeardownError(err)) throw err as Error;
+};
+beforeAll(() => {
+  proc?.on('unhandledRejection', onUnhandled);
+});
+afterAll(() => {
+  proc?.off('unhandledRejection', onUnhandled);
+});
+
+afterEach(async () => {
+  cleanup();
+  // Drain any in-flight `refresh` IDB reads from the just-unmounted hook
+  // before the next test's `beforeEach` nulls the cached db promise.
+  await new Promise<void>((r) => setTimeout(r, 0));
+  await new Promise<void>((r) => setTimeout(r, 0));
+});
 
 beforeEach(async () => {
   _resetSigningDbForTests();
@@ -27,14 +61,37 @@ describe('useSigningKey', () => {
     expect(result.current.publicKey).not.toBe('');
   });
 
-  it('exportKeyToClipboard swallows clipboard failures', async () => {
+  it('exportKeyToClipboard returns { status: "copied" } on success', async () => {
+    const { result } = renderHook(() => useSigningKey());
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    await expect(result.current.exportKeyToClipboard('pkbase64')).resolves.toEqual({
+      status: 'copied',
+    });
+    expect(writeText).toHaveBeenCalledWith('pkbase64');
+  });
+
+  it('exportKeyToClipboard returns { status: "denied", reason } when writeText rejects', async () => {
     const { result } = renderHook(() => useSigningKey());
     const writeText = vi.fn().mockRejectedValue(new Error('blocked'));
     Object.defineProperty(globalThis.navigator, 'clipboard', {
       configurable: true,
       value: { writeText },
     });
-    await expect(result.current.exportKeyToClipboard('pkbase64')).resolves.toBeUndefined();
-    expect(writeText).toHaveBeenCalledWith('pkbase64');
+    const out = await result.current.exportKeyToClipboard('pkbase64');
+    expect(out).toEqual({ status: 'denied', reason: 'blocked' });
+  });
+
+  it('exportKeyToClipboard returns { status: "denied" } when the clipboard API is missing', async () => {
+    const { result } = renderHook(() => useSigningKey());
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+    const out = await result.current.exportKeyToClipboard('pkbase64');
+    expect(out.status).toBe('denied');
   });
 });

--- a/app/src/App/useSigningKey.ts
+++ b/app/src/App/useSigningKey.ts
@@ -2,9 +2,19 @@ import { useCallback, useEffect, useState } from 'react';
 import { createSigningKey, exportPublicKey } from '../security/signingKeys';
 import { signExport, exportFindingsJson } from '../storage/exportReport';
 import { sha256Hex } from '../security/inputHash';
+import { computeShortFingerprintFromBase64 } from '../security/fingerprint';
 import type { LeaseDocument } from '../parser/types';
 import type { Finding } from '../rules/types';
 import { downloadBlob, stripPdfExt } from './appHelpers';
+
+/**
+ * Discriminated status returned by `exportKeyToClipboard`. `copied` on
+ * success; `denied` when the API is missing (insecure context) or the
+ * platform rejected the write (permission, focus). `reason` is the bare
+ * `Error.message` from the rejection, or a synthetic message when the API
+ * is unavailable.
+ */
+export type ClipboardWriteStatus = { status: 'copied' } | { status: 'denied'; reason: string };
 
 export interface UseSigningKeyApi {
   /** Base64 public key, or null if no key has been generated yet. */
@@ -13,10 +23,10 @@ export interface UseSigningKeyApi {
   createKey: (passphrase: string) => Promise<void>;
   /**
    * Best-effort copy of the base64 public key to the clipboard. CSP / focus
-   * policies may block; failure is intentionally silent (UI fallback shows
-   * the key inline anyway).
+   * policies may block; on failure we surface the reason so callers can render
+   * a visible status. The UI fallback (the key shown inline) is unchanged.
    */
-  exportKeyToClipboard: (publicKey: string) => Promise<void>;
+  exportKeyToClipboard: (publicKey: string) => Promise<ClipboardWriteStatus>;
   /**
    * Sign + download a findings JSON. Throws on bad passphrase or signing
    * failure so callers can surface the message via their error channel.
@@ -27,7 +37,17 @@ export interface UseSigningKeyApi {
     findings: Finding[];
     bytes: Uint8Array | null;
     passphrase: string;
-  }) => Promise<void>;
+  }) => Promise<{
+    fileName: string;
+    /** SHA-256 hex of the original PDF bytes, or null when bytes are absent. */
+    inputHash: string | null;
+    /**
+     * Short fingerprint (8 hex chars, SHA-256(rawPublicKey)[0:4]) of the
+     * Ed25519 public key used to sign. Null when the public key cannot be
+     * resolved at sign time. Honest-not-coerced.
+     */
+    signingKeyId: string | null;
+  }>;
   /** Re-read the public key from storage (used after rotation). */
   refresh: () => Promise<void>;
 }
@@ -51,29 +71,48 @@ export function useSigningKey(): UseSigningKeyApi {
     [refresh],
   );
 
-  const exportKeyToClipboard = useCallback(async (pk: string): Promise<void> => {
+  const exportKeyToClipboard = useCallback(async (pk: string): Promise<ClipboardWriteStatus> => {
+    const nav = globalThis.navigator as
+      | { clipboard?: { writeText?: (s: string) => Promise<void> } }
+      | undefined;
+    const writeText = nav?.clipboard?.writeText;
+    if (typeof writeText !== 'function') {
+      return {
+        status: 'denied',
+        reason: 'Clipboard API unavailable in this context.',
+      };
+    }
     try {
-      const nav = globalThis.navigator as
-        | { clipboard?: { writeText?: (s: string) => Promise<void> } }
-        | undefined;
-      await nav?.clipboard?.writeText?.(pk);
-    } catch {
-      // swallow — exporting is best-effort
+      await writeText.call(nav!.clipboard, pk);
+      return { status: 'copied' };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return { status: 'denied', reason };
     }
   }, []);
 
-  const signAndDownloadFindings = useCallback<
-    UseSigningKeyApi['signAndDownloadFindings']
-  >(async ({ fileName, doc, findings, bytes, passphrase }) => {
-    const inputHash = bytes ? await sha256Hex(bytes) : null;
-    const unsigned = exportFindingsJson({ name: fileName, doc, findings, inputHash });
-    const signed = await signExport(unsigned, passphrase);
-    downloadBlob(
-      signed,
-      'application/json',
-      `${stripPdfExt(fileName)}-findings.signed.json`,
-    );
-  }, []);
+  const signAndDownloadFindings = useCallback<UseSigningKeyApi['signAndDownloadFindings']>(
+    async ({ fileName, doc, findings, bytes, passphrase }) => {
+      const inputHash = bytes ? await sha256Hex(bytes) : null;
+      const unsigned = exportFindingsJson({ name: fileName, doc, findings, inputHash });
+      const signed = await signExport(unsigned, passphrase);
+      // Resolve the signing key fingerprint from the public key on file. If the
+      // public key cannot be resolved, surface null rather than coercing.
+      let signingKeyId: string | null = null;
+      const pk = await exportPublicKey();
+      if (pk) {
+        try {
+          signingKeyId = await computeShortFingerprintFromBase64(pk);
+        } catch {
+          signingKeyId = null;
+        }
+      }
+      const downloadName = `${stripPdfExt(fileName)}-findings.signed.json`;
+      downloadBlob(signed, 'application/json', downloadName);
+      return { fileName: downloadName, inputHash, signingKeyId };
+    },
+    [],
+  );
 
   useEffect(() => {
     void refresh();

--- a/app/src/security/fingerprint.test.ts
+++ b/app/src/security/fingerprint.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { computeShortFingerprint, computeShortFingerprintFromBase64 } from './fingerprint';
+
+describe('computeShortFingerprint', () => {
+  it('returns the first 4 bytes of SHA-256 as 8 lowercase hex chars', async () => {
+    // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    // First 4 bytes -> "e3b0c442"
+    const fp = await computeShortFingerprint(new Uint8Array(0));
+    expect(fp).toBe('e3b0c442');
+  });
+
+  it('returns 8 hex chars for any input', async () => {
+    const fp = await computeShortFingerprint(new Uint8Array([1, 2, 3, 4, 5]));
+    expect(fp).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('is deterministic for identical inputs', async () => {
+    const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    const a = await computeShortFingerprint(bytes);
+    const b = await computeShortFingerprint(bytes);
+    expect(a).toBe(b);
+  });
+
+  it('changes when any byte of the input changes', async () => {
+    const a = await computeShortFingerprint(new Uint8Array([1, 2, 3]));
+    const b = await computeShortFingerprint(new Uint8Array([1, 2, 4]));
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('computeShortFingerprintFromBase64', () => {
+  it('matches the raw-bytes fingerprint of the decoded value', async () => {
+    const raw = new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f]); // "hello"
+    const b64 = btoa('hello');
+    const expected = await computeShortFingerprint(raw);
+    expect(await computeShortFingerprintFromBase64(b64)).toBe(expected);
+  });
+});

--- a/app/src/security/fingerprint.ts
+++ b/app/src/security/fingerprint.ts
@@ -1,0 +1,42 @@
+/**
+ * Wave 46 Item C — short SHA-256 fingerprint of a raw Ed25519 public key.
+ *
+ * Returns the first 4 bytes of `SHA-256(rawPublicKeyBytes)` as 8 lowercase
+ * hex characters. Short enough to read aloud over the phone, long enough that
+ * a random collision is roughly 1 in 4 billion.
+ *
+ * This fingerprint is *informational*: a match between two fingerprints is
+ * evidence the underlying public-key bytes match, not proof of the key
+ * holder's identity. It is used as an out-of-band comparison artifact for
+ * signed-export verification.
+ */
+export async function computeShortFingerprint(rawPublicKeyBytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', rawPublicKeyBytes as BufferSource);
+  const view = new Uint8Array(digest).slice(0, 4);
+  let out = '';
+  for (let i = 0; i < view.length; i++) {
+    const b = view[i] ?? 0;
+    out += b.toString(16).padStart(2, '0');
+  }
+  return out;
+}
+
+/**
+ * Convenience wrapper that decodes a base64 public key (the format
+ * `signingKeys.exportPublicKey` returns) before fingerprinting.
+ */
+export async function computeShortFingerprintFromBase64(
+  publicKeyB64: string,
+): Promise<string | null> {
+  let bin: string;
+  try {
+    bin = atob(publicKeyB64);
+  } catch {
+    return null;
+  }
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) {
+    bytes[i] = bin.charCodeAt(i);
+  }
+  return computeShortFingerprint(bytes);
+}

--- a/app/src/ui/AppCurrentPane/ResultsHeader.test.tsx
+++ b/app/src/ui/AppCurrentPane/ResultsHeader.test.tsx
@@ -48,11 +48,19 @@ describe('ResultsHeader', () => {
       </I18nProvider>,
     );
     expect(screen.getByText(/what is signed export/i)).toBeInTheDocument();
-    // Wave 45-D copy verbatim — claim must map to code (Ed25519 sign over
-    // payload, recipient must compare embedded pubkey out-of-band).
+    // Wave 46 Item C — copy now references the 8-character fingerprint
+    // surfaced in SigningKeyPanel. Every claim maps to code:
+    //   - "8-character fingerprint" → computeShortFingerprint returns 8 hex
+    //   - "next to your signing key (Settings, Signing key)" → SigningKeyPanel row
+    //   - "embedded in the signed export" → exportReport.ts SignatureBlock.publicKey
+    //   - "computes the same SHA-256 fingerprint" → algorithm is deterministic
     expect(
-      screen.getByText(/share your public key with the recipient out-of-band/i),
+      screen.getByText(/8-character fingerprint shown next to your signing key/i),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(/computes the same sha-256 fingerprint over the public key embedded/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/does not by itself prove identity/i)).toBeInTheDocument();
   });
 
   it('fires onExportJson when the JSON-export button is clicked', async () => {

--- a/app/src/ui/AppCurrentPane/ResultsHeader.tsx
+++ b/app/src/ui/AppCurrentPane/ResultsHeader.tsx
@@ -39,10 +39,12 @@ export function ResultsHeader({
         <details className="text-small text-fg-muted mb-3">
           <summary className="cursor-pointer select-none">What is signed export?</summary>
           <p className="mt-1 max-w-prose">
-            The exported file carries a digital signature made with your local key. To use it as
-            proof of origin, share your public key with the recipient out-of-band; they compare it
-            against the key embedded in the signed export. Without that comparison step, the file
-            only verifies against its own embedded key, which an attacker could replace.
+            The exported file carries a digital signature made with your local key. Share the
+            8-character fingerprint shown next to your signing key (Settings, Signing key) with the
+            recipient out-of-band: phone, encrypted message, or paper. The recipient computes the
+            same SHA-256 fingerprint over the public key embedded in the signed export and checks
+            the match. A match is evidence the embedded key was not substituted. It does not by
+            itself prove identity.
           </p>
         </details>
       )}

--- a/app/src/ui/AppLibraryAndPacksPane.tsx
+++ b/app/src/ui/AppLibraryAndPacksPane.tsx
@@ -246,7 +246,7 @@ export function AppLibraryAndPacksPane({
           <SigningKeyPanel
             state={{ publicKey: signingKey.publicKey }}
             onCreateKey={(pp) => void signingKey.createKey(pp)}
-            onExportPublicKey={(pk) => void signingKey.exportKeyToClipboard(pk)}
+            onExportPublicKey={(pk) => signingKey.exportKeyToClipboard(pk)}
           />
         </div>
       </SectionGroup>

--- a/app/src/ui/SigningKeyPanel.test.tsx
+++ b/app/src/ui/SigningKeyPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SigningKeyPanel } from './SigningKeyPanel';
 
@@ -12,11 +12,7 @@ afterEach(() => {
 describe('SigningKeyPanel', () => {
   it('shows "No signing key" and a Create button when state.publicKey is null', () => {
     render(
-      <SigningKeyPanel
-        state={{ publicKey: null }}
-        onCreateKey={noop}
-        onExportPublicKey={noop}
-      />,
+      <SigningKeyPanel state={{ publicKey: null }} onCreateKey={noop} onExportPublicKey={noop} />,
     );
     expect(screen.getByText(/no signing key/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /create key/i })).toBeInTheDocument();
@@ -31,7 +27,7 @@ describe('SigningKeyPanel', () => {
         onExportPublicKey={noop}
       />,
     );
-    expect(screen.getByLabelText(/public key/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^public key$/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /export public key/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /create key/i })).not.toBeInTheDocument();
   });
@@ -103,9 +99,91 @@ describe('SigningKeyPanel', () => {
         onExportPublicKey={noop}
       />,
     );
+    // First code element is the truncated public key.
     const code = container.querySelector('code');
     expect(code).toBeTruthy();
-    // Truncated rendering should be shorter than the full key.
     expect(code?.textContent?.length ?? 0).toBeLessThan(longKey.length);
+  });
+
+  it('renders the public-key fingerprint as 8 hex chars', async () => {
+    render(
+      <SigningKeyPanel
+        state={{ publicKey: btoa('hello') }}
+        onCreateKey={noop}
+        onExportPublicKey={noop}
+      />,
+    );
+    const fp = await screen.findByLabelText(/public key fingerprint/i);
+    await waitFor(() => {
+      expect(fp.textContent).toMatch(/^[0-9a-f]{8}$/);
+    });
+  });
+
+  it('shows a transient success status when Export public key copies', async () => {
+    const onExport = vi.fn(async () => ({ status: 'copied' as const }));
+    render(
+      <SigningKeyPanel
+        state={{ publicKey: btoa('hello') }}
+        onCreateKey={noop}
+        onExportPublicKey={onExport}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /export public key/i }));
+    expect(onExport).toHaveBeenCalled();
+    expect(await screen.findByRole('status')).toHaveTextContent(/public key copied to clipboard/i);
+  });
+
+  it('shows a persistent failure status with a Copy failed badge when Export is denied', async () => {
+    const onExport = vi.fn(async () => ({
+      status: 'denied' as const,
+      reason: 'NotAllowedError',
+    }));
+    render(
+      <SigningKeyPanel
+        state={{ publicKey: btoa('hello') }}
+        onCreateKey={noop}
+        onExportPublicKey={onExport}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /export public key/i }));
+    const status = await screen.findByRole('status');
+    expect(status).toHaveTextContent(/could not copy: notallowederror/i);
+    expect(status).toHaveTextContent(/copy failed/i);
+  });
+
+  it('Copy fingerprint surfaces success status via the same role=status pattern', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    render(
+      <SigningKeyPanel
+        state={{ publicKey: btoa('hello') }}
+        onCreateKey={noop}
+        onExportPublicKey={noop}
+      />,
+    );
+    await screen.findByLabelText(/public key fingerprint/i);
+    await userEvent.click(screen.getByRole('button', { name: /copy fingerprint/i }));
+    expect(writeText).toHaveBeenCalled();
+    expect(await screen.findByRole('status')).toHaveTextContent(/fingerprint copied to clipboard/i);
+  });
+
+  it('Copy fingerprint surfaces a denied status when the clipboard API is missing', async () => {
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+    render(
+      <SigningKeyPanel
+        state={{ publicKey: btoa('hello') }}
+        onCreateKey={noop}
+        onExportPublicKey={noop}
+      />,
+    );
+    await screen.findByLabelText(/public key fingerprint/i);
+    await userEvent.click(screen.getByRole('button', { name: /copy fingerprint/i }));
+    expect(await screen.findByRole('status')).toHaveTextContent(/could not copy/i);
   });
 });

--- a/app/src/ui/SigningKeyPanel.tsx
+++ b/app/src/ui/SigningKeyPanel.tsx
@@ -1,11 +1,17 @@
 // Wave 27-C — design pass rewrite.
+// Wave 46 — fingerprint row + clipboard status (success / denied) for
+// Export public key and Copy fingerprint.
 // Semantic attributes preserved verbatim:
 //   aria-label="signing key"   (section)
 //   aria-label="public key"    (span)
 //   aria-label="key history"   (ul)
 //
+import { useEffect, useRef, useState } from 'react';
 import { Section } from './system/Section';
 import { Button } from './system/Button';
+import { Badge } from './system/Badge';
+import { computeShortFingerprintFromBase64 } from '../security/fingerprint';
+import type { ClipboardWriteStatus } from '../App/useSigningKey';
 
 export interface SigningKeyState {
   /** base64 raw public key, or null if no key exists. */
@@ -29,13 +35,23 @@ export interface SigningKeyPanelProps {
   state: SigningKeyState;
   /** Prompted-for-passphrase create-key callback; panel calls with the passphrase. */
   onCreateKey: (passphrase: string) => void | Promise<void>;
-  /** Copy the current public key somewhere (clipboard). Only called when key exists. */
-  onExportPublicKey: (publicKey: string) => void | Promise<void>;
+  /**
+   * Copy the current public key to the clipboard. Only called when key
+   * exists. Returns a discriminated status the panel renders as a transient
+   * `role="status"` confirmation (success) or persistent failure message.
+   * When the caller cannot return a status (legacy void / Promise<void>),
+   * the panel treats the call as success.
+   */
+  onExportPublicKey: (publicKey: string) => void | Promise<void> | Promise<ClipboardWriteStatus>;
   /** Wave 8 Part D — rotate the active signing key, generating a new keypair. */
   onRotateKey?: (passphrase: string) => void | Promise<void>;
   /** Wave 8 Part D — full key history (active + retired) for display. */
   keys?: KeyHistoryEntry[];
 }
+
+type CopyStatus = { kind: 'idle' } | { kind: 'copied' } | { kind: 'denied'; reason: string };
+
+const COPIED_TIMEOUT_MS = 4000;
 
 export function SigningKeyPanel({
   state,
@@ -45,16 +61,105 @@ export function SigningKeyPanel({
   keys,
 }: SigningKeyPanelProps): JSX.Element {
   const hasKey = state.publicKey !== null;
+
+  const [fingerprint, setFingerprint] = useState<string | null>(null);
+  const [exportStatus, setExportStatus] = useState<CopyStatus>({ kind: 'idle' });
+  const [fingerprintStatus, setFingerprintStatus] = useState<CopyStatus>({ kind: 'idle' });
+  const exportTimer = useRef<number | null>(null);
+  const fingerprintTimer = useRef<number | null>(null);
+
+  // Compute the short fingerprint whenever publicKey changes.
+  useEffect(() => {
+    let cancelled = false;
+    if (!state.publicKey) {
+      setFingerprint(null);
+      return;
+    }
+    void computeShortFingerprintFromBase64(state.publicKey).then((fp) => {
+      if (!cancelled) setFingerprint(fp);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [state.publicKey]);
+
+  // Auto-clear the success status after COPIED_TIMEOUT_MS. Failures persist
+  // until the next user action (handled in the click handlers below).
+  useEffect(() => {
+    if (exportStatus.kind !== 'copied') return;
+    exportTimer.current = window.setTimeout(() => {
+      setExportStatus({ kind: 'idle' });
+    }, COPIED_TIMEOUT_MS);
+    return () => {
+      if (exportTimer.current !== null) window.clearTimeout(exportTimer.current);
+      exportTimer.current = null;
+    };
+  }, [exportStatus]);
+  useEffect(() => {
+    if (fingerprintStatus.kind !== 'copied') return;
+    fingerprintTimer.current = window.setTimeout(() => {
+      setFingerprintStatus({ kind: 'idle' });
+    }, COPIED_TIMEOUT_MS);
+    return () => {
+      if (fingerprintTimer.current !== null) window.clearTimeout(fingerprintTimer.current);
+      fingerprintTimer.current = null;
+    };
+  }, [fingerprintStatus]);
+
+  async function handleExportPublicKey(): Promise<void> {
+    if (!state.publicKey) return;
+    setExportStatus({ kind: 'idle' });
+    try {
+      const out = await onExportPublicKey(state.publicKey);
+      if (out && typeof out === 'object' && 'status' in out) {
+        if (out.status === 'copied') setExportStatus({ kind: 'copied' });
+        else setExportStatus({ kind: 'denied', reason: out.reason });
+      } else {
+        // Caller did not return a status (legacy void). Treat as success.
+        setExportStatus({ kind: 'copied' });
+      }
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      setExportStatus({ kind: 'denied', reason });
+    }
+  }
+
+  async function handleCopyFingerprint(): Promise<void> {
+    if (!fingerprint) return;
+    setFingerprintStatus({ kind: 'idle' });
+    const nav = globalThis.navigator as
+      | { clipboard?: { writeText?: (s: string) => Promise<void> } }
+      | undefined;
+    const writeText = nav?.clipboard?.writeText;
+    if (typeof writeText !== 'function') {
+      setFingerprintStatus({
+        kind: 'denied',
+        reason: 'Clipboard API unavailable in this context.',
+      });
+      return;
+    }
+    try {
+      await writeText.call(nav!.clipboard, fingerprint);
+      setFingerprintStatus({ kind: 'copied' });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      setFingerprintStatus({ kind: 'denied', reason });
+    }
+  }
+
   return (
     <Section label="signing key" className="space-y-3 px-4 py-4">
       <h2 className="text-heading uppercase text-fg-muted">Signing key</h2>
       <details className="text-small text-fg-muted">
         <summary className="cursor-pointer select-none">Why does signing matter?</summary>
         <p className="mt-1 max-w-prose">
-          A signed export carries a digital signature made with this local key. To use it as proof
-          of origin, share your public key with the recipient out-of-band; they compare it against
-          the key embedded in the signed export. Without that comparison step, the file only
-          verifies against its own embedded key, which an attacker could replace.
+          A signed export carries a digital signature made with this local key. The 8-character
+          fingerprint shown below is the first 4 bytes of SHA-256 over the public key, in hex. To
+          use a signed export as proof of origin, share that fingerprint with the recipient
+          out-of-band (phone, encrypted message, paper). The recipient computes the same SHA-256
+          fingerprint over the public key embedded in the signed export and checks the match. A
+          match is evidence the embedded key was not substituted; it does not by itself prove
+          identity.
         </p>
       </details>
       {hasKey ? (
@@ -68,6 +173,42 @@ export function SigningKeyPanel({
         </p>
       ) : (
         <p className="text-body text-fg-muted">No signing key.</p>
+      )}
+      {hasKey && (
+        <div className="text-small text-fg-muted">
+          <span>Fingerprint: </span>
+          <code aria-label="public key fingerprint" className="font-mono text-mono text-fg-body">
+            {fingerprint ?? '...'}
+          </code>{' '}
+          <Button
+            type="button"
+            variant="subtle"
+            size="sm"
+            onClick={() => void handleCopyFingerprint()}
+            disabled={fingerprint === null}
+          >
+            Copy fingerprint
+          </Button>
+          {fingerprintStatus.kind === 'copied' && (
+            <p role="status" className="text-small text-fg-muted mt-1">
+              Fingerprint copied to clipboard.
+            </p>
+          )}
+          {fingerprintStatus.kind === 'denied' && (
+            <p
+              role="status"
+              className="text-small text-severity-high mt-1 inline-flex items-center gap-2"
+            >
+              <Badge severity="high" variant="severity">
+                Copy failed
+              </Badge>
+              <span>
+                Could not copy: {fingerprintStatus.reason}. Copy the fingerprint manually from the
+                field above.
+              </span>
+            </p>
+          )}
+        </div>
       )}
       <div className="flex flex-wrap gap-2">
         {!hasKey && (
@@ -84,13 +225,7 @@ export function SigningKeyPanel({
           </Button>
         )}
         {hasKey && (
-          <Button
-            variant="subtle"
-            size="sm"
-            onClick={() => {
-              if (state.publicKey) void onExportPublicKey(state.publicKey);
-            }}
-          >
+          <Button variant="subtle" size="sm" onClick={() => void handleExportPublicKey()}>
             Export public key
           </Button>
         )}
@@ -108,6 +243,24 @@ export function SigningKeyPanel({
           </Button>
         )}
       </div>
+      {exportStatus.kind === 'copied' && (
+        <p role="status" className="text-small text-fg-muted mt-1">
+          Public key copied to clipboard.
+        </p>
+      )}
+      {exportStatus.kind === 'denied' && (
+        <p
+          role="status"
+          className="text-small text-severity-high mt-1 inline-flex items-center gap-2"
+        >
+          <Badge severity="high" variant="severity">
+            Copy failed
+          </Badge>
+          <span>
+            Could not copy: {exportStatus.reason}. Copy the key manually from the field above.
+          </span>
+        </p>
+      )}
       {keys && keys.length > 0 && (
         <ul aria-label="key history" className="space-y-1 mt-2">
           {keys.map((k) => (

--- a/app/src/ui/system/Dialog.test.tsx
+++ b/app/src/ui/system/Dialog.test.tsx
@@ -139,6 +139,44 @@ describe('Dialog', () => {
     expect(screen.queryByRole('dialog')).toBeNull();
   });
 
+  it('applies inert to body siblings of the dialog while open and clears on close', async () => {
+    // Insert a sibling div on document.body so we have something to mark inert.
+    const sibling = document.createElement('div');
+    sibling.setAttribute('data-test', 'pre-existing-sibling');
+    document.body.appendChild(sibling);
+    try {
+      const user = userEvent.setup();
+      render(<Harness />);
+      // Before opening: sibling is not inert.
+      expect(sibling.hasAttribute('inert')).toBe(false);
+      await user.click(screen.getByRole('button', { name: 'open dialog' }));
+      // While open: sibling is inert.
+      expect(sibling.hasAttribute('inert')).toBe(true);
+      // After dismiss: sibling lost the attribute.
+      await user.keyboard('{Escape}');
+      expect(sibling.hasAttribute('inert')).toBe(false);
+    } finally {
+      sibling.remove();
+    }
+  });
+
+  it('does not strip inert from siblings that were already inert before the dialog opened', async () => {
+    const sibling = document.createElement('div');
+    sibling.setAttribute('inert', '');
+    document.body.appendChild(sibling);
+    try {
+      const user = userEvent.setup();
+      render(<Harness />);
+      await user.click(screen.getByRole('button', { name: 'open dialog' }));
+      expect(sibling.hasAttribute('inert')).toBe(true);
+      await user.keyboard('{Escape}');
+      // Pre-existing inert preserved.
+      expect(sibling.hasAttribute('inert')).toBe(true);
+    } finally {
+      sibling.remove();
+    }
+  });
+
   it('has no a11y violations', async () => {
     const user = userEvent.setup();
     const { container } = render(<Harness />);

--- a/app/src/ui/system/Dialog.tsx
+++ b/app/src/ui/system/Dialog.tsx
@@ -45,6 +45,30 @@ export function Dialog({
   // Focus trap inside the dialog while open.
   useFocusTrap(dialogRef, open);
 
+  // Wave 46 Item D — apply `inert` to body siblings while open. The focus
+  // trap governs Tab cycling; `inert` blocks programmatic .focus() and
+  // pointer interaction from outside the dialog (e.g. the App `/` and
+  // Cmd+F shortcuts that .focus() the search input directly). We track
+  // which siblings we toggled so cleanup does not stomp siblings that
+  // were already inert for unrelated reasons.
+  useEffect(() => {
+    if (!open) return;
+    const dialogEl = dialogRef.current;
+    if (!dialogEl) return;
+    const toggled: Element[] = [];
+    for (const child of Array.from(document.body.children)) {
+      if (child.contains(dialogEl)) continue;
+      if (child.hasAttribute('inert')) continue;
+      child.setAttribute('inert', '');
+      toggled.push(child);
+    }
+    return () => {
+      for (const el of toggled) {
+        el.removeAttribute('inert');
+      }
+    };
+  }, [open]);
+
   // Esc handler.
   useEffect(() => {
     if (!open || !closeOnEscape) return;

--- a/docs/audits/clarify-inventory-2026-04-29.md
+++ b/docs/audits/clarify-inventory-2026-04-29.md
@@ -1,0 +1,262 @@
+# LeaseGuard Copy Clarity Inventory — 2026-04-29
+
+Read-only audit of UI copy across `app/src/ui/*.tsx` and `app/src/App/*.tsx`,
+anchored to PRODUCT.md ("clear, calm, informative; plainspoken where the law
+is plainspoken; never cheerful, never alarming, never coy") and DESIGN.md
+("plain language outranks legal language", "severity is never color-only").
+
+Wave 45-D (commit cb506e9, merged 2026-04-24) is treated as a hard floor —
+strings it touched (FindingsPanel `~`/similarity badge, AuditLogPanel
+preamble, AppCurrentPane + SigningKeyPanel signed-export `<details>`,
+PackManagerPanel error, OnboardingTour audit-log step) are flagged only
+where a separate axis (e.g. CTA generic-ness, missing-context) recurs.
+
+## Summary
+
+- **Files audited:** 44 panel/shell .tsx files + `i18n/messages.ts` + `App/useAppCallbacks.ts` + `App/usePackManager.ts` + `App/appHelpers.ts`.
+- **Strings flagged:** 47 (High: 9 / Medium: 23 / Low: 15).
+- **Surfaces with the highest concentration of issues:**
+  1. `OpenReviewPanel.tsx` — passphrase + archive flow, every error string is technical and most CTAs are non-specific.
+  2. `CustomRuleBuilderPanel.tsx` — practitioner-only, but raw errors ("Regex compile error: …") and unlabeled save with no validation mirror.
+  3. `DeltaPanel.tsx` / `ShareReviewPanel.tsx` / `CounterSignPanel.tsx` — passphrase / signing flow share a vocabulary problem (passphrase length is silent until submit; failure surfaces are generic).
+  4. `OnboardingTour.tsx` — copy is on-voice but step 2 still says "Critical / Warning / Info" while the rest of the app says "High / Medium / Low / Info" (severity vocabulary drift).
+  5. `App/useAppCallbacks.ts` + `appHelpers.ts` — `window.prompt` / `window.confirm` are used for passphrases and destructive confirmation; copy is one line and renter-hostile.
+- **Already-strong surfaces (post Wave 45-D):**
+  - `FindingsPanel` similarity badge + `aria-label` (Wave 45-D).
+  - `AuditLogPanel` preamble explaining what the chain does and doesn't prove (Wave 45-D).
+  - `AppCurrentPane` + `SigningKeyPanel` "What is signed export?" disclosure (Wave 45-D).
+  - `BulkImportPanel` live-region progress + closing summary (Wave 45-F is recent and clear).
+  - `AppHeader` privacy disclosure list — concrete, calm, audited.
+
+## Findings by surface
+
+### App shell — header / footer / pane (`app/src/App/`)
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| H | confirm | App/appHelpers.ts:235 | `window.confirm('Delete all saved leases from this device? This cannot be undone.')` | Native `confirm()` is unstyled, off-voice, and doesn't name the count. Renter-hostile destructive flow. | Replace with Dialog primitive; name count + lease names |
+| H | error | App/useAppCallbacks.ts:60 | `Could not load sample (${res.status})` | HTTP status is renter-jargon; no recovery path | "Couldn't load the sample lease. Refresh and try again." |
+| H | confirm | App/appHelpers.ts:179,204 | `window.prompt('Passphrase for the encrypted archive:')` | Native prompt; no min-length / strength hint; no explanation what passphrase protects | Replace with Dialog + Field + min-length helper text |
+| M | error | App/useAppCallbacks.ts:129 | `Signing failed: ${friendlyError(err)}` | Bubble of raw Error.message; "Signing failed" is verb-first but offers no next step | Distinguish wrong-passphrase from other failures; suggest "try the passphrase again" vs. "your key may be missing" |
+| M | error | App/appHelpers.ts:24-28 | `friendlyError` returns `err.message` verbatim | "Friendly" wrapper is a passthrough; raw browser/IDB messages reach renters | Map known error classes to plain-language strings |
+
+### `AppHeader.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| L | help | AppHeader.tsx:56 | "LeaseGuard is not legal advice. Findings are heuristic pattern matches." | "Heuristic" is jargon for renters; everything else in this list is plain | "…are computer-generated suggestions, not lawyer review." |
+
+### `AppCurrentPane.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| M | error | AppCurrentPane.tsx:178-183 | "OCR didn't finish reading this PDF. The error was: {message}…" | Embeds raw error mid-sentence; long passive sentence | Lead with what to do; quote the technical reason at the end as small print |
+| L | help | AppCurrentPane.tsx:159-161 | "This PDF looks scanned (avg N chars/page). Text extraction may be incomplete." | "chars/page" is a debug detail | Drop the parenthetical for renters; keep behind a `details` for practitioners |
+
+### `FindingsPanel.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| H | empty | FindingsPanel.tsx:143 | "No findings yet. Upload a lease to analyze." | OK but the same panel mounts when filters hide everything; renter sees this instead of "0 of 12 match your filters" | Branch: `findings.length === 0` vs. `visible.length === 0 && findings.length > 0` |
+| M | label | FindingsPanel.tsx:438-444 | "deviates from verified pack" | Renter doesn't know what a "pack" is; "verified" is overloaded with the signing flow | "Differs from the standard rule we shipped" or expose only to practitioner mode |
+| M | label | FindingsPanel.tsx:435 | "(possibly not applicable)" | Vague — possibly per what? | "This clause appears to be negated (e.g. 'shall not')" |
+| L | label | FindingsPanel.tsx:511 | "Above the 70% similarity floor" | Mixes concept (floor) with number; renter has no anchor | "70% is the cutoff for showing this match" |
+
+### `AnnotationsPanel.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| M | empty | AnnotationsPanel.tsx:40 | "Click a finding to attach a note." | Implies there is a finding open already; when nothing is selected this is dead-end advice for a renter scanning the panel | "Open a finding above to add notes about it." |
+| L | empty | AnnotationsPanel.tsx:68 | "No notes yet for this paragraph." | OK; could be warmer | Keep |
+
+### `CounterOfferPanel.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| M | label | CounterOfferPanel.tsx:60 | "Select a finding to see or add counter-offers." | "Counter-offer" is practitioner jargon — renter needs the term grounded once | Add one-line plain reading: "alternative wording you'd ask the landlord to use" |
+| L | label | CounterOfferPanel.tsx:81 | `For rule: {finding.title}` | Practitioner-flavored "rule"; renter sees the title twice elsewhere | "About: {title}" |
+
+### `AuditLogPanel.tsx`
+
+(Preamble is Wave 45-D; leave it.)
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| M | header | AuditLogPanel.tsx:91 | column header "Kind" | Internal type-system word ("Kind") leaks to user UI; "Action" is the user-facing concept | Rename column header to "Action" |
+| M | content | AuditLogPanel.tsx:104 | `{e.kind}` rendered raw (e.g. `analyze`, `delete-lease`, `hybrid-feedback`) | Slug strings shown to renter | Map kinds to plain labels ("Analyzed lease", "Deleted lease", "Marked finding not relevant") |
+| L | content | AuditLogPanel.tsx:107 | `summarizePayload` JSON-truncated | Renter can't read JSON | Keep behind a "show raw" toggle; render kind-specific summaries by default |
+
+### `BulkImportPanel.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| L | label | BulkImportPanel.tsx:164 | "Skipped (duplicate)" | Clear; could name what was duplicated | "Skipped — same content as a saved lease" |
+| L | progress | BulkImportPanel.tsx:104 | "Processing… imported N · skipped N · errors N" | OK; the leading "Processing…" is technically accurate but tonally bureaucratic | "Working through your files — N imported · N skipped · N errors" |
+
+### `OcrLanguagePickerPanel.tsx` / OCR strings (also see AppCurrentPane)
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| L | label | AppCurrentPane.tsx:174 | `Running OCR: {stage} ({pct}%)` | "OCR" is jargon for renters | "Reading scanned text: {stage} ({pct}%)" |
+
+### `PackManagerPanel.tsx`
+
+(Wave 45-D touched the import-error string; preserve.)
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| M | label | PackManagerPanel.tsx:56,127 | Badge: "Community" / "Verified" / "Invalid signature" / "Unknown" | "Community" is opaque to renters — implies people, not absence-of-signature | Re-label "Community" → "Unsigned" with tooltip explaining what verification adds |
+| L | empty | PackManagerPanel.tsx:147 | `<em>No additional packs installed.</em>` | OK; italic + plain. Could name the next action | "No additional packs installed. Browse included packs to add one." |
+
+### `SigningKeyPanel.tsx`
+
+(Disclosure body is Wave 45-D; preserve.)
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| H | confirm | SigningKeyPanel.tsx:78,102 | `window.prompt('Set a passphrase for the new signing key:')` | Native prompt; no length floor, no warning that lost passphrase = lost key | Replace with Dialog + Field + recovery-loss warning |
+| L | empty | SigningKeyPanel.tsx:70 | "No signing key." | Terse; renter doesn't know what creating one buys | "No signing key yet. Create one to sign exports — see 'Why does signing matter?' above." |
+
+### `OpenReviewPanel.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| H | error | OpenReviewPanel.tsx:15 | `'wrong-passphrase': 'Wrong or incorrect key — check what you typed.'` | "Wrong or incorrect" is redundant; "key" conflates passphrase with cryptographic key | "That passphrase didn't unlock the file. Try again." |
+| M | error | OpenReviewPanel.tsx:17 | "Missing rule pack — install the matching signed pack." | Doesn't say which pack | "This review needs the rule pack '{packId}', which isn't installed yet." |
+| M | error | OpenReviewPanel.tsx:18 | "This file is not a LeaseGuard review archive." | Negative-framed; doesn't suggest fix | "We couldn't read this file as a LeaseGuard review. It may be the wrong file or damaged." |
+| L | help | OpenReviewPanel.tsx:85-89 | "…The lease will mount as a non-editable session — your audit log records this session separately and writes back to the original lease are gated off." | Two clauses joined with em-dash; "mount", "gated off" are dev-speak | Two short sentences; replace "mount as a non-editable session" with "open in read-only review mode" |
+
+### `ShareReviewPanel.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| M | error | ShareReviewPanel.tsx:37 | `Passphrase must be at least ${MIN_PASSPHRASE_LEN} characters.` | Surfaces only after submit; helper text on the field would prevent the error | Add helper text under field: "16+ characters" |
+| M | error | ShareReviewPanel.tsx:71 | "Requires a signed pack to share." | Renter doesn't know what a signed pack is or how to get one | "You need a signed rule pack to share — open Rule packs to install one." |
+| L | label | ShareReviewPanel.tsx:62-65 | "Generates an expiring, key-protected `.lgreview` file." | "Key-protected" + ".lgreview" are jargon | "Creates a passphrase-protected file that expires on the date below. Recipient opens it locally — nothing leaves your device." |
+
+### `CounterSignPanel.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| H | error | CounterSignPanel.tsx:41 | `'Sign failed'` (default fallback) | Bare phrase; no recovery | "We couldn't sign the patch. Check the passphrase and try again." |
+| M | label | CounterSignPanel.tsx:50 | "Sign & export patch" | "Patch" is dev jargon; the user just made decisions on edits | "Sign and send your decisions" |
+| L | label | CounterSignPanel.tsx:52 | `<span aria-label="archive fingerprint">{slice(0,12)}…</span>` | Bare hex without context | Prefix "Reviewing archive:" or similar |
+
+### `DeltaPanel.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| M | help | DeltaPanel.tsx:56 | "Pick two saved versions to produce a signed `.lgdelta` patch the recipient can verify and apply on their local copy." | "Patch", "apply on their local copy" — practitioner OK but exposes file extension | Plain reading first, "(file ends in .lgdelta)" parenthetical |
+| M | error | DeltaPanel.tsx:33 | `setError(err instanceof Error ? err.message : String(err))` | Raw Error.message reaches user | Branch on known failures; fall back to "Something went wrong creating the delta. Check the passphrase and try again." |
+
+### `CustomRuleBuilderPanel.tsx` (practitioner-only, but still flag)
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| H | error | CustomRuleBuilderPanel.tsx:321 | "Regex compile error: {raw}" | Raw browser error; no example | Surface the raw error in `<small>` and lead with "The pattern isn't a valid regular expression." |
+| M | label | CustomRuleBuilderPanel.tsx:114 | `<h2>Custom rule builder</h2>` (no introductory copy) | Practitioner can guess but new users land cold | One-paragraph intro: "Define a clause-matching rule. The preview at the bottom fires it against the loaded lease." |
+| M | label | CustomRuleBuilderPanel.tsx:272-274 | "Preview unavailable." / "Fires at N location(s)." / "Does not fire on the loaded document." | "Fires" is dev jargon; "unavailable" without reason | "Matches N place(s)." / "No matches in this lease." / "Preview hidden until the rule is valid." |
+| L | empty | CustomRuleBuilderPanel.tsx:128 | `A rule with id "{form.id}" already exists.` | Quotes around id but no fix path | "The id '{form.id}' is already used. Pick another id." |
+
+### `MarketplacePanel.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| M | error | MarketplacePanel.tsx:54 | `'failed to load manifest'` (lowercase fallback) | Sentence-case mismatch; "manifest" is dev jargon | "Couldn't load the curated pack list." |
+| M | error | MarketplacePanel.tsx:79 | `'install failed'` (fallback) + `Install failed: {message}` | Generic, lowercase fallback, no recovery | "Couldn't install '{name}'. {message}" |
+| L | label | MarketplacePanel.tsx:153 | "View diff vs current" | "Diff" is dev jargon | "See what changes" |
+
+### `LibraryPanel.tsx` / `JurisdictionPickerPanel.tsx` / `TemplatesPanel.tsx` / `HybridPrecisionPanel.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| L | empty | LibraryPanel.tsx:37 | "No saved leases yet." | OK; could name action | "No saved leases yet. Upload a PDF above to start." |
+| L | empty | JurisdictionPickerPanel.tsx:64 | "No jurisdictions selected — all rules run regardless of regional tags." | "Regional tags" is jargon | "No state/city selected. Every rule runs." |
+| L | empty | TemplatesPanel.tsx:62 | "No clause templates saved yet." | OK | Keep |
+| L | empty | HybridPrecisionPanel.tsx:39 | "No hybrid feedback yet" | "Hybrid" is internal jargon (Phase 18 ML pipeline name) | "No 'not relevant' feedback recorded yet." |
+
+### `ClauseSimilarityPanel.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| L | empty | ClauseSimilarityPanel.tsx:28 | "No clause clusters yet — analyze two or more leases to see overlap." | "Clusters" is data-science jargon | "Save two or more leases to see clauses that repeat across them." |
+
+### `OnboardingTour.tsx`
+
+(Wave 45-D updated step 4. Preserve.)
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| H | content | OnboardingTour.tsx:32-35 | "Each finding is tagged Critical / Warning / Info…" | Severity vocabulary drift — the rest of the app uses High / Medium / Low / Info per FindingsPanel.tsx:37-42 and DESIGN.md `severity-*` tokens | "High / Medium / Low / Info" |
+| L | label | OnboardingTour.tsx:111 | aria-label="skip onboarding tour" + visible "Skip" | OK but Skip is ambiguous mid-flow vs. dismiss | Keep (Wave 45-F just added Dialog primitive; tour copy itself is fine) |
+
+### `RedlinePanel.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| M | empty | RedlinePanel.tsx:84 | "Upload a lease to start editing." | The redline view is reachable from a lease — but if the lease was cleared the message offers no next step | "No lease loaded. Upload one or open a saved lease from the library." |
+| L | label | RedlinePanel.tsx:115 | "Export redlined HTML" | "Redlined" is legalese — but here it's accurate to the feature | Keep; it's a practitioner-mode panel |
+
+### `SideLetterPanel.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| L | label | SideLetterPanel.tsx:43-44 | `{N} proposed change(s)` | OK | Keep |
+| L | label | SideLetterPanel.tsx:38 | `<h2>Side letter</h2>` | "Side letter" is a term of art (a separate signed agreement); renters won't know | One-line plain reading under the h2: "A short signed letter requesting these changes alongside the lease." |
+
+### `VersionHistoryPanel.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| M | confirm | VersionHistoryPanel.tsx:105-110 | `aria-label="delete version {label}"` + button "Delete" — no confirmation | Destructive action without confirm or naming target visibly | Add Dialog confirm naming the version + edit count |
+| L | empty | VersionHistoryPanel.tsx:74 | "No versions saved yet." | OK | Keep |
+
+### `StandardSuitePanel.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| L | empty | StandardSuitePanel.tsx:15 | "No standards yet. Promote a clause from a lease to start your suite." | "Suite" is the internal product word | "No standard clauses yet. From any finding, click 'Promote to standard' to add one." |
+
+### `ComparePanel.tsx`
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| L | help | ComparePanel.tsx:42-44 | "These leases were analyzed under different rule-pack versions (A: vX, B: vY). Differences may reflect rule changes rather than content changes." | Solid practitioner copy | Keep |
+| L | empty | ComparePanel.tsx:56 | "No differences in findings between these leases." | OK; could be warmer | Keep |
+
+### i18n (`app/src/i18n/messages.ts`)
+
+| Sev | Genre | Location | Current | Diagnosis | Suggested direction |
+|---|---|---|---|---|---|
+| M | error | messages.ts:35 | `status.error: 'Could not analyze this file: {message}'` | Generic; no triage between "wrong file type" / "password protected" / "OCR needed" | Map known PdfErrors to specific keys (already partially handled in code) |
+| L | empty | messages.ts:41 | `findings.empty: 'No findings yet.'` | Same string used for 0-findings and pre-analyze; ambiguous | Add `findings.empty.preAnalyze` and `findings.empty.zeroAfterAnalysis` |
+
+## Cross-cutting patterns
+
+- **Native `window.prompt` / `window.confirm` for passphrase + destructive flows.** AppHelpers `clearAll`, archive export/import, and SigningKeyPanel create/rotate all use them. Off-voice, unstyled, no helper text, no min-length feedback. With Wave 45-F's Dialog/FileButton primitives shipped, every one of these has a primitive available now.
+- **`error.message` passthroughs.** `friendlyError()` is a misnomer — it returns `err.message` verbatim. PackManager, Marketplace, Delta, CounterSign, Signing all surface raw browser/IDB strings. Inconsistent capitalization too ("install failed" lowercase vs. "Import failed:" capitalized).
+- **Internal slug strings rendered to users.** AuditLogPanel kind column shows `analyze` / `delete-lease` / `hybrid-feedback`. PackManager shows raw `id`. CustomRuleBuilder echoes regex pattern errors. These leak the data model.
+- **Severity vocabulary drift.** OnboardingTour says "Critical / Warning / Info"; the actual FindingsPanel uses "High / Medium / Low / Info" (DESIGN.md severity tokens are `severity-high/medium/low/info`). Renter sees two vocabularies in one session.
+- **Empty states without next-action.** AnnotationsPanel, LibraryPanel, JurisdictionPickerPanel, StandardSuitePanel, HybridPrecisionPanel, TemplatesPanel — most empty states declare absence without naming the action that fills them.
+- **"Pack" / "diff" / "patch" / "manifest" / "kind" / "fires" / "regex" / "OCR" / "fingerprint"** appear unwrapped on renter-reachable surfaces. PRODUCT.md §"Plain language outranks legal language" applies equally to dev-speak.
+- **Aria-label / visible-label divergence.** FindingsPanel.tsx:466 has the rich Wave 45-D aria-label "Identified by on-device similarity match (similarity X%). Click to see details." while the visible label is "On-device similarity match" — fine. But across the app several aria-labels are lowercase slugs ("counter-offers", "audit log", "rule packs") that match section headings rendered in `text-heading uppercase`; consistent but worth normalizing in a sweep.
+
+## Recommended slicing
+
+### Slice 1 — Renter-facing error and confirmation copy (High-value, contained)
+- **Surfaces:** `App/useAppCallbacks.ts`, `App/appHelpers.ts`, `OpenReviewPanel.tsx`, `ShareReviewPanel.tsx`, `CounterSignPanel.tsx`, `MarketplacePanel.tsx`, `DeltaPanel.tsx`, `i18n/messages.ts`.
+- **High/Medium counts:** 5 H / 9 M.
+- **Risk of churning Wave 45-D work:** Low — none of these strings overlap with cb506e9.
+- **Rationale:** Replace `friendlyError` passthrough with a small error→plain-string mapper, route the four `window.prompt` / `window.confirm` callsites through the Wave 45-F Dialog primitive, and rewrite the `OpenReviewPanel.REASON_MESSAGES` table. This is a single PR's worth of work and removes the highest-impact renter blockers (cryptic errors with no recovery hint, native browser dialogs in the destructive path). One migration helper carries most of the leverage.
+
+### Slice 2 — Audit-log + onboarding vocabulary normalization
+- **Surfaces:** `AuditLogPanel.tsx` (column header + kind→plain-label map), `OnboardingTour.tsx` (severity vocabulary fix), `FindingsPanel.tsx` ("deviates from verified pack" + "negated" labels), `PackManagerPanel.tsx` ("Community" → "Unsigned" badge label).
+- **High/Medium counts:** 1 H / 6 M.
+- **Risk of churning Wave 45-D work:** Medium — touches `AuditLogPanel.tsx` and `OnboardingTour.tsx`, both of which Wave 45-D edited. The preamble paragraph and the audit-log step body must stay verbatim; only the column header, the kind→label adapter, and step 2's severity vocabulary change.
+- **Rationale:** The single highest-confusion item for a renter scanning the audit log is seeing `delete-lease` instead of "Deleted lease". This is also where the severity vocabulary drift in OnboardingTour bites. One narrow PR with a kind-to-label adapter + a 3-word fix in OnboardingTour step 2 + the badge rename. Test impact is contained because tests query by aria-label, not visible text.
+
+### Slice 3 — Empty states, helper text, plain-reading wraps for jargon
+- **Surfaces:** `AnnotationsPanel.tsx`, `CounterOfferPanel.tsx`, `LibraryPanel.tsx`, `JurisdictionPickerPanel.tsx`, `StandardSuitePanel.tsx`, `HybridPrecisionPanel.tsx`, `ClauseSimilarityPanel.tsx`, `RedlinePanel.tsx`, `ShareReviewPanel.tsx` (helper text), `SideLetterPanel.tsx`, `CustomRuleBuilderPanel.tsx` intro + preview labels.
+- **High/Medium counts:** 1 H / 6 M / 8 L.
+- **Risk of churning Wave 45-D work:** Low — none of these surfaces overlap with cb506e9.
+- **Rationale:** Lowest individual impact per string but the largest total surface; reads as a "polish pass" rather than a critical fix. Save for after Slices 1 and 2. The CustomRuleBuilder regex-error rewrite is the only High in this slice and could be promoted into Slice 1 if practitioner UX is in scope.

--- a/docs/audits/extract-inventory-2026-04-29.md
+++ b/docs/audits/extract-inventory-2026-04-29.md
@@ -1,0 +1,115 @@
+# LeaseGuard Design-System Extract Inventory — 2026-04-29
+
+## Summary
+
+- Files audited: 44 panels in `app/src/ui/*.tsx` + 6 shell files in `app/src/App/*.tsx` + 9 system primitives + `DESIGN.md` / `DESIGN.json`.
+- Extraction candidates: **9** (Components: 4 / Tokens: 0 net-new (1 alias) / Patterns: 5).
+- Highest-confidence candidates (used ≥5 times): `PanelHeader` heading (25+), `Section` pad-and-stack default (18), `mini-card list-row` (5), `font-mono text-mono` mono-text combo (16+), `text-small text-fg-muted` helper-text combo (49 — but most are correctly placed; only the `<p>` form is extractable).
+- Marginal candidates (≥3 but with shape drift): `severity/trust pill` triplet (5 callsites, two different alpha conventions vs canonical Badge), `evidence blockquote` (2 — below threshold; flagged in cross-cutting), `inline-input override` reproducing `Field` styles (4 callsites that bypass `Field`).
+
+## Candidates
+
+### Component candidates
+
+**PanelHeader** (proposed) — 25+ usages of `<h2 className="text-heading uppercase text-fg-muted">…` plus a `mb-1`/`mb-3` companion variant on h3 lease-panel sub-headers.
+- Locations: `TemplatesPanel.tsx:59`, `BulkImportPanel.tsx:61`, `SeverityOverridesPanel.tsx:72,93`, `AuditLogPanel.tsx:29`, `HybridPrecisionPanel.tsx:35,64`, `LibraryPanel.tsx:35,45`, `JurisdictionPickerPanel.tsx:50,61`, `AppLibraryAndPacksPane.tsx:196`, `RedlinePanel.tsx:83,114`, `SigningKeyPanel.tsx:50`, `PackManagerPanel.tsx:99`, `PortfolioPanel.tsx:103,113`, plus h3 variants in `LeaseFactsPanel.tsx:36,44`, `CounterOfferPanel.tsx:59,80`, `PortfolioRollupsPanel.tsx:28,36`, `AppCurrentPane.tsx:226`, `WorkflowPanel.tsx:37`, `TemplateMatchesPanel.tsx:26,33`, `AnnotationsPanel.tsx:39,66`. 25+ direct callsites.
+- Same-intent justification: every usage is a panel/section title styled as the chrome label-tier (`text-heading uppercase text-fg-muted`), some with `mb-{1|3}` to set the rhythm to the body. The only divergence is heading level (h2 for top-level panel, h3 for sub-section under a Pane), which is a prop, not different intent. Existing `Section` primitive deliberately does not render the title — so the title duplication is structural.
+- Proposed props:
+  ```ts
+  { as?: 'h2'|'h3'; children: ReactNode; mb?: 0|1|3; className?: string }
+  ```
+- Risk: `Section` already takes a `label` (used as `aria-label` only, not rendered). Risk that two callers want a different heading-rank than the surrounding landmark dictates — but every current callsite uses h2 directly under the Pane h1, h3 under a Pane that already promotes to h2. Ship `PanelHeader as="h2"|"h3"` and let `Section` accept it as a slot in a follow-up.
+
+**SeverityTrustPill** (proposed) — 5 usages of the `bg-X/10 text-X border-X/30` triplet against severity/positive/negative tokens.
+- Locations: `PortfolioPanel.tsx:180-183` (severity matrix), `PackManagerPanel.tsx:64-67` (signature trust badges), `AuditLogPanel.tsx:59` (verification ok/fail), `RedlinePanel.tsx:164` (`severity-medium`), `SigningKeyPanel.tsx:120` (positive-only inline).
+- Same-intent justification: all five render a small bordered chip whose tint encodes a status enum (severity / trust / verification). They reuse a `bg-{token}/10 + text-{token} + border-{token}/30` recipe — but Wave 45-A landed `Badge variant="severity"` with `severity-bg-*` / `severity-border-*` color-mix tokens that auto-rebalance for dark mode. The five callsites bypass that primitive and re-derive opacity by hand, drifting from canonical (`/10` vs `severity-bg-*` ≈ 22% mix).
+- Proposed props (extends Badge):
+  ```ts
+  // add to existing Badge.tsx
+  variant: 'severity' | 'trust' | 'verification' | 'mono'
+  severity?: 'high'|'medium'|'low'|'info'
+  trust?: 'verified'|'community'|'invalid'|'unknown'
+  verification?: 'ok'|'fail'
+  ```
+  or a separate `<TrustBadge>` for non-severity statuses to keep `Badge severity` semantically pure.
+- Risk: AuditLogPanel and PackManagerPanel use `positive` / `severity-high` (tertiary status) where `Badge variant="severity"` would assert finding-severity meaning the rule-pack-trust callsite shouldn't claim. Keep severity vs trust as different primitives; do NOT collapse into one variant. Two callsites also color text with the token — Badge's "always Ink Black" rule (DESIGN §5 Severity Badges) may need an opt-out for trust.
+
+**ConfirmDialog** (proposed) — 6 usages of `window.confirm` / `window.prompt` for destructive or sensitive flows.
+- Locations: `appHelpers.ts:210` (delete-all confirm), `appHelpers.ts:235` (delete-all-leases confirm), `appHelpers.ts:179`, `appHelpers.ts:204` (passphrase prompts), `useAppCallbacks.ts:118` (signing-key passphrase), `LibraryPanel.tsx:80` (rename prompt), `SigningKeyPanel.tsx:78,102` (passphrase prompts).
+- Same-intent justification: every callsite is an inline confirmation or single-input prompt that today uses the browser's blocking dialog. A `Dialog` primitive already exists (Wave 45-F). Standardizing a `ConfirmDialog` on top would (a) match the Marginalia type voice, (b) allow plain-language affirm/cancel labels per Wave 45-D, (c) make the "destructive vs data-entry" intent visible per the project memory note on crypto copy. Six callsites; still using browser native.
+- Proposed props:
+  ```ts
+  { open: boolean; title: string; description?: ReactNode;
+    affirmLabel: string; cancelLabel?: string;
+    variant?: 'destructive'|'default';
+    input?: { label: string; type: 'text'|'password' };
+    onAffirm: (value?: string) => void; onCancel: () => void }
+  ```
+- Risk: passphrase prompts are crypto-adjacent — converting to React state means the cleartext lingers in memory longer than `window.prompt`. Plan a memory-zeroing pattern before migration. Migration also requires every call-site to switch from sync to async — that's a wide diff. Ship the primitive first; migrate one panel at a time.
+
+**StatusMessage** (proposed) — 17+ usages of `<p role="status">…</p>` / `<p role="alert">…</p>` carrying a one-liner success/error/info state.
+- Locations: `PackManagerPanel.tsx:164,169`, `MarketplacePanel.tsx:94,103,112,157,160`, `OpenReviewPanel.tsx:105,107`, `WorkflowPanel.tsx:59`, `CounterSignPanel.tsx:74`, `DeltaPanel.tsx:86`, `OpenDeltaPanel.tsx:78`, `AppCurrentPane.tsx:178`, `ShareReviewPanel.tsx:76,93`, `AuditLogPanel.tsx:56`, `BulkImportPanel.tsx:149`.
+- Same-intent justification: all render a one-line role=status or role=alert message. Today three different className patterns coexist (`text-small text-positive`, `text-small text-severity-high`, `error` legacy class, plain `<p>`). A `<StatusMessage tone="success|error|info" live="polite|assertive">` would centralise the (a) role mapping, (b) color token, (c) the `{message}: {error.message}` plain-language convention plan from Wave 45-D.
+- Proposed props:
+  ```ts
+  { tone: 'success'|'error'|'info'|'warning';
+    live?: 'polite'|'assertive'|'off';
+    children: ReactNode; className?: string }
+  ```
+- Risk: two of the 17 wrap their text inside other live regions; double live regions over-announce. Prop must allow `live="off"` so callers nested in `<div role="status">` don't double-up. Also: ComparePanel `<div role="alert">` wraps a paragraph + dismiss button — that's a richer pattern (Banner) and should NOT be folded in.
+
+### Token candidates
+
+**(none net-new).** The audited code uses canonical tokens almost exclusively — the only literals found were `style={{ height: '32rem' }}` in `SideLetterPanel.tsx:100` (one-off iframe sizing) and `style={{ display: 'none' }}` in `system/FileButton.tsx:94` (legitimate). No `#hex`, no `oklch(`, no `rgba(`. The PDF highlight literal documented in DESIGN.md §5 lives in `PdfViewer.tsx` (intentional off-palette per spec). All severity/positive/negative usages thread through the named tokens.
+
+**Token alias suggestion (marginal):** `--state-hover` / `--state-active` are referenced ~6× via `bg-[var(--state-hover)]`. They're real CSS custom properties but not first-class entries in `DESIGN.json`. Consider promoting them to named tokens (`state.hover`, `state.active`) for parity with the `severity-bg-*` family. Not blocking; cosmetic for the design-token export.
+
+### Pattern candidates
+
+**SectionShell** — 18 usages of `Section label="…" className="space-y-{2|3|4} px-4 py-4"`.
+- Locations: `BulkImportPanel.tsx:60`, `SeverityOverridesPanel.tsx:71,92`, `HybridPrecisionPanel.tsx:34,63`, `LibraryPanel.tsx:34,44`, `TemplatesPanel.tsx:58`, `AppLibraryAndPacksPane.tsx:195`, `PortfolioPanel.tsx:102,112`, `AuditLogPanel.tsx:28`, `SigningKeyPanel.tsx:49`, `JurisdictionPickerPanel.tsx:49,60`, `RedlinePanel.tsx:82,112`, `PackManagerPanel.tsx:98`.
+- Composition shape: `<Section label aria> + <PanelHeader> + body stack`, padded `px-4 py-4`, vertical rhythm `space-y-{2|3|4}`.
+- Existing primitive(s) it would compose: `Section` (wrapper) + new `PanelHeader` candidate above. Option: bake the padding + default stack into `Section` via a `density` prop matching `SectionGroup`'s `comfortable|compact`.
+
+**MiniCardListRow** — 5 usages of `rounded-sm border border-rule bg-paper-raised shadow-paper px-3 py-2`.
+- Locations: `TemplatesPanel.tsx:68` (template list-row), `LibraryPanel.tsx:50` (lease list-row), `RedlinePanel.tsx:126` (redline paragraph row), `PackManagerPanel.tsx:101,109` (built-in + installed pack rows). Plus `bg-paper-sunken` variant at `CounterOfferPanel.tsx:87`, `AnnotationsPanel.tsx:72` (3 sunken usages).
+- Composition shape: a `Card`-equivalent at smaller padding (`px-3 py-2` vs `Card`'s 16px) for list rows. Effectively a `<Card density="compact">`.
+- Existing primitive(s): `Card` — extend with a `density` prop (`comfortable | compact`) and a `surface` prop (`raised | sunken`) so the 8 callsites collapse into one.
+
+**MonoCode** — 16 usages of `font-mono text-mono` ± `text-fg-muted`.
+- Locations: `PortfolioRollupsPanel.tsx:56`, `SeverityOverridesPanel.tsx:117`, `AuditLogPanel.tsx:106`, `HybridPrecisionPanel.tsx:83,138`, `AppLibraryAndPacksPane.tsx:198`, `TemplateMatchesPanel.tsx:47,53`, `PackManagerPanel.tsx:171`, `SigningKeyPanel.tsx:65,117`, `BulkImportPanel.tsx:64,139`, `AppCurrentPane.tsx:228`, `PortfolioPanel.tsx:133`, `FindingsPanel.tsx:449,507,516`, `system/Badge.tsx:103` (already a variant!).
+- Composition shape: hash digests, rule-IDs, JSON fragments, file extensions. `Badge variant="mono"` already exists — but most callsites are `<code>` / `<span>` not badges, so a `<MonoText>` (or pure utility class) would close the gap. Lowest-risk: add a `.mono-text` utility recipe to the global stylesheet; all 16 callsites collapse to that one class. Highest-utility: ship `<MonoText as="code"|"span">` so semantics stay correct.
+
+**EvidenceQuote** — 2 usages of `border-l border-rule pl-3 font-mono text-mono text-fg-muted italic` (`AppCurrentPane.tsx:228`, `TemplateMatchesPanel.tsx:53`). **Below the ≥3 threshold — flagged below in cross-cutting; do not extract yet.**
+
+**SeverityFilterChip** — 1 usage at `JurisdictionPickerPanel.tsx:72` (`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-sm border text-small`). Toggle-pill checkbox pattern. Flagged for visibility but only one callsite; do not extract.
+
+## Cross-cutting observations
+
+- **Form-row pattern (label-above-field-with-helper):** The `Field` primitive already exists. CustomRuleBuilderPanel has 14 raw `<input>` / `<select>` / `<textarea>` callsites that bypass it. This is a *migration* problem, not an *extraction* problem — the primitive is already sufficient.
+- **EvidenceQuote (blockquote of clause text):** only 2 usages — below threshold. Re-evaluate after Wave 47 if the open-review panel adds a third.
+- **OCR / streaming progress banner:** `AppCurrentPane.tsx:155` (ScannedPdfNotice / ResultsHeader sub-components extracted in Wave 45-BE) + `BulkImportPanel.tsx:91` (Wave 45-F live region). Same intent (progressive aria-live + tone), different shape. Not the same enough to extract — keep separate.
+- **`ComparePanel` h2/h3 + plain `<ul>`:** the panel uses no design-system primitives at all (predates Wave 27-C). The Added/Removed/Changed sub-sections each have their own `<h3>{label} ({count})</h3>` — three different intents (added=positive, removed=negative, changed=warning) but rendered identically. A `<DiffSection variant=…>` is tempting; passes ≥3 with same-intent technically, but risks freezing a too-narrow API. Recommend re-flagging after PackDiffPanel adopts the same shape (it already does via SectionGroup).
+- **Severity sub-card (sunken variant):** `CounterOfferPanel.tsx:87` + `AnnotationsPanel.tsx:72` use `bg-paper-sunken border border-rule rounded-sm p-3` (3rd usage at `AppCurrentPane.tsx:156` is the OCR banner — different intent). Two valid + one drift; below threshold for now.
+- **`window.prompt` for passphrase (3 callsites):** all crypto-adjacent. ConfirmDialog migration must zero memory; track separately from rename-prompt usage (1 callsite, non-sensitive).
+- **`text-small text-fg-muted` (49 hits):** valid utility-class composition; only the standalone `<p>` form is candidate (StatusMessage). Do NOT extract a `<MutedText>` — that's premature abstraction.
+
+## Recommended slicing
+
+### Slice 1 — PanelHeader + SectionShell (highest ROI)
+- Candidates covered: `PanelHeader` component + `Section` density/padding default (or new `SectionShell` composing both).
+- Migration footprint: 18 panels touch `Section`; 25+ touch `PanelHeader`. Net ~30 panel-file rewrites of 1-2 lines each. No tests change.
+- Risk of breaking Wave 45 / Wave 46-pending / Wave 47-planned: **low**. Wave 45 shipped Section-internal patterns; PanelHeader is purely a chrome rename. Wave 46 closeout (the un-merged plan in working tree) and Wave 47 (per project notes) target signing/UX copy — neither touches panel scaffolding.
+- Rationale: every panel in the app reads from these two patterns. One PR collapses 25 + 18 hand-written class strings into two primitives, eliminates the most frequent style-drift target, and leaves a single edit-point for future density tweaks. Idiomatic and reversible.
+
+### Slice 2 — Card density/surface variants (collapse MiniCardListRow)
+- Candidates covered: extend `Card` with `density: comfortable|compact` and `surface: raised|sunken`. Migrates 5 raised + 3 sunken list-row callsites.
+- Migration footprint: 8 panel files (Templates, Library, Redline, PackManager ×2, CounterOffer, Annotations, AppCurrentPane).
+- Risk: **low-medium**. Card already has `variant="severity-…"` from Wave 45-A; adding two orthogonal props requires care that severity + density don't collide. Test matrix grows from 5 (severity) to 5 × 2 × 2 = 20. CounterOfferPanel renders inside Wave 47-planned counter-offer UX — coordinate with that plan.
+- Rationale: `Card` is the right home; the duplication is the most copy-pasted Tailwind string in the repo. Bundling MiniCardListRow into `Card density="compact"` keeps the primitive count flat.
+
+### Slice 3 — StatusMessage + ConfirmDialog (safety + a11y discipline)
+- Candidates covered: new `<StatusMessage tone live>` (17 callsites) and `<ConfirmDialog>` building on existing `Dialog` (6 callsites; ship primitive only, migrate one panel).
+- Migration footprint: ~17 small `<p role=…>` rewrites + 1 first ConfirmDialog adoption (suggest LibraryPanel rename — non-crypto, lowest risk). Crypto-passphrase migrations deferred to a follow-up wave with a memory-zero pattern.
+- Risk: **medium**. Live-region semantics are easy to over-announce; `StatusMessage` API must let callers opt out of the role when nested. ConfirmDialog touches the destructive-confirm gate that PR #173 just hardened — propose, don't ship blind. Crypto callsites must wait until passphrase memory handling is specified.
+- Rationale: closes the last meaningfully drift-prone surface (status messaging is currently 4 different className recipes) and replaces the last `window.confirm` / `window.prompt` blockers, aligning with both the Marginalia copy voice (Wave 45-D) and the error-discipline badge work just shipped in Wave 45-BE.

--- a/docs/plans/wave46-program-closeout.md
+++ b/docs/plans/wave46-program-closeout.md
@@ -1,0 +1,180 @@
+# Wave 46 — Wave-45 Program Closeout Implementation Plan
+
+**Goal.** Land the four code-level follow-ups deferred during the Wave 45 impeccable program: audit-log the signed-export event so the audit chain reflects what the UI claims, surface clipboard-write status for `Export public key`, add a SHA-256 fingerprint affordance to `SigningKeyPanel` so renters have a practical out-of-band verification artifact, and close the focus-containment gap left by Wave 45-F by applying `inert` to the background while a Dialog is open. After this wave, every clarify-pass copy claim shipped in 45-D maps to a code-verifiable behavior.
+
+**Architecture.** No new primitives. Item A extends `useAppCallbacks.onExportSignedJson` to emit a `safeAudit` event; the audit-log type union grows by one `kind`. Item B returns a discriminated status from `onExportPublicKey` and renders a transient `role="status"` confirmation in `SigningKeyPanel`. Item C adds a fingerprint row computed via `crypto.subtle.digest('SHA-256', rawPublicKeyBytes)` truncated to the first 4 bytes (8 hex chars) plus a copy affordance, then refreshes the signed-export disclosure copy in `AppCurrentPane/ResultsHeader.tsx` to reference fingerprint compare. Item D applies the `inert` HTML attribute to siblings of the open `<Dialog>` portal root inside the existing `Dialog` primitive — no API change.
+
+**Tech Stack.** React 18 + TypeScript strict, Tailwind v4, Vitest + RTL, Storybook 8 CSF, `crypto.subtle` (already used elsewhere in the audit chain).
+
+**Base SHA.** `origin/main` after Wave 45-BE merge. Verify `git fetch origin && git log origin/main --oneline -5` before branching; expected to include both `wave(45-c)` and `wave(45-be)` commits.
+
+**Prerequisites.** Wave 45 program fully merged: 45-A, 45-D, 45-F, 45-C, 45-BE. Verify with `git log origin/main --oneline | grep -E "Wave 45-[ABCDFE]" | wc -l` == 5.
+
+---
+
+## §1 Hard rules
+
+1. **One PR.** Whole wave on one feature branch `wave46-program-closeout`.
+2. **No new dependencies.** Reuse `safeAudit`, `crypto.subtle`, existing system/ primitives. The `inert` attribute is a baseline HTML platform feature; no polyfill.
+3. **Audit-event schema is additive.** Adding `kind: 'signed-export'` must not break existing `AuditLogPanel` rendering or hash-chain consistency checks. Verify by running the audit-chain test suite and asserting old entries still verify.
+4. **Fingerprint is informational, not authoritative.** The disclosure copy must say "compare the fingerprint your recipient sees against the one shown here" — it must NOT claim the fingerprint authenticates identity, just that mismatch is evidence of substitution. Plan for ≥3 Codex passes (per memory: crypto copy magnetizes adversarial findings).
+5. **`Export public key` clipboard status is per-attempt, transient.** The `role="status"` confirmation appears for ≤4 seconds after success; on failure (denied / no clipboard API), it stays until the next user action. Do not introduce a global toast system.
+6. **`inert` on Dialog background must not break existing `useFocusTrap` Tab-cycle tests.** The trap continues to govern Tab; `inert` only blocks programmatic `.focus()` and click-through from outside the dialog.
+7. **Real-browser a11y gate.** `npx playwright test tests/e2e/a11y.spec.ts` must pass — the `inert` change touches a11y semantics.
+8. **Local gate green** (`npm run typecheck && npm run lint && npm run test:coverage`) before push.
+9. **Codex adversarial gate** before `gh pr ready`. Findings on items A and C (crypto/audit copy) likely; address or escalate per project policy.
+
+## §2 Out of scope
+
+- Any new UI redesign in `AppCurrentPane/ResultsHeader` beyond the disclosure-copy refresh required by item C.
+- Migrating other clipboard call sites (annotations export, summary copy) to the same status pattern. This wave only touches `Export public key`.
+- Surfacing the fingerprint anywhere outside `SigningKeyPanel` and the signed-export disclosure (e.g., embedding in the signed-export filename or in `AuditLogPanel`). Defer to a Wave 47 ticket if requested.
+- Replacing `inert` with a polyfill for older browsers. The project already targets evergreen browsers per `browserslist`.
+- Closing the deferred `keys?` / `KeyHistoryEntry.fingerprint` plumbing the BACKLOG entry references — that's a separate refactor and not required to ship the user-visible fingerprint row here.
+
+## §3 Files in scope
+
+**Item A — Signed-export audit event:**
+- Modify: `app/src/App/useAppCallbacks.ts` (add `safeAudit` call site in `onExportSignedJson`)
+- Modify: `app/src/App/useAppCallbacks.test.ts`
+- Modify: the audit-event type union (search for the union; likely in `app/src/audit/types.ts` or similar — verify before edit)
+- Modify: `app/src/ui/AuditLogPanel.tsx` if the new `kind` needs explicit rendering; otherwise no UI change
+
+**Item B — Clipboard status for `Export public key`:**
+- Modify: `app/src/ui/SigningKeyPanel.tsx` (line 91 area — wrap the `onExportPublicKey` call site to track status)
+- Modify: the `signingKey.exportKeyToClipboard` implementation (find via grep; lives under `app/src/keys/` or similar)
+- Modify: `app/src/ui/SigningKeyPanel.test.tsx` (add success + clipboard-denied tests)
+- Modify: `app/src/ui/AppLibraryAndPacksPane.tsx:249` (caller may need to thread the status return)
+
+**Item C — Public-key fingerprint affordance:**
+- Modify: `app/src/ui/SigningKeyPanel.tsx` (add fingerprint row + copy button)
+- Create or modify: a small `app/src/keys/fingerprint.ts` with `computeShortFingerprint(rawPublicKeyBytes: Uint8Array): Promise<string>` returning 8 hex chars
+- Create: `app/src/keys/fingerprint.test.ts`
+- Modify: `app/src/ui/SigningKeyPanel.test.tsx` (assert fingerprint row + copy)
+- Modify: `app/src/ui/SigningKeyPanel.stories.tsx`
+- Modify: `app/src/ui/AppCurrentPane/ResultsHeader.tsx` (refresh signed-export disclosure copy to reference fingerprint compare)
+- Modify: `app/src/ui/AppCurrentPane/ResultsHeader.test.tsx`
+
+**Item D — Dialog `inert` background:**
+- Modify: `app/src/ui/system/Dialog.tsx` (apply/remove `inert` on body siblings while open)
+- Modify: `app/src/ui/system/Dialog.test.tsx` (assert background siblings receive `inert` while open and lose it on close)
+- Modify: `app/src/ui/system/Dialog.stories.tsx` if needed (probably no change)
+
+## §4 Execution
+
+**Direct, single-track.** Estimated 4-6 hours including tests + Codex passes. Items A → B → D → C in that order: A and B are the smallest and exercise familiar surfaces; D unblocks future Dialog work without UI change; C is the largest and the most likely to attract Codex findings, so it lands last with the wave's polish budget.
+
+### Item A — Signed-export audit event
+
+**Why.** Wave 45-D's clarify pass asserted in copy that signed-export events appear in the audit log. Codex's pass `20260429T135619Z` flagged that they do not — the signing path emits no `safeAudit` entry. The wave shipped with the copy weakened to describe only what the code records; the durable fix is to record the event.
+
+**Scope.**
+- Locate the audit-event type union (`grep -rn "kind: 'unsigned-export'\|kind: 'sign'" app/src` to find existing kinds).
+- Add `kind: 'signed-export'` with payload `{ fileName: string; format: 'json'; inputHash: string; signingKeyId: string }`. The `inputHash` is the SHA-256 of the unsigned payload (already computed during signing — reuse). The `signingKeyId` is the active key's id (already in scope inside `onExportSignedJson`).
+- In `useAppCallbacks.onExportSignedJson`, after the signed download succeeds, call `safeAudit({ kind: 'signed-export', ... })`.
+- If `AuditLogPanel` renders kind-specific labels, add a label for `signed-export` ("Signed export"); if it just shows raw kinds, no UI change is required.
+- Verify hash-chain consistency: existing audit entries chain by `prevHash` — adding a new kind appends to the chain, doesn't rewrite it. Existing entries verify unchanged.
+
+**Tests.**
+- `useAppCallbacks.test.ts`: add a test that `onExportSignedJson` emits exactly one `safeAudit` call with the expected shape.
+- Audit-chain consistency test: synthesize a chain with a `signed-export` entry interleaved with existing kinds; verify the chain still validates.
+- `AuditLogPanel.test.tsx`: if a label was added, assert it renders.
+
+**Commit.** `feat(46): emit signed-export audit event`.
+
+### Item B — Clipboard status for `Export public key`
+
+**Why.** The button at `SigningKeyPanel.tsx:91` calls `onExportPublicKey` (which calls `signingKey.exportKeyToClipboard`) and assumes success. `clipboard.writeText` can fail with `NotAllowedError` on permission denial or `undefined` `navigator.clipboard` on insecure contexts. Today's UI gives no feedback either way — the user could believe the key was shared when it wasn't, undermining the signed-export verification copy.
+
+**Scope.**
+- Update `signingKey.exportKeyToClipboard` to return `{ status: 'copied' } | { status: 'denied'; reason: string }` instead of a bare promise. Wrap the existing `clipboard.writeText` call in `try/catch`; map the catch to `denied` with the error message.
+- Update callers (`AppLibraryAndPacksPane.tsx:249`) to thread the status to `SigningKeyPanel` via a new `onExportResult` callback prop or by lifting the status to local state inside the panel itself. Choose the simpler: lift status into `SigningKeyPanel` local state by changing `onExportPublicKey` to return the status, and the panel renders the confirmation.
+- Render `<p role="status" className="text-small text-fg-muted mt-1">Public key copied to clipboard.</p>` for ≤4 seconds after success (use `useEffect` + `setTimeout`). On denial, render `<p role="status" className="text-small text-severity-high mt-1">Couldn't copy: {reason}. Copy the key manually from the field above.</p>` and persist until next user action (clearing on re-click).
+- Pair the failure message with `<Badge severity="high" label="Copy failed" />` (the 45-A primitive) per the discipline rule from 45-BE.
+
+**Tests.**
+- Mock `navigator.clipboard.writeText` to resolve → assert success status renders.
+- Mock to reject with `DOMException('NotAllowedError')` → assert failure status renders + badge.
+- Mock `navigator.clipboard` as `undefined` → assert failure status renders.
+
+**Commit.** `feat(46): surface clipboard status for Export public key + Badge pairing`.
+
+### Item D — Dialog `inert` background
+
+**Why.** Wave 45-F's `useFocusTrap` only governs Tab cycling. `App.tsx`'s `/` and Cmd+F keyboard shortcuts call `.focus()` directly on the findings search input, which can move focus *out* of an open Dialog, leaving the trap and the dialog's modal pretense out of sync. The platform answer is the `inert` HTML attribute: applied to background siblings of the dialog portal root, it blocks programmatic focus and pointer interaction without disturbing Tab semantics inside the dialog.
+
+**Scope.**
+- In `app/src/ui/system/Dialog.tsx`, on dialog open: enumerate `document.body.children`, mark every child whose subtree does NOT contain the dialog root with `inert = true`. On close: clear `inert` on those same siblings. Use a ref to remember which siblings were toggled (avoid stomping siblings that were already `inert` for other reasons).
+- Place this side effect adjacent to (not inside) `useFocusTrap` so the existing trap behavior is unchanged.
+- Update the Dialog story to demonstrate the inert behavior is non-visual (no story-level change usually needed).
+
+**Tests.**
+- `Dialog.test.tsx`: render Dialog inside a wrapper with two sibling `<div>`s; on open, assert both siblings have `inert` attribute; on close, assert neither does.
+- `Dialog.test.tsx`: assert that an attempt to call `.focus()` on a button inside an inert sibling does NOT move document.activeElement (browsers enforce this; jsdom may not — if jsdom doesn't, mark the test as `it.skip` with a comment pointing at the Playwright spec instead, and add the assertion to the existing `tests/e2e/a11y.spec.ts`).
+- Existing `useFocusTrap` Tab-cycle tests must continue to pass.
+
+**Commit.** `feat(46): apply inert to Dialog background siblings`.
+
+### Item C — Public-key fingerprint affordance + disclosure copy refresh
+
+**Why.** Wave 45-D's signed-export disclosure tells users to "share your public key with the recipient out-of-band; they compare it against the key embedded in the signed export." Comparing a full base64 ed25519 public key by eye is impractical for non-technical recipients. A short SHA-256 fingerprint (8 hex chars from the first 4 bytes) is the standard solution: short enough to read aloud over the phone, long enough that random collision is ~1 in 4 billion. Codex pass `20260429T135226Z` flagged the disclosure copy as overpromising the workflow given no fingerprint exists in the UI.
+
+**Scope.**
+- Create `app/src/keys/fingerprint.ts`:
+```ts
+export async function computeShortFingerprint(rawPublicKeyBytes: Uint8Array): Promise<string> {
+  const hash = await crypto.subtle.digest('SHA-256', rawPublicKeyBytes);
+  return Array.from(new Uint8Array(hash).slice(0, 4))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+```
+- In `SigningKeyPanel.tsx`, when `state.publicKey` is set, compute the fingerprint via `useEffect` (async, store in local state) and render a row:
+```tsx
+<div className="text-small text-fg-muted mt-2">
+  <span>Fingerprint: </span>
+  <code className="font-mono text-mono">{fingerprint ?? '...'}</code>
+  <Button type="button" variant="subtle" size="sm" onClick={() => copyFingerprint()}>
+    Copy
+  </Button>
+</div>
+```
+- The fingerprint copy affordance threads through the same status pattern from item B (success / denied feedback).
+- Refresh the disclosure body in `app/src/ui/AppCurrentPane/ResultsHeader.tsx` from the current "share your public key with the recipient" text to: "Share the 8-character fingerprint shown next to your signing key (Settings → Signing key) with the recipient out-of-band — phone, encrypted message, or paper. They compare it against the fingerprint shown after they verify the signed export. A match is evidence the file was signed by your key; a mismatch is evidence of substitution. Without this comparison step the export only verifies against its own embedded key, which an attacker could replace."
+- Confirm the new copy stays accurate against the implementation: every claim ("8-character fingerprint", "shown next to your signing key", "shown after they verify the signed export") must point at code that exists. The third claim presumes the verification UI also surfaces the fingerprint — verify in `OpenReviewPanel` / `OpenDeltaPanel` that this is true; if not, add fingerprint rendering there too inside this wave's scope.
+
+**Tests.**
+- `fingerprint.test.ts`: known-vector test (a hardcoded raw public key + its known short SHA-256 prefix).
+- `SigningKeyPanel.test.tsx`: assert the fingerprint row renders the computed value once async completes; assert copy affordance triggers the same status pattern.
+- `ResultsHeader.test.tsx`: assert the new disclosure copy matches verbatim (so future copy drift is caught by tests).
+- If verification panels (`OpenReviewPanel`, `OpenDeltaPanel`) gain fingerprint rendering: per-panel test that asserts the fingerprint appears alongside the verified-key block.
+
+**Commit (split into two for blame clarity).**
+1. `feat(46): add public-key fingerprint affordance in SigningKeyPanel`
+2. `clarify(46): refresh signed-export disclosure copy to reference fingerprint compare`
+
+### §5 Verification
+
+Before `gh pr ready`:
+
+1. `npm run typecheck && npm run lint && npm run test:coverage` — all green from `app/`.
+2. `npx playwright test tests/e2e/a11y.spec.ts` — all green (Dialog inert change + new SigningKeyPanel copy surfaces).
+3. `gh pr checks <pr>` — all green, no pending.
+4. Codex adversarial gate clean. Expected hot spots:
+   - Item A: does the audit event payload over-claim? (Specifically, the `inputHash` claim — verify it actually hashes the unsigned payload, not the signed envelope.)
+   - Item C: does the disclosure copy promise the verifier sees the fingerprint in the verification panel? If yes, ensure that's true; if not, drop the claim.
+   - Item D: does the `inert` cleanup leak — what happens if the Dialog unmounts without a close transition?
+
+### §6 Risk register
+
+- **Audit-chain hash drift** — item A appends a new entry kind. Verify with the existing chain-consistency test that prior entries still validate against their `prevHash`.
+- **Clipboard API surface differences** — Safari's `navigator.clipboard.writeText` requires user-gesture context and may reject silently. The denied-status path covers this, but verify in the Playwright spec that the click-handler chain is preserved (no async hop before `writeText`).
+- **`inert` on Dialog siblings catching React portal targets** — if the Dialog renders inside a portal whose root is itself a body-sibling, the cleanup must handle it. Test by including a portal in the Dialog test fixture.
+- **Fingerprint copy claims** — see hard rule §1.4. Plan for ≥3 Codex passes.
+
+### §7 Out-of-band notes
+
+- BACKLOG `### Wave 45-D follow-ups` and `### Wave 45-F follow-ups` sections fully consumed by this wave; promote those rows to §7 (Done) on merge.
+- No telemetry change.
+- No public types added beyond the audit-event union extension.
+- The wave's PR description must reference Codex run IDs `20260429T135619Z`, `20260429T135226Z`, and `20260429T124811Z` so the audit trail closes the loop.

--- a/docs/plans/wave47-renter-clarify-errors.md
+++ b/docs/plans/wave47-renter-clarify-errors.md
@@ -1,0 +1,179 @@
+# Wave 47 — Renter-Facing Errors and Confirmations Clarify Pass
+
+**Goal.** Land Slice 1 of the project-wide copy clarify inventory
+(`docs/audits/clarify-inventory-2026-04-29.md`): rewrite the renter-facing
+error and confirmation copy that sits on the destructive, signing, and
+review-archive paths. Replace the misnamed `friendlyError` passthrough
+with a real error-to-plain-string mapper, route four `window.prompt` /
+`window.confirm` callsites through the Wave 45-F `Dialog` primitive, and
+rewrite the `OpenReviewPanel.REASON_MESSAGES` table. After this wave,
+the highest-impact renter blockers — cryptic browser errors with no
+recovery hint, native browser dialogs in the destructive path, and
+"wrong-passphrase" copy that conflates passphrases with cryptographic
+keys — are gone.
+
+**Scope corresponds to:** inventory rows tagged Slice 1 — 5 High / 9
+Medium across `App/useAppCallbacks.ts`, `App/appHelpers.ts`,
+`OpenReviewPanel.tsx`, `ShareReviewPanel.tsx`, `CounterSignPanel.tsx`,
+`MarketplacePanel.tsx`, `DeltaPanel.tsx`, `i18n/messages.ts`,
+`SigningKeyPanel.tsx` (passphrase prompts only — Wave 45-D disclosure
+preserved), `AppCurrentPane.tsx` (OCR error structure only — Wave 45-D
+disclosure preserved).
+
+**Architecture.** No new primitives. Item A introduces
+`app/src/App/clarifyError.ts` — a small classifier that maps known error
+classes (`PdfPasswordError`, `PdfStructureError`, IDB quota, signing
+wrong-passphrase, clipboard-denied, fetch failures) to plain-language
+renter-facing strings; existing `friendlyError` callers migrate to
+`clarifyError(err, { context })`. Item B replaces four
+`window.prompt` / `window.confirm` callsites with the existing
+`Dialog` primitive from `src/ui/system/Dialog.tsx` plus the existing
+`Field` primitive for passphrase entry — no new components. Items C
+and D are pure copy rewrites in `OpenReviewPanel.REASON_MESSAGES`,
+`MarketplacePanel`, `DeltaPanel`, `CounterSignPanel`, `ShareReviewPanel`,
+`AppCurrentPane` (OCR error reflow), and `i18n/messages.ts`.
+
+**Tech Stack.** React 18 + TypeScript strict, Tailwind v4, Vitest +
+RTL + `user-event`, Storybook 8 CSF. No new dependencies.
+
+**Base SHA.** `origin/main` after Wave 46 (program closeout) merges.
+Verify `git fetch origin && git log origin/main --oneline -10` includes
+`wave(46): program closeout` before branching.
+
+**Prerequisites.** Wave 46 program-closeout merged (Dialog `inert` shipped
+in 46-D — needed because Item B mounts new Dialogs and the focus-
+containment test is the gate that catches regressions). Wave 45-F also
+required — `Dialog` and `FileButton` primitives are the foundation for
+Item B.
+
+---
+
+## §1 Hard rules
+
+1. **One PR.** Whole wave on one feature branch `wave47-renter-clarify-errors`.
+2. **No new dependencies.** Reuse `Dialog`, `Field`, `Button` system primitives. No new toast / global notification system.
+3. **Wave 45-D strings are immutable.** Do not modify: FindingsPanel similarity badge + aria-label, AuditLogPanel preamble, `AppCurrentPane`/`SigningKeyPanel` "What is signed export?" disclosure body, PackManagerPanel import-error string, OnboardingTour step 4 body. CI greps for the canonical strings — see §6.
+4. **`clarifyError` is purely additive.** Don't break callers that pass a non-Error. Add a fallback branch that returns `"Something went wrong. Please try again."` with the raw `String(err)` exposed only via `details` (not in the visible string). The existing `friendlyError` export stays as a one-line re-export to `clarifyError` for the duration of the wave; remove the old helper file in a follow-up only after grep confirms zero callers.
+5. **Dialog migration must preserve test behavior.** The four prompt/confirm sites have tests that mock `window.prompt` / `window.confirm`. Each test must be rewritten to drive the `Dialog` via RTL + `user-event` (open dialog → fill field → click confirm), not via `vi.spyOn(window, 'prompt')`. The `App.tsx` testing pattern in `docs/CLAUDE.md` calls these mocks out — update the §"Testing patterns" guidance in this PR to match.
+6. **Passphrase fields use `type="password"`, `autocomplete="new-password"` (create) / `"current-password"` (unlock), and a visible min-length helper text.** No floor enforcement in this wave beyond the existing `MIN_PASSPHRASE_LEN` server-side check — the helper text is the only behavioral change. (Promoting min-length to client-side `pattern` is a Wave 48 candidate.)
+7. **Destructive confirms name the target.** `clearAll` Dialog body must include the lease count ("Delete N saved leases?"). VersionHistoryPanel destructive-confirm gap from inventory row "VersionHistoryPanel.tsx:105-110" is **out of scope** here — file a backlog row, defer.
+8. **Real-browser a11y gate.** `npx playwright test tests/e2e/a11y.spec.ts` must pass — Item B introduces new Dialog mount points and the trap + `inert` (Wave 46-D) interaction is the failure mode this catches.
+9. **Local gate green** (`npm run typecheck && npm run lint && npm run test:coverage`) before push. Coverage on the new `clarifyError` mapper module: 100% (it's tiny — every branch covered).
+10. **Codex adversarial gate** before `gh pr ready`. Renter-facing error copy in signing/passphrase paths magnetizes findings (per `feedback_crypto_copy_must_match_code_exactly` memory). Plan ≥3 passes; every plain-language claim must map to a code-verifiable property.
+
+## §2 Out of scope
+
+- **Slices 2 and 3 of the inventory.** Audit-log kind→label adapter, OnboardingTour severity vocabulary fix, and the 15-string empty-state polish pass are deferred to Wave 48 / 49.
+- **CustomRuleBuilder regex-error rewrite** (inventory High in Slice 3). Practitioner-only surface, can ride Slice 3.
+- **VersionHistoryPanel destructive-confirm gap.** File a BACKLOG row; do not bundle.
+- **`useAppCallbacks.ts:60` HTTP-status leak in sample fetch.** Inventory High but tied to a fetch-failure branch only renters on the marketing path hit; covered by Item A's `clarifyError` mapper as a side effect — no separate item.
+- **Toast / global notification system.** Confirmations and errors stay scoped to their owning panel/Dialog. No app-wide event bus.
+- **Promoting `MIN_PASSPHRASE_LEN` to client-side validation.** Add helper text only. Hard validation is Wave 48.
+- **i18n locale coverage beyond the source `messages.ts`.** Locale files in `app/src/i18n/locales/` get the new keys; translation backfill is a separate ticket.
+
+## §3 Files in scope
+
+**Item A — `clarifyError` mapper:**
+- New: `app/src/App/clarifyError.ts`
+- New: `app/src/App/clarifyError.test.ts` (100% branch coverage)
+- Modify: `app/src/App/appHelpers.ts` (delete `friendlyError` body, re-export `clarifyError` for one wave)
+- Modify call sites that previously used `friendlyError`: grep `app/src/` for `friendlyError` and migrate each — likely `useAppCallbacks.ts`, `MarketplacePanel.tsx`, `DeltaPanel.tsx`, `PackManagerPanel.tsx`, `CounterSignPanel.tsx`, signing helpers.
+
+**Item B — Dialog migration of prompt/confirm:**
+- Modify: `app/src/App/appHelpers.ts:235` (`clearAll` `window.confirm` → Dialog confirm with count + lease names)
+- Modify: `app/src/App/appHelpers.ts:179, 204` (archive export + import passphrase prompts → Dialog with Field + min-length helper)
+- Modify: `app/src/ui/SigningKeyPanel.tsx:78, 102` (create + rotate passphrase prompts → Dialog with Field + recovery-loss warning)
+- Modify the corresponding tests in `appHelpers.test.ts` and `SigningKeyPanel.test.tsx` to drive Dialog via RTL, removing `vi.spyOn(window, 'prompt'|'confirm')` patterns
+- Update: `docs/CLAUDE.md` §"Testing patterns" — replace the prompt/confirm mock guidance with the Dialog-driven pattern
+
+**Item C — `OpenReviewPanel.REASON_MESSAGES` rewrite:**
+- Modify: `app/src/ui/OpenReviewPanel.tsx:15-18` (three message strings)
+- Modify: `app/src/ui/OpenReviewPanel.tsx:85-89` (split em-dash sentence; "mount as a non-editable session" → "open in read-only review mode"; "gated off" → plain language)
+- Modify: `app/src/ui/OpenReviewPanel.test.tsx`
+- Modify: `app/src/ui/OpenReviewPanel.stories.tsx` (re-snap stories with new copy if any visual gold)
+
+**Item D — Per-panel error and helper-text rewrites:**
+- Modify: `app/src/ui/CounterSignPanel.tsx:41` (default fallback "Sign failed" → recovery-hint string)
+- Modify: `app/src/ui/CounterSignPanel.tsx:50` ("Sign & export patch" → "Sign and send your decisions")
+- Modify: `app/src/ui/ShareReviewPanel.tsx:37` (passphrase length error → field helper text "16+ characters" rendered before submit)
+- Modify: `app/src/ui/ShareReviewPanel.tsx:62-65, 71` ("Generates an expiring, key-protected `.lgreview` file." + "Requires a signed pack to share." rewrites)
+- Modify: `app/src/ui/DeltaPanel.tsx:33` (raw `err.message` → `clarifyError(err, { context: 'delta-export' })`)
+- Modify: `app/src/ui/MarketplacePanel.tsx:54, 79` (manifest + install error fallbacks via `clarifyError`)
+- Modify: `app/src/ui/AppCurrentPane.tsx:178-183` (OCR error reflow — recovery first, raw reason in `<small>`; preserve Wave 45-D disclosure structure above)
+- Modify: `app/src/i18n/messages.ts:35, 41` (split `findings.empty` into pre/post-analyze keys; route `status.error` via `clarifyError` consumers)
+- Modify: corresponding `*.test.tsx` siblings for each panel above
+
+**Item E — Documentation refresh:**
+- Modify: `docs/audits/clarify-inventory-2026-04-29.md` — add a "Slice 1 shipped — Wave 47" header note pointing at the merged PR; do **not** modify rows (the inventory is the historical baseline).
+- Modify: `docs/CLAUDE.md` — testing-patterns guidance for Dialog-driven replacements (see §1.5).
+- Modify: `docs/BACKLOG.md` — add rows for the deferred items (VersionHistoryPanel confirm, MIN_PASSPHRASE_LEN promotion, Slice 2, Slice 3).
+
+## §4 Item ordering
+
+1. **A first.** `clarifyError` lands with full test coverage and one consumer migrated. This unblocks D since most D-items are one-line `clarifyError(err)` replacements.
+2. **D in parallel with A's tail.** Pure copy edits across panels — independent files, no merge conflicts.
+3. **C parallel with D.** `OpenReviewPanel` is a self-contained surface.
+4. **B last.** Dialog migration is the largest behavioral change and the riskiest test-rewrite. Land after A/C/D are green so a Dialog-trap regression isn't entangled with copy edits.
+5. **E last.** Doc/backlog refresh after code is green; updates the inventory header pointing at the merged PR.
+
+## §5 Storybook
+
+- `OpenReviewPanel.stories.tsx`: add a `WrongPassphrase` story that renders the new REASON_MESSAGES copy.
+- `SigningKeyPanel.stories.tsx`: add a `CreateKeyDialogOpen` story showing the Dialog with the new passphrase Field + recovery-loss warning.
+- `ShareReviewPanel.stories.tsx`: add a `PassphraseTooShort` story showing the helper text before submit.
+- `MarketplacePanel.stories.tsx`: add an `InstallFailed` story exercising the new fallback.
+
+(One new story per panel, mirroring Wave 45-A's pattern. The all-stories
+axe sweep in `src/ui/__tests__/all-stories.a11y.test.tsx` will pick them
+up automatically.)
+
+## §6 Verification gates
+
+1. **Inventory cross-check.** Every Slice 1 row in
+   `docs/audits/clarify-inventory-2026-04-29.md` either (a) has a code
+   change in this PR, (b) is explicitly listed in §2 Out of scope with
+   a backlog row, or (c) has a documented decision in the PR body.
+2. **Wave 45-D string protection.** A repo-grep gate (added to the verify
+   workflow or as a Vitest policy test under
+   `app/src/test/clarify-immutable.policy.test.ts`) asserts the canonical
+   Wave 45-D strings still appear verbatim. Tested strings: AuditLogPanel
+   preamble first sentence, AppCurrentPane signed-export disclosure
+   summary, FindingsPanel similarity-badge aria-label.
+3. **No native browser dialogs on renter paths.** Repo-grep policy test
+   asserts `window.prompt(` and `window.confirm(` no longer appear in
+   `app/src/App/appHelpers.ts` or `app/src/ui/SigningKeyPanel.tsx`. (Other
+   files may retain them transiently — Wave 48 can finish the sweep.)
+4. **`clarifyError` coverage.** Module hits 100% branch coverage in
+   `clarifyError.test.ts`.
+5. **Real-browser a11y gate.** `npx playwright test tests/e2e/a11y.spec.ts`
+   green — covers the four new Dialog mount points against axe + the
+   focus-trap × `inert` interaction landed in Wave 46-D.
+6. **Codex adversarial gate.** ≥3 passes; every plain-language error
+   claim maps to a code-verifiable property (e.g. "That passphrase
+   didn't unlock the file" must only fire on the `wrong-passphrase`
+   reason path, never on a structural decode failure).
+7. **Local gate.** `npm run typecheck && npm run lint && npm run test:coverage`
+   green; coverage floor unchanged.
+
+## §7 Risks and mitigations
+
+- **Test-rewrite churn from Dialog migration.** Mitigation: do Item B last; keep each rewrite to one file at a time; commit per file.
+- **Codex magnet on passphrase / signing copy.** Mitigation: per-string code-property mapping table in the PR body before the first Codex run; budget for 3 passes.
+- **Wave 45-D regression risk.** Mitigation: §6 gate #2 grep test runs in CI on every commit.
+- **Locale-file drift.** Mitigation: confine i18n changes to keys; existing locale files get the new keys with English fallbacks; backfill is a separate ticket.
+- **Subtle behavioral change in `clearAll` confirm.** The current `window.confirm` blocks the JS thread; a Dialog yields control. Mitigation: existing `clearAll` callers don't depend on synchronous return — verify before merging.
+
+## §8 Success definition
+
+Renter on the destructive / signing / review-archive paths sees, in this
+order:
+- A styled in-app Dialog (not a native browser prompt) for every
+  passphrase entry and every destructive confirm.
+- Plain-language error messages with a recovery hint on every failure
+  surface listed in Slice 1.
+- A passphrase field with visible "16+ characters" helper text **before**
+  they submit a too-short passphrase.
+
+Practitioner sees the same — practitioner views inherit the renter
+copy under the design north-star ("if the renter understands the screen,
+the practitioner can always go faster").

--- a/docs/plans/wave48-section-chrome-extract.md
+++ b/docs/plans/wave48-section-chrome-extract.md
@@ -1,0 +1,146 @@
+# Wave 48 — Section Chrome Extract: PanelHeader + Section Density
+
+**Goal.** Land Slice 1 of the project-wide design-system extract inventory
+(`docs/audits/extract-inventory-2026-04-29.md`): introduce a `PanelHeader`
+primitive in `app/src/ui/system/` and extend the existing `Section`
+primitive with a `density` prop that bakes the canonical
+`px-4 py-4 space-y-{2|3|4}` recipe. Migrate ~30 panel files (25+ h2/h3
+callsites + 18 Section padding callsites) to consume the new shape.
+After this wave, every panel in the app reads its title and section
+padding from the system, not from a hand-written class string — the
+single most-copy-pasted Tailwind recipe in the repo collapses to two
+primitives.
+
+**Scope corresponds to:** inventory rows tagged Slice 1 — `PanelHeader`
+component (25+ callsites) + `SectionShell` pattern (18 callsites,
+absorbed into `Section` via density prop rather than a new primitive).
+
+**Architecture.** Two changes in `app/src/ui/system/`:
+
+1. **New: `app/src/ui/system/PanelHeader.tsx`** — a minimal primitive
+   that renders the canonical `text-heading uppercase text-fg-muted`
+   header. Props: `{ as?: 'h2'|'h3'; mb?: 0|1|3; children: ReactNode;
+   className?: string }`. Default `as="h2"`, default `mb={3}`. The
+   `className` slot composes; it does not override the canonical chrome
+   tokens. Re-export from `app/src/ui/system/index.ts`.
+2. **Extend: `app/src/ui/system/Section.tsx`** — add a `density` prop
+   matching `SectionGroup`'s vocabulary: `'comfortable' | 'compact' |
+   'flush'`. `comfortable` (default) sets `px-4 py-4 space-y-3`;
+   `compact` sets `px-3 py-3 space-y-2`; `flush` sets `p-0 space-y-0`
+   for callers that already control their own padding. The existing
+   `label`/`aria-label` behavior stays unchanged (still not rendered).
+
+Migrations are 1-2 line edits per panel: replace
+`<h2 className="text-heading uppercase text-fg-muted mb-3">Title</h2>`
+with `<PanelHeader>Title</PanelHeader>`, and replace
+`<Section label="X" className="space-y-3 px-4 py-4">` with
+`<Section label="X">` (default density absorbs the padding).
+
+**Tech Stack.** React 18 + TypeScript strict, Tailwind v4, Vitest +
+RTL, Storybook 8 CSF. No new dependencies.
+
+**Base SHA.** `origin/main` after Wave 46 (program closeout) and Wave
+47 (renter clarify-errors) merge. Verify
+`git fetch origin && git log origin/main --oneline -10` includes both
+`wave(46): program closeout` and `wave(47): renter clarify errors`
+before branching. Wave 48 is independent of both content-wise but must
+rebase cleanly.
+
+**Prerequisites.** Waves 45 program (A/D/F/C/BE), 46, and 47 merged.
+Wave 47 doesn't touch panel chrome; Wave 46 touches `SigningKeyPanel` +
+`AppCurrentPane`'s ResultsHeader, which we'll need to thread through
+the new `PanelHeader` carefully (those panels have h2/h3 callsites).
+
+---
+
+## §1 Hard rules
+
+1. **One PR.** Whole wave on one feature branch `wave48-section-chrome-extract`.
+2. **No new dependencies.** Reuse Tailwind v4 + existing tokens. No new tokens; the inventory confirmed token surface is clean.
+3. **No visual regression.** Every migrated panel must render byte-identically to current main. CI gates: existing all-stories axe sweep (`src/ui/__tests__/all-stories.a11y.test.tsx`) + manual Storybook diff per migrated panel + the existing `no-side-stripe.policy.test.ts`.
+4. **Heading semantics preserved.** Every `<h2>` callsite maps to `PanelHeader as="h2"` (default); every `<h3>` callsite maps to `PanelHeader as="h3"` explicitly. Run `axe-core` story-driven sweep — the heading-order check (already enforced post-Wave 41) must stay green.
+5. **`PanelHeader` is chrome-only.** It MUST NOT accept severity / status / interactive props. Severity headers do not exist in this app. Section titles are calm; status lives in `<StatusMessage>` (deferred to Slice 3 / Wave 49+).
+6. **`Section` density default = `comfortable`.** Existing callers that pass `className="space-y-3 px-4 py-4"` collapse to no className. Existing callers that pass an unrelated className (e.g. `className="bg-paper-sunken"`) keep their className; the density prop only affects the padding/stack tokens. Verify no className still contains `space-y-` or `px-` / `py-` literals after migration.
+7. **Don't touch `SectionGroup`.** It already has the right vocabulary. The `density` prop on `Section` aligns with it; do not refactor `SectionGroup`.
+8. **Wave 45-D / 45-BE / 46 / 47 strings immutable.** No header text changes. This is a structural rename only — the rendered string and aria-label semantics stay byte-identical.
+9. **Local gate green** (`npm run typecheck && npm run lint && npm run test:coverage`) before push. Coverage on new `PanelHeader.tsx`: 100%.
+10. **Codex adversarial gate.** Chrome refactors usually attract 0–1 minor findings (className-shape edge cases). Budget 1–2 passes.
+11. **No `gh pr ready` while CI is red.** Per CLAUDE.md.
+
+## §2 Out of scope
+
+- **Slices 2 and 3 of the extract inventory.** Card density/surface variants (Slice 2) and StatusMessage + ConfirmDialog (Slice 3) are deferred to Wave 49 / 50. Slice 3's `ConfirmDialog` overlaps Wave 47's Dialog migration — re-scope after Wave 47 merges.
+- **Folding `PanelHeader` into `Section` as a `title` slot.** The inventory recommends shipping `PanelHeader` as its own primitive first, then optionally letting `Section` accept it as a slot in a follow-up. This wave keeps them separate.
+- **CustomRuleBuilder raw `<input>` migration to `Field`.** Cross-cutting observation in the inventory; that's a migration problem, not an extraction problem. Defer.
+- **State-hover / state-active token promotion.** Marginal token-alias suggestion in the inventory; no functional gain. Defer.
+- **EvidenceQuote / SeverityFilterChip / DiffSection extraction.** All sub-threshold per the inventory. Defer.
+- **`<ComparePanel>` migration to PanelHeader's h3 callsites for Added/Removed/Changed.** That panel just landed in Wave 45-C with an explicit shape; touching it again would re-enter the Codex review loop and push three Added/Removed/Changed h3s into a primitive that hasn't been validated against ComparePanel's ARIA structure. Migrate in a follow-up wave only after PanelHeader is stable.
+
+## §3 Files in scope
+
+**Item A — New primitive:**
+- New: `app/src/ui/system/PanelHeader.tsx`
+- New: `app/src/ui/system/PanelHeader.test.tsx` (props + axe sweep)
+- New: `app/src/ui/system/PanelHeader.stories.tsx` (h2 default, h3 variant, mb=0/1/3 variants)
+- Modify: `app/src/ui/system/index.ts` (re-export)
+
+**Item B — Section density extension:**
+- Modify: `app/src/ui/system/Section.tsx` (add `density` prop)
+- Modify: `app/src/ui/system/Section.test.tsx` (cover comfortable/compact/flush)
+- Modify: `app/src/ui/system/Section.stories.tsx` (add three density stories)
+
+**Item C — h2 callsite migrations (panel-level):**
+- Modify: `TemplatesPanel.tsx:59`, `BulkImportPanel.tsx:61`, `SeverityOverridesPanel.tsx:72,93`, `AuditLogPanel.tsx:29`, `HybridPrecisionPanel.tsx:35,64`, `LibraryPanel.tsx:35,45`, `JurisdictionPickerPanel.tsx:50,61`, `AppLibraryAndPacksPane.tsx:196`, `RedlinePanel.tsx:83,114`, `SigningKeyPanel.tsx:50`, `PackManagerPanel.tsx:99`, `PortfolioPanel.tsx:103,113`
+- Plus corresponding `*.test.tsx` siblings — most query by visible text, not by tag, so should stay green; verify per-file before batching.
+
+**Item D — h3 callsite migrations (sub-section):**
+- Modify: `LeaseFactsPanel.tsx:36,44`, `CounterOfferPanel.tsx:59,80`, `PortfolioRollupsPanel.tsx:28,36`, `AppCurrentPane.tsx:226`, `WorkflowPanel.tsx:37`, `TemplateMatchesPanel.tsx:26,33`, `AnnotationsPanel.tsx:39,66`
+- Plus corresponding tests.
+
+**Item E — Section padding-default migrations:**
+- Modify the 18 callsites listed in inventory §"Pattern candidates → SectionShell" — each loses `space-y-{2|3|4} px-4 py-4` from its className (or migrates to `density="compact"` where the original used `space-y-2`).
+
+**Item F — Documentation refresh:**
+- Modify: `docs/audits/extract-inventory-2026-04-29.md` — add a "Slice 1 shipped — Wave 48" header note pointing at the merged PR; do not modify the candidate rows.
+- Modify: `DESIGN.md` §5 Components — add a "Section Chrome" sub-section under Inputs/Fields with the `PanelHeader` + `Section density` recipes. Mention the canonical class string is now banned outside `system/`.
+- Modify: `docs/CLAUDE.md` §"Adding a panel" — replace the implicit "h2 with these classes" guidance with "use `<PanelHeader>` from system/".
+- Modify: `docs/BACKLOG.md` — add rows for the deferred items (Slices 2 and 3, ComparePanel h3 migration, EvidenceQuote re-evaluation post-Wave-47).
+
+## §4 Item ordering
+
+1. **A first.** Ship `PanelHeader` with full test + story + axe coverage. Independent.
+2. **B parallel with A.** `Section` density extension — independent file.
+3. **C, D, E in batches.** Migrate by directory cluster to keep diffs reviewable: pane shells (A* panels) first, then practitioner panels (Marketplace/PackManager/Portfolio/Redline), then renter panels (Library/Templates/Annotations/CounterOffer/etc.), then the small ones.
+4. **F last.** Doc/backlog refresh after code is green.
+
+## §5 Storybook
+
+- `PanelHeader.stories.tsx`: `Default` (h2, mb=3), `H3Variant` (h3, mb=1), `MbZero`, `LongTitle` (truncation behavior), `WithSecondaryActionRowSibling` (composition example).
+- `Section.stories.tsx`: add `Comfortable`, `Compact`, `Flush` stories alongside the existing label/aria stories.
+- The all-stories axe sweep picks them up automatically.
+
+## §6 Verification gates
+
+1. **Inventory cross-check.** Every Slice 1 row in the extract inventory either migrates in this PR or is explicitly listed in §2 Out of scope.
+2. **Class-string ban.** A repo-grep policy test (`app/src/test/panel-chrome-extract.policy.test.ts`) asserts that `text-heading uppercase text-fg-muted` does NOT appear in any `app/src/ui/*.tsx` outside `app/src/ui/system/`. Same test bans `space-y-3 px-4 py-4` (and the `space-y-2`/`space-y-4` variants) on `<Section>` elements outside `system/`.
+3. **Visual parity.** Storybook for each migrated panel renders identically to pre-migration (manual diff acceptable; no automated visual regression in this repo, but eyeball confirm before merge).
+4. **A11y gate.** `src/ui/__tests__/all-stories.a11y.test.tsx` green. Heading-order check unchanged. `npx playwright test tests/e2e/a11y.spec.ts` green.
+5. **Coverage.** `PanelHeader.tsx` 100% branch; `Section.tsx` density branches covered.
+6. **Local gate.** `npm run typecheck && npm run lint && npm run test:coverage` green; coverage floor unchanged.
+
+## §7 Risks and mitigations
+
+- **Default-density absorbs the wrong padding for one or two callers.** Mitigation: §6 #2 grep test fails loud if a `<Section>` still carries `px-/py-/space-y-` literals. Per-callsite review during migration.
+- **`mb` prop interferes with caller's flow gap.** Some callers wrap the header in a flex column with its own `gap-3`. Mitigation: default `mb={3}` matches today's most common pattern; callers that want zero set `mb={0}`. Document in the story.
+- **Heading-rank ambiguity in `Pane` wrappers that already promote.** Mitigation: every callsite explicitly passes `as="h2"|"h3"` per the inventory's existing mapping; do not infer from context.
+- **ComparePanel is intentionally excluded** — re-flagging it would re-enter Codex's review loop. Mitigation: §2 lists it as out of scope; backlog row tracks the follow-up.
+- **Wave 46 / Wave 47 rebase conflicts.** Both touch a few of the migrated files. Mitigation: rebase Wave 48 onto post-46-and-47 main; cherry-pick conflicts will be limited to the specific h2/Section lines those waves touched (e.g. SigningKeyPanel header survives Wave 46's Dialog edits, AppCurrentPane sub-component shape survives Wave 47).
+
+## §8 Success definition
+
+- Two primitives shipped: `PanelHeader` and `Section` density extension.
+- Zero panels in `app/src/ui/*.tsx` carry the canonical `text-heading uppercase text-fg-muted` class string outside `system/`.
+- Zero `<Section>` callers carry `space-y-{2|3|4} px-4 py-4` literals outside `system/`.
+- All-stories axe sweep + Lighthouse + Playwright a11y all green.
+- DESIGN.md §5 documents the new chrome recipe.
+- One follow-up backlog row each for Slice 2, Slice 3, ComparePanel migration, EvidenceQuote re-eval.


### PR DESCRIPTION
## Summary

Closes the four Wave-45 program follow-ups deferred during the impeccable program (per `docs/plans/wave46-program-closeout.md`):

- **Item A** — emit `signed-export` audit event from `onExportSignedJson` with payload `{ fileName, format, inputHash, signingKeyId }`. The `signingKeyId` is the 8-char SHA-256 fingerprint of the embedded public key; both fields are nullable when the upstream data is unavailable. `kind` is free-form per `audit/auditLog.ts` so no type union extension was needed (deviation from plan §3 noted).
- **Item B** — `exportKeyToClipboard` returns `{ status: 'copied' } | { status: 'denied'; reason }` instead of swallowing failures. SigningKeyPanel renders a transient `role=\"status\"` confirmation on success (4-second auto-clear) and a persistent error message paired with `<Badge severity=\"high\">` on failure.
- **Item C** — SHA-256 short fingerprint (8 hex chars, first 4 bytes) via new `app/src/security/fingerprint.ts`. SigningKeyPanel renders a fingerprint row with a Copy affordance reusing the Item B status pattern. Disclosure copy in `AppCurrentPane/ResultsHeader` refreshed to reference the fingerprint compare flow without promising a verifier UI we don't ship (Q1=option-1 scope decision: drop the verifier-side claim; recipient computes the same SHA-256 over the embedded `signature.publicKey` themselves).
- **Item D** — `inert` HTML attribute applied to body siblings of the Dialog portal root while open, blocking programmatic `.focus()` and pointer interaction without disturbing the existing `useFocusTrap` Tab semantics. Cleanup tracks pre-existing `inert` so we don't stomp values set by other layers.

Codex run IDs the wave addresses: `20260429T135619Z`, `20260429T135226Z`, `20260429T124811Z`.

## Test plan

- [x] `npm run typecheck` (clean)
- [x] `npm run lint` (clean)
- [x] `npm test -- --run` (189 files / 1641 passed / 0 errors)
- [ ] CI verify + smoke + Lighthouse + npm-audit
- [ ] Real-browser a11y: `npx playwright test tests/e2e/a11y.spec.ts`
- [ ] Codex adversarial gate (recommended ≥3 passes for crypto copy per `feedback_crypto_copy_must_match_code_exactly`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)