### PR TITLE
wave(50): restore pdf.js worker + pipeline pre-emption

### DIFF
--- a/app/src/App/usePipeline.test.ts
+++ b/app/src/App/usePipeline.test.ts
@@ -88,6 +88,36 @@ describe('usePipeline', () => {
     expect(result.current.status.kind).toBe('error');
   });
 
+  // Wave 50 — pipeline pre-emption guard. Without the guard, A's late
+  // setStatus({kind:'analyzed', fileName:'first.pdf'}) overwrites B's
+  // 'loading' status and the live region reads the wrong filename.
+  it('upload pre-empts an in-flight analyze: late callbacks from the prior file no-op', async () => {
+    const { result } = renderHook(() => usePipeline());
+    const bytes1 = await makeBytes();
+    const bytes2 = await makeBytes();
+
+    // Start the first upload but do NOT await it. Its analyze pipeline
+    // will resolve some time after the second upload starts.
+    let firstUpload: Promise<void> | null = null;
+    await act(async () => {
+      firstUpload = result.current.upload(bytes1, 'first.pdf');
+      // Yield a microtask so React commits the 'loading' state for first.pdf,
+      // then start the second upload before the first finishes.
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.upload(bytes2, 'second.pdf');
+    });
+
+    // After both resolve, status MUST reflect the second upload.
+    if (firstUpload) await firstUpload;
+    await waitFor(() => expect(result.current.status.kind).toBe('analyzed'));
+    if (result.current.status.kind === 'analyzed') {
+      expect(result.current.status.fileName).toBe('second.pdf');
+    }
+  });
+
   it('auto-compares against the standard when one is set', async () => {
     // Seed a standard lease directly through storage.
     const std = await saveLease({

--- a/app/src/App/usePipeline.ts
+++ b/app/src/App/usePipeline.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { type AnalysisResult } from '../ui/analyzeFile';
 import { runOcr } from '../ocr/runOcr';
 import { analyze } from '../rules/analyze';
@@ -120,6 +120,12 @@ export function usePipeline(deps: UsePipelineDeps = {}): PipelineApi {
     null,
   );
 
+  // Wave 50 — every upload increments this token. Late callbacks from a
+  // previous upload (analyze finishes after a new file was selected) check
+  // the token and no-op if the user has moved on. Prevents the stuck
+  // "Analyzing X" status the perf probe surfaced.
+  const uploadTokenRef = useRef(0);
+
   const { onLibraryChange, rules, pipelineClient, audit } = deps;
   const activeRules = rules ?? RULE_PACK_V1;
 
@@ -131,6 +137,8 @@ export function usePipeline(deps: UsePipelineDeps = {}): PipelineApi {
 
   const upload = useCallback(
     async (bytes: Uint8Array, fileName: string): Promise<void> => {
+      const myToken = ++uploadTokenRef.current;
+      const isCurrent = (): boolean => uploadTokenRef.current === myToken;
       setStatus({ kind: 'loading', fileName });
       setComparisonState(null);
       try {
@@ -175,12 +183,15 @@ export function usePipeline(deps: UsePipelineDeps = {}): PipelineApi {
           findings: result.findings,
         });
         if (onLibraryChange) await onLibraryChange();
+        if (!isCurrent()) return;
         setStatus({ kind: 'analyzed', fileName, result, bytes, leaseId: newId });
 
         // Auto-compare against the standard, if one exists and it isn't this lease.
         const std = await getStandardId();
+        if (!isCurrent()) return;
         if (std && std !== newId) {
           const standard = await getLease(std);
+          if (!isCurrent()) return;
           if (standard) {
             setComparisonState({
               a: standard,
@@ -199,6 +210,7 @@ export function usePipeline(deps: UsePipelineDeps = {}): PipelineApi {
           }
         }
       } catch (err) {
+        if (!isCurrent()) return;
         setStatus({ kind: 'error', message: friendlyError(err) });
       }
     },

--- a/app/src/parser/extractPages.ts
+++ b/app/src/parser/extractPages.ts
@@ -1,5 +1,9 @@
 import type { PageText, TextItem } from './types';
 import { mapPdfError } from './errors';
+// Vite resolves `?url` to the bundled worker file URL (hashed in build, dev
+// path in dev). pdf.js uses this URL to spawn a real Web Worker for parsing
+// instead of falling back to the on-main-thread "fake worker" — Wave 50.
+import pdfWorkerUrl from 'pdfjs-dist/legacy/build/pdf.worker.mjs?url';
 
 type PdfjsModule = typeof import('pdfjs-dist/legacy/build/pdf.mjs');
 let pdfjsPromise: Promise<PdfjsModule> | null = null;
@@ -7,10 +11,9 @@ let pdfjsPromise: Promise<PdfjsModule> | null = null;
 async function loadPdfjs(): Promise<PdfjsModule> {
   if (!pdfjsPromise) {
     pdfjsPromise = (async () => {
-      await import('pdfjs-dist/legacy/build/pdf.worker.mjs');
       const mod = await import('pdfjs-dist/legacy/build/pdf.mjs');
       if (!mod.GlobalWorkerOptions.workerSrc) {
-        mod.GlobalWorkerOptions.workerSrc = 'pdfjs-dist/legacy/build/pdf.worker.mjs';
+        mod.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
       }
       return mod;
     })();
@@ -27,12 +30,7 @@ interface PdfTextItem {
 }
 
 function toTextItem(raw: unknown): TextItem | null {
-  if (
-    typeof raw !== 'object' ||
-    raw === null ||
-    !('str' in raw) ||
-    !('transform' in raw)
-  ) {
+  if (typeof raw !== 'object' || raw === null || !('str' in raw) || !('transform' in raw)) {
     return null;
   }
   const r = raw as PdfTextItem;
@@ -79,4 +77,3 @@ export async function extractPages(bytes: Uint8Array): Promise<PageText[]> {
   }
   return pages;
 }
-

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -2,3 +2,8 @@ declare module '*?raw' {
   const content: string;
   export default content;
 }
+
+declare module '*?url' {
+  const url: string;
+  export default url;
+}

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -19,7 +19,8 @@
   "include": [
     "src/**/*.ts",
     "../app/src/parser/**/*.ts",
-    "../app/src/rules/**/*.ts"
+    "../app/src/rules/**/*.ts",
+    "../app/src/vite-env.d.ts"
   ],
   "exclude": [
     "src/**/*.test.ts",

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -644,6 +644,15 @@ blob:` envelope. Done = `scripts/check-csp.mjs` stays green
       `20260429T124811Z`); shipped with this gap because mustFix=0 and
       the proper fix is non-trivial.
 
+### Wave 50 deferrals (filed after Wave 50 perf fix shipped)
+
+Slice 3 of `docs/audits/perf-probe-2026-04-29.md` was deferred when Wave 50 shipped the high-impact pair (pdf.js worker restoration + pipeline pre-emption). The remaining findings:
+
+- [ ] **`source-serif-4-400.woff2` fails to decode.** `OTS parsing error: invalid sfntVersion: 1008821359`. Body type falls back to platform serif (Iowan Old Style on macOS, Georgia elsewhere). Re-source the woff2 from upstream Source Serif 4 release; audit 500/600/italic variants too. Visual-fidelity regression DESIGN.md "Serif-for-Substance Rule" specifically rejects.
+- [ ] **`audit append failed QuotaExceededError`.** Audit chain hit IDB quota during typical local use; `safeAudit` swallows the failure so subsequent writes silently lose. Either rotation policy (the test file `auditLog.rotation.test.ts` suggests one is partially designed) or a dev-only reset hook. Investigate prod exposure first.
+- [ ] **Three `Uncaught (in promise)` errors during upload flow.** Likely the same IDB-teardown rejections we swallow in tests (Wave 45-BE, Wave 46) but that hit user-visible console in dev. Confirm prod-quiet vs dev-loud.
+- [ ] **CSP `frame-ancestors` via `<meta>` is a no-op.** Per W3C, must be HTTP response header. Move to Vite dev-server header config (and prod static-host header config). Until then clickjacking protection isn't enforced.
+
 ### Wave 47 / 48 / 49 deferrals (filed by Wave 49 backlog reconcile)
 
 **From `docs/audits/clarify-inventory-2026-04-29.md` (deferred from Wave 47 Slice 1):**


### PR DESCRIPTION
## Summary

Per `docs/plans/wave50-perf-pipeline-fix.md` (Slices 1 + 2 from `docs/audits/perf-probe-2026-04-29.md`).

**Pillar A — pdf.js worker.** The previous setup did a side-effect import of `pdf.worker.mjs` and assigned a bare module-specifier string to `GlobalWorkerOptions.workerSrc`. pdf.js can't fetch a module specifier as a worker URL, so it fell back to a 'fake worker' running on the main thread. Visible in console as `Setting up fake worker` at every parse. Symptom: **analyze pipeline blocking the UI for 17–25 s on a 162 KB lease** in the perf probe.

Fix: Vite's `?url` query resolves the bundled worker chunk's URL (hashed in build, dev-server path in dev). pdf.js can then spawn a real Web Worker. Adds the matching `*?url` module declaration to `vite-env.d.ts`.

**Pillar B — pipeline pre-emption.** Adds an upload-token ref to `usePipeline`. Each upload increments the token; post-await callbacks check `isCurrent()` before calling `setStatus` / `setComparisonState`. A new upload mid-analyze pre-empts the prior one cleanly: status reflects the new file, the prior analyze's late callbacks no-op. Closes the stuck-status UX bug the perf probe surfaced.

New test in `usePipeline.test.ts` covers the pre-emption case (upload A, start B before A's analyze resolves, assert final status reflects B).

**BACKLOG:** Slice 3 deferrals (woff2 corruption, audit quota, silent rejections, CSP header) filed under a 'Wave 50 deferrals' section.

## Verification

The plan's §5 gate #2 calls for a real-browser perf re-probe on the production build. Recommend running it after merge to confirm the analyze time drops from ~17 s to ≤ 3 s on `consumer-gov-basic.pdf`. Tooling: `npm run build && npx serve dist/` then drive via `chrome-devtools-mcp`.

## Test plan

- [x] `npm run typecheck` (clean)
- [x] `npm run lint` (clean)
- [x] `npm test -- --run` (189 files / 1642 passed / 0 errors)
- [ ] CI verify + smoke + Lighthouse + npm-audit
- [ ] Real-browser re-probe (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)