### PR TITLE
docs(50): perf probe + Wave 50 pipeline-fix plan

### DIFF
--- a/docs/audits/perf-probe-2026-04-29.md
+++ b/docs/audits/perf-probe-2026-04-29.md
@@ -1,0 +1,217 @@
+# LeaseGuard Performance Probe — 2026-04-29
+
+Browser-driven probe via `chrome-devtools-mcp` against `http://localhost:5173`
+(dev build). Three real public-source lease PDFs were sourced from
+`.gov` URLs in addition to the existing `app/public/sample.pdf`:
+
+| File | Size | Source |
+|---|---|---|
+| `sample.pdf` | 2 KB | Project synthetic fixture |
+| `consumer-gov-basic.pdf` | 162 KB | `consumer.gov` rental agreement basic |
+| `hud-90105a.pdf` | 266 KB | HUD form 90105a, model lease for subsidized programs |
+| `oklahoma-2025.pdf` | 222 KB | Oklahoma Real Estate Commission 2025 residential lease |
+
+Probe focus: cold-start Web Vitals (LCP / CLS), analyze-pipeline timing,
+console errors during the canonical upload-to-findings flow.
+
+---
+
+## TL;DR
+
+The cold-start metrics are good (LCP 387ms, CLS 0.00). The user-perceived
+slowness is the **analyze pipeline post-upload, which blocks for 17–25
+seconds on a 162 KB PDF in dev** because **pdf.js falls back to a
+"fake worker" running on the main thread**. That's the single highest-
+leverage finding. Several smaller issues compound: a malformed Source
+Serif 4 woff2 font that fails to decode, an `audit append failed
+QuotaExceededError` during typical use, multiple silent promise
+rejections, and stuck "Analyzing X" status when a new upload
+pre-empts an in-flight analyze.
+
+## Cold-start Web Vitals (navigation trace, dev build)
+
+```
+LCP:           387 ms
+LCP element:   <p> (H1 + tagline composite text); not fetched from network
+TTFB:           11 ms
+Render delay: 376 ms (97% of LCP time)
+CLS:           0.00
+```
+
+The 376 ms render delay is JS-bundle parse + initial React commit.
+**Acceptable on desktop; likely 2–3× on mid-range mobile.** No image
+or font is on the LCP critical path; reducing main-bundle JS or
+deferring non-critical reducers would shave the render-delay tail.
+
+## Critical findings (ranked by user impact)
+
+### 1. **pdf.js falls back to fake worker — main-thread parsing blocks UI for 15–25 s.** [HIGH]
+
+Console message at every upload: `Warning: Setting up fake worker.`
+
+pdf.js looks for a same-origin worker at the configured `workerSrc`
+URL. When it can't find one (CSP-mismatched, wrong public path, or
+missing register-call), it loads a "fake worker" that runs the entire
+parse on the main thread. That's exactly what's happening here:
+
+- `consumer-gov-basic.pdf` (162 KB, ~3 pages): analyze took ~17 s
+- Concurrent upload mid-analyze on `hud-90105a.pdf`: 25 s span and
+  the status display never caught up
+
+The architectural intent (per `docs/CLAUDE.md` "Build order" and
+"Data handling gotchas") is for parse + analyze to run inside the
+project's own `leaseWorker`, with pdf.js parsing inside that worker.
+The dev build is clearly NOT achieving that: pdf.js's own worker
+isn't running, so document parsing happens on the main thread, which
+serializes against React rendering, IDB writes, and the audit chain.
+
+**Fix surface:** verify `pdfjs.GlobalWorkerOptions.workerSrc` is set
+to the bundled pdf.worker chunk in `parseLease.ts` / `extractPages.ts`,
+and that the chunk is being served (the bundle budget says it's
+1.3 MiB so it exists, but evidently isn't being reached). Confirm
+behaviour matches in the production build (the bundled worker may
+work in `dist/` while the dev import chain breaks it). If the worker
+runs in production, this is a dev-only finding; if it doesn't,
+it's a real perf regression that's been in place since the worker
+was first added.
+
+### 2. **Stuck "Analyzing X" status when a new upload pre-empts.** [HIGH]
+
+Reproduce: upload `consumer-gov-basic.pdf`, immediately upload
+`hud-90105a.pdf` before the first analyze completes. The live
+region keeps reading "Analyzing consumer-gov-basic.pdf…" while the
+internal pipeline is on the new file. The status never updates.
+
+Root cause is almost certainly in `usePipeline.ts`: a single
+in-flight analyze isn't cancelled or its status overwritten when a
+new upload arrives. The user sees a stuck status and may believe
+the second upload was rejected. UX-blocking.
+
+**Fix surface:** `usePipeline` needs an `AbortController`-style
+guard or at minimum a `currentToken` ref that prefixes every
+`setStatus` so stale callbacks lose the race.
+
+### 3. **Source Serif 4 woff2 fails to decode.** [MEDIUM]
+
+```
+Failed to decode downloaded font: http://localhost:5173/fonts/source-serif-4-400.woff2
+OTS parsing error: invalid sfntVersion: 1008821359
+```
+
+DESIGN.md's "Serif-for-Substance Rule" requires the body type to be
+Source Serif 4. With this woff2 corrupted, every finding body and
+every long-form passage falls back to the platform serif (Iowan Old
+Style on macOS, Georgia elsewhere). Visual-fidelity regression that
+the design system contract specifically rejects.
+
+`sfntVersion: 1008821359` is the integer for ASCII `<htm` (or
+similar) — a strong signal the file is HTML (a 404/redirect page) or
+otherwise corrupted, not actual woff2 bytes. Probably regenerated by
+the wrong tool or the font subsetter writes a header it shouldn't.
+
+**Fix surface:** `app/public/fonts/source-serif-4-400.woff2` —
+re-fetch from the upstream Source Serif 4 release, verify with
+`woff2_decompress` or by opening as a font, ship the regenerated
+file. The 500 / 600 / italic variants may have the same issue;
+audit the whole font dir.
+
+### 4. **`audit append failed QuotaExceededError`.** [MEDIUM]
+
+```
+audit append failed QuotaExceededError
+```
+
+The audit chain hit IDB quota during typical local use. The
+`safeAudit` wrapper swallows the failure (per `docs/CLAUDE.md`
+"audit must never abort the caller"), so the user sees nothing,
+but every subsequent audit write also fails until storage frees
+up. The chain becomes lossy.
+
+Worth investigating: is this dev-only profile bloat (multi-day
+session, lots of test runs accumulating audit entries), or do
+production users hit it too over weeks of normal use? If
+production: we need a rotation policy on the audit log
+(`auditLog.rotation.test.ts` exists, suggesting one is partially
+designed). If dev-only: a reset hook on dev startup.
+
+### 5. **Multiple `Uncaught (in promise)` errors with no handler.** [MEDIUM]
+
+Three console errors during the upload flow with no message
+attached:
+
+```
+[error] Uncaught (in promise)
+[error] Uncaught (in promise)
+[error] Uncaught (in promise)
+```
+
+These are silent. Likely the same IDB-teardown rejections we've
+been swallowing in tests (Wave 45-BE, Wave 46), but in dev they
+hit user-visible console. Dev-loud / prod-quiet may be acceptable
+but worth confirming.
+
+### 6. **CSP `frame-ancestors` delivered via `<meta>`.** [LOW]
+
+```
+The Content Security Policy directive 'frame-ancestors' is ignored
+when delivered via a <meta> element.
+```
+
+Per W3C: `frame-ancestors` MUST be an HTTP response header to take
+effect. The current CSP is in `<meta>`. Move `frame-ancestors`
+into a vite dev-server header config (or, in prod, the static-host
+header config). Until then it's a no-op directive — clickjacking
+protection isn't actually enforced.
+
+## What was good
+
+- **CLS 0.00** through both reload + upload flows. Wave 33-A's
+  no-layout-shift claim holds under real input.
+- **TTFB 11 ms** (local dev). No server-rendering hop, no async
+  init blocking the document.
+- **No render-blocking network requests** in the cold-start
+  insight set.
+- **Analyze pipeline succeeds eventually** — every PDF reached an
+  analyzed state in tests; the issue is *time*, not correctness.
+
+## Probe limitations
+
+- **All measurements are dev-build, not production.** The dev
+  build doesn't tree-shake or chunk-split as aggressively, and
+  the pdf.js worker resolution may differ. Re-run against
+  `dist/` (built via `npm run build && npx serve dist/`) to
+  confirm finding #1 in production.
+- **No network throttling** applied. Real users on slow connections
+  would see a different LCP profile. Run with Lighthouse mobile
+  preset for a representative number.
+- **No memory baseline.** Heap-snapshot capture would show whether
+  multi-PDF sessions leak; deferred to a follow-up.
+- **No WCAG 1.4.3 contrast check.** That's the Playwright e2e a11y
+  spec's job (see `tests/e2e/a11y.spec.ts`).
+- **Couldn't measure INP** (no real interactions during the cold
+  navigation trace; uploads are file-input clicks, which don't
+  produce a Web Vitals INP fire).
+
+## Recommended slicing
+
+### Slice 1 — Restore the pdf.js worker (Critical Finding #1)
+
+- Investigate `parseLease.ts` / `extractPages.ts` for `GlobalWorkerOptions.workerSrc` registration.
+- Verify the bundled `pdf.worker.min.js` chunk is reachable in dev; fix the resolver if not.
+- Re-probe: confirm analyze drops from 17 s to expected 1–3 s on small PDFs.
+- Single PR; potentially 1–2 file changes, plus a regression test.
+
+### Slice 2 — Fix font + concurrent-upload UX
+
+- Re-source `source-serif-4-400.woff2` (and 500 / 600 / italic). Add a one-time CI check that the woff2 decodes (a 5-line script using `fontkit` or `woff2_decompress`).
+- Add a `currentToken`/`AbortController` guard to `usePipeline.ts` so a new upload cancels the prior analyze's status updates.
+- Bundle into one PR.
+
+### Slice 3 — Audit-log quota management + CSP header migration
+
+- Quota: design a rotation policy (cap entries, archive oldest to a separate `archived` store, surface in `AuditLogPanel` if approaching cap).
+- CSP: move `frame-ancestors` from `<meta>` to a Vite + production-host header.
+- Lower urgency than 1 + 2; can ride a future hygiene wave.
+
+Recommend **Slice 1 first** (highest impact) followed by **Slice 2**.
+Slice 3 has no user-perceived urgency.

--- a/docs/plans/wave50-perf-pipeline-fix.md
+++ b/docs/plans/wave50-perf-pipeline-fix.md
@@ -1,0 +1,144 @@
+# Wave 50 — Perf: Restore pdf.js Worker + Fix Concurrent Upload UX
+
+**Goal.** Land the two highest-impact findings from
+`docs/audits/perf-probe-2026-04-29.md`: restore the pdf.js worker so
+PDF parsing stops blocking the main thread (analyze pipeline drops
+from 15–25 s to an expected 1–3 s on small PDFs), and add an
+`AbortController`/token-guard to `usePipeline.ts` so a new upload
+pre-empts an in-flight analyze cleanly instead of leaving a stuck
+"Analyzing X" status. After this wave, the canonical upload-to-findings
+flow feels responsive and the live region tells the truth about which
+file is currently being processed.
+
+**Scope corresponds to:** perf-probe Slices 1 and 2.
+
+**Out of scope** (deferred to Wave 51 housekeeping or Slice 3 of the
+probe): font woff2 regeneration, audit-log quota rotation policy, CSP
+`frame-ancestors` header migration. Each is real but lower per-user
+impact and won't compound with the pipeline fix.
+
+**Architecture.** Two pillars, one PR.
+
+- **Pillar A (pdf.js worker restoration):** find where `pdfjs-dist` is
+  imported and the `GlobalWorkerOptions.workerSrc` should be set
+  (likely in `parser/parseLease.ts` or `parser/extractPages.ts`).
+  Confirm the bundled `pdf.worker.min.js` chunk is reachable; fix the
+  resolver if not. The fix is almost certainly a one-line `import
+  workerSrc from 'pdfjs-dist/build/pdf.worker.min.js?url'` plus
+  `pdfjs.GlobalWorkerOptions.workerSrc = workerSrc`. Add a regression
+  test that asserts no "Setting up fake worker" warning surfaces in
+  the test runner's console during a parse.
+- **Pillar B (pipeline pre-emption):** add a `currentTokenRef` to
+  `usePipeline.ts`. Every upload increments the token. Async
+  callbacks (`setStatus`, `safeAudit`, `pipeline.setError`) check
+  the token before firing; mismatched-token callbacks no-op. Same
+  pattern that resolves StrictMode double-invoked-effect races
+  elsewhere in the codebase.
+
+**Tech Stack.** React 18 + TypeScript strict, pdf.js, Vite 5, Vitest
++ RTL. No new dependencies.
+
+**Base SHA.** `origin/main` after Wave 49 merged (`eb4c67e`). Verify
+`git log origin/main --oneline -3 | grep "wave(49)"` before branching.
+
+**Prerequisites.** Wave 49 merged (`eb4c67e`). Wave 47 and 48 plans
+remain queued; Wave 50 is independent of both content-wise and should
+be sequenced wherever you have capacity. The pdf.js worker fix is
+self-contained enough to land before either of them.
+
+---
+
+## §1 Hard rules
+
+1. **One PR.** Whole wave on one feature branch `wave50-perf-pipeline-fix`.
+2. **No new dependencies.** Reuse existing `pdfjs-dist` and `?url`
+   import handling that Vite already provides for the OCR worker
+   chunk.
+3. **Pillar A must verify in production**, not just dev. Build via
+   `npm run build`, serve `dist/` locally, re-probe the same flow.
+   Confirm the "Setting up fake worker" message is gone AND analyze
+   times match the expected bounds.
+4. **Pillar B must not regress the existing "upload completes
+   correctly" path.** Tests in `usePipeline.test.ts` already cover
+   the happy path; add new tests for the pre-emption case, do not
+   weaken existing ones.
+5. **No behavioural change to the audit chain or signing path.**
+   `safeAudit` calls keep firing per the existing schedule; the
+   token guard wraps the *callback delivery*, not the IDB write.
+6. **Local gate green** (`npm run typecheck && npm run lint && npm
+   run test:coverage`) before push.
+7. **Real-browser perf re-probe** before merge. Open `dist/` in
+   Chrome via `chrome-devtools-mcp`, run the same upload flow used
+   in the original probe, capture timing. Document the before/after
+   numbers in the PR body.
+8. **No `gh pr ready` while CI is red.** Per CLAUDE.md.
+9. **Codex adversarial gate** before `gh pr ready`. The pre-emption
+   logic in Pillar B is exactly the kind of small async-correctness
+   change Codex catches well; budget 1–2 passes.
+
+## §2 Out of scope
+
+- **Font fix (`source-serif-4-400.woff2` decode failure).** Real
+  visual regression but design-fidelity, not perf. Defer to Slice 3
+  / Wave 51.
+- **Audit-log quota rotation.** Probe surfaced a
+  `QuotaExceededError` in dev; production exposure unclear. Needs
+  its own measurement + design discussion, not a quick fix.
+- **CSP `frame-ancestors` header migration.** Security finding,
+  separate concern from pipeline perf.
+- **OCR pipeline perf.** OCR is opt-in and already heavy by design;
+  separate wave.
+- **Bundle-size reduction (LCP render-delay tail).** 387 ms is
+  acceptable on desktop; mobile-tier work is its own initiative.
+- **Mobile/network throttled re-probe.** Run after this wave lands;
+  any more aggressive optimization should be measured against the
+  post-fix baseline, not the current dev-broken one.
+
+## §3 Files in scope
+
+**Pillar A — pdf.js worker:**
+- Modify: `app/src/parser/parseLease.ts` (set `pdfjs.GlobalWorkerOptions.workerSrc` if not already set, and via the right path)
+- Modify: `app/src/parser/extractPages.ts` (same — figure out which file owns the worker registration; likely just one)
+- Modify: `vite.config.ts` if needed (the `?url` import handling for `pdf.worker.min.js`)
+- Modify: `app/src/parser/parseLease.test.ts` — add a regression test that mocks `console.warn` and asserts "Setting up fake worker" never fires during a successful parse
+- Modify: relevant Storybook stories or `tests/e2e/smoke.spec.ts` if they exercise the parser
+
+**Pillar B — pipeline pre-emption:**
+- Modify: `app/src/App/usePipeline.ts` (add `currentTokenRef` + token-check on every async setState callsite)
+- Modify: `app/src/App/usePipeline.test.ts` (add: "second upload mid-analyze pre-empts the first; status reflects the second file; first file's setState callbacks no-op")
+- Modify: `app/src/App.test.tsx` if any cross-cutting test relies on the prior stuck-status behaviour (unlikely)
+
+**Documentation refresh:**
+- Modify: `docs/audits/perf-probe-2026-04-29.md` — add a "Slice 1 + 2 shipped — Wave 50" header note pointing at the merged PR.
+- Modify: `docs/BACKLOG.md` — promote findings #1 and #2 to `[x]`; file the deferred ones (#3 woff2, #4 audit quota, #5 silent rejections, #6 CSP header) under a "Wave 50 deferrals" section.
+
+## §4 Item ordering
+
+1. **Pillar A first.** Without the worker fix, perf measurements lie. Land + verify in production build before touching Pillar B.
+2. **Pillar B second.** Pre-emption logic is small and self-contained; lands cleanly on top of A.
+3. **Re-probe + doc refresh last.** PR body cites the new measured numbers.
+
+## §5 Verification gates
+
+1. **Console regression test.** During parse, `console.warn` is not called with `"Setting up fake worker"`. Asserted by Vitest.
+2. **Real-browser perf re-probe.** Build production bundle (`npm run build`), serve `dist/`, drive the upload flow through `chrome-devtools-mcp` for `consumer-gov-basic.pdf` (162 KB) and `hud-90105a.pdf` (266 KB). Capture trace; assert analyze time < 5 s for the small PDF, < 8 s for the medium one.
+3. **Pipeline pre-emption test.** `usePipeline.test.ts` covers: upload A; before A's analyze resolves, upload B; assert status reflects B, not A; assert A's late callbacks no-op (don't overwrite B's status).
+4. **Local gate.** `npm run typecheck && npm run lint && npm run test:coverage` green; coverage on `usePipeline.ts` does not regress.
+5. **CI.** `gh pr checks` all green, no pending. Lighthouse + smoke + verify + npm-audit clean.
+6. **Codex adversarial gate.** Clean by ≤2 passes. Pillar B's async-correctness logic is the likely magnet; pre-build a property table mapping every "after pre-emption, X must be true" claim to a code-verifiable assertion in tests.
+
+## §6 Risks and mitigations
+
+- **Worker fix exposes a different perf issue underneath.** With the worker actually running, analyze time may still be slow because the rules engine or shingle indexing is slow. Mitigation: re-probe and write down whatever the new bottleneck is; defer to a follow-up wave only if it exceeds expected bounds.
+- **Pillar B token guard masks a real bug.** If a callback that *should* fire is wrapped under the wrong token check, the user sees nothing. Mitigation: token check goes around UI updates only, never around audit writes or storage writes.
+- **Vite's `?url` import contract changed.** The `?url` query param in dev vs. prod produces different paths in some configurations. Mitigation: explicitly verify both `npm run dev` and `npm run build && serve dist/` render the same path.
+- **Workers have different module-loading rules under the project's CSP.** The CSP allows `worker-src 'self' blob:`. The bundled chunk needs to be served same-origin (it is); blob: is a fallback. If the worker still fails, the next move is to inline-bundle it via `?worker&inline` instead of `?url`.
+
+## §7 Success definition
+
+- Console no longer prints `"Setting up fake worker"` during a parse.
+- Real-browser probe shows analyze time on `consumer-gov-basic.pdf` drops from ~17 s to ≤ 3 s.
+- Uploading a second PDF mid-analyze updates the live region to the new filename within 100 ms.
+- `usePipeline.test.ts` covers the pre-emption case with at least one test.
+- `docs/audits/perf-probe-2026-04-29.md` gets a "Slice 1 + 2 shipped" header pointing at this PR's commit.
+- BACKLOG reflects current truth: findings #1 and #2 promoted to Done; #3, #4, #5, #6 filed as Wave 50 deferrals.


### PR DESCRIPTION
## Summary

Real-browser performance probe via \`chrome-devtools-mcp\` against the dev build, driven through the canonical upload-to-findings flow with three public-source lease PDFs (consumer.gov, HUD form 90105a, Oklahoma 2025 residential lease) plus the existing project \`sample.pdf\`.

**TL;DR**: cold-start fine (LCP 387ms, CLS 0.00), but the analyze pipeline blocks for **17-25 seconds on a 162 KB PDF** because pdf.js falls back to a 'fake worker' running on the main thread. Six findings ranked by user impact in \`docs/audits/perf-probe-2026-04-29.md\`.

Wave 50 plan in \`docs/plans/wave50-perf-pipeline-fix.md\` covers the two highest-impact slices:

1. **Restore pdf.js worker** — the worker registration is broken, parsing happens on main thread.
2. **Pipeline pre-emption** — concurrent uploads leave a stuck 'Analyzing X' status; \`usePipeline\` needs a token guard.

Three lower-impact findings (font woff2 corruption, audit-log quota, CSP \`frame-ancestors\` via meta) are explicitly deferred and can ride a future hygiene wave.

## Test plan

This PR is **docs-only** — no code changes. No test gates apply beyond CI's verify suite.

- [x] Probe executed; findings written
- [x] Wave 50 plan drafted
- [ ] CI verify + smoke + Lighthouse + npm-audit (will pass — no code changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)