### PR TITLE
polish: brand-align exported HTML/PDF artifacts

### DIFF
--- a/app/src/App.panels.test.tsx
+++ b/app/src/App.panels.test.tsx
@@ -279,7 +279,9 @@ describe('App panel wire-ups', () => {
     render(<App />);
     await uploadLease('Handoff.pdf');
     await userEvent.click(screen.getByRole('button', { name: /download handoff zip/i }));
-    expect(aClicks).toContain('Handoff-handoff.zip');
+    // downloadHandoffZip lazy-imports the export module (polish: brand-align
+    // exports) so the anchor click fires after the dynamic import resolves.
+    await waitFor(() => expect(aClicks).toContain('Handoff-handoff.zip'));
     createSpy.mockRestore();
   });
 

--- a/app/src/App/appHelpers.ts
+++ b/app/src/App/appHelpers.ts
@@ -4,7 +4,6 @@ import type { IcsDateInput } from '../workflow/buildIcs';
 import { buildIcs } from '../workflow/buildIcs';
 import { extractLeaseFacts } from '../facts/extractFacts';
 import { buildHandoffZip } from '../workflow/buildHandoffZip';
-import { exportFindingsHtml } from '../storage/exportHtml';
 import { exportFindingsJson } from '../storage/exportReport';
 import type { LeaseDocument } from '../parser/types';
 import type { Finding } from '../rules/types';
@@ -59,11 +58,7 @@ export function downloadBlob(content: string, mime: string, filename: string): v
   triggerDownload(new Blob([content], { type: mime }), filename);
 }
 
-export function downloadBlobBytes(
-  bytes: Uint8Array,
-  mime: string,
-  filename: string,
-): void {
+export function downloadBlobBytes(bytes: Uint8Array, mime: string, filename: string): void {
   triggerDownload(new Blob([bytes as BlobPart], { type: mime }), filename);
 }
 
@@ -112,8 +107,13 @@ export function exportFindingsAsJson(input: AnalyzedExportInput): void {
   );
 }
 
-/** Trigger a printable-HTML export download for the current analysis. */
-export function exportFindingsAsHtml(input: AnalyzedExportInput): void {
+/**
+ * Trigger a printable-HTML export download for the current analysis.
+ * Lazy-imports the export module to keep its inline brand CSS out of the
+ * app shell — see `scripts/check-bundle-budget.mjs` shell-budget comment.
+ */
+export async function exportFindingsAsHtml(input: AnalyzedExportInput): Promise<void> {
+  const { exportFindingsHtml } = await import('../storage/exportHtml');
   downloadBlob(
     exportFindingsHtml({
       name: input.fileName,
@@ -137,15 +137,14 @@ export function buildIcsBytes(input: {
   const dates = leaseFactsToIcsDates(extractLeaseFacts(input.doc));
   if (dates.length === 0) return null;
   return {
-    bytes: new TextEncoder().encode(
-      buildIcs({ leaseName: input.fileName, dates }),
-    ),
+    bytes: new TextEncoder().encode(buildIcs({ leaseName: input.fileName, dates })),
     filename: `${stripPdfExt(input.fileName)}.ics`,
   };
 }
 
 /** Build the handoff zip (PDF + findings + readme) and trigger a download. */
-export function downloadHandoffZip(input: AnalyzedExportInput): void {
+export async function downloadHandoffZip(input: AnalyzedExportInput): Promise<void> {
+  const { exportFindingsHtml } = await import('../storage/exportHtml');
   const findingsJson = exportFindingsJson({
     name: input.fileName,
     doc: input.doc,
@@ -217,9 +216,7 @@ export async function importEncryptedArchiveFlow(
     await cb.onSuccess(payload.leases);
   } catch (err) {
     cb.onError(
-      err instanceof WrongPassphraseError
-        ? err.message
-        : `Import failed: ${friendlyError(err)}`,
+      err instanceof WrongPassphraseError ? err.message : `Import failed: ${friendlyError(err)}`,
     );
   }
 }

--- a/app/src/negotiation/sideLetter.ts
+++ b/app/src/negotiation/sideLetter.ts
@@ -37,9 +37,7 @@ function buildClauses(input: SideLetterInput): Clause[] {
     if (seen.has(edit.paragraphIndex)) continue;
     seen.add(edit.paragraphIndex);
     const section = input.sectionFor(edit.paragraphIndex);
-    const label = section
-      ? `Section ${section}`
-      : `Page N, \u00b6 ${edit.paragraphIndex + 1}`;
+    const label = section ? `Section ${section}` : `Page N, \u00b6 ${edit.paragraphIndex + 1}`;
     clauses.push({ label, before: edit.before, after: edit.after });
   }
   return clauses;
@@ -73,16 +71,17 @@ export function buildSideLetterHtml(input: SideLetterInput): string {
 <meta charset="utf-8">
 <title>${escapeHtml(leaseName)} \u00b7 side letter</title>
 <style>
-  body { font-family: system-ui, -apple-system, Segoe UI, sans-serif; max-width: 48rem; margin: 0 auto; padding: 2rem 1rem; color: #111; line-height: 1.55; }
-  h1 { margin-bottom: 0.25rem; }
-  .meta { color: #555; font-size: 0.9rem; margin-bottom: 2rem; }
+  /* Marginalia palette inlined. */
+  body { font-family: 'Source Serif 4', 'Iowan Old Style', Georgia, serif; background: #faf6ee; color: #4a3f25; max-width: 65ch; margin: 0 auto; padding: 2rem 1rem; line-height: 1.55; }
+  h1 { font-weight: 600; color: #2a2316; margin-bottom: 0.25rem; }
+  .meta { font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; color: #7a6f57; font-size: 0.8125rem; margin-bottom: 2rem; }
   ol.clauses li { margin-bottom: 1rem; }
-  .empty { color: #555; font-style: italic; }
+  .empty { color: #7a6f57; font-style: italic; }
   .sig { margin-top: 3rem; }
-  .sig .name { font-weight: 600; margin-bottom: 0; }
-  .sig .title { color: #555; margin-top: 0; }
+  .sig .name { font-weight: 600; color: #2a2316; margin-bottom: 0; }
+  .sig .title { font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; color: #7a6f57; margin-top: 0; }
   @media print {
-    body { max-width: none; padding: 0; }
+    body { background: transparent; max-width: none; padding: 0; }
     ol.clauses li { page-break-inside: avoid; }
   }
 </style>
@@ -100,8 +99,7 @@ export function buildSideLetterText(input: SideLetterInput): string {
   const { leaseName, leaseDate, signer } = input;
   const clauses = buildClauses(input);
   const header =
-    `Side Letter\n` +
-    `Re: ${leaseName}${leaseDate ? ` (dated ${leaseDate})` : ''}\n\n`;
+    `Side Letter\n` + `Re: ${leaseName}${leaseDate ? ` (dated ${leaseDate})` : ''}\n\n`;
   const body =
     clauses.length === 0
       ? 'No changes to propose.\n'

--- a/app/src/redline/redline.ts
+++ b/app/src/redline/redline.ts
@@ -90,14 +90,15 @@ export function buildRedlineHtml(input: BuildRedlineHtmlInput): string {
 <meta charset="utf-8">
 <title>${escapeHtml(leaseName)} \u00b7 LeaseGuard redline</title>
 <style>
-  body { font-family: system-ui, -apple-system, Segoe UI, sans-serif; max-width: 48rem; margin: 0 auto; padding: 2rem 1rem; color: #111; line-height: 1.55; }
-  h1 { margin-bottom: 0.25rem; }
-  .meta { color: #555; font-size: 0.9rem; margin-bottom: 2rem; }
+  /* Marginalia palette inlined: ins=Sage Note tint, del=Negative Red tint. */
+  body { font-family: 'Source Serif 4', 'Iowan Old Style', Georgia, serif; background: #faf6ee; color: #4a3f25; max-width: 65ch; margin: 0 auto; padding: 2rem 1rem; line-height: 1.55; }
+  h1 { font-weight: 600; color: #2a2316; margin-bottom: 0.25rem; }
+  .meta { font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; color: #7a6f57; font-size: 0.8125rem; margin-bottom: 2rem; }
   .para { margin: 0 0 1rem; }
-  ins { background: #e6ffed; text-decoration: none; color: #036400; padding: 0 0.1em; }
-  del { background: #ffeef0; color: #86181d; padding: 0 0.1em; }
+  ins { background: rgba(90, 122, 90, 0.18); text-decoration: none; color: #2a2316; padding: 0 0.1em; }
+  del { background: rgba(154, 48, 34, 0.16); color: #2a2316; padding: 0 0.1em; }
   @media print {
-    body { max-width: none; padding: 0; }
+    body { background: transparent; max-width: none; padding: 0; }
     .para { page-break-inside: avoid; }
     ins { background: transparent; color: #2a2316; text-decoration: underline; }
     del { background: transparent; color: #2a2316; text-decoration: line-through; }

--- a/app/src/storage/exportHtml.ts
+++ b/app/src/storage/exportHtml.ts
@@ -44,10 +44,7 @@ export function exportFindingsHtml(input: HtmlExportInput): string {
     `;
   }).join('');
 
-  const body =
-    findings.length === 0
-      ? '<p class="empty">No findings detected.</p>'
-      : sections;
+  const body = findings.length === 0 ? '<p class="empty">No findings detected.</p>' : sections;
 
   return `<!doctype html>
 <html lang="en">
@@ -55,16 +52,20 @@ export function exportFindingsHtml(input: HtmlExportInput): string {
 <meta charset="utf-8">
 <title>${escapeHtml(name)} · LeaseGuard findings</title>
 <style>
-  body { font-family: system-ui, -apple-system, Segoe UI, sans-serif; max-width: 48rem; margin: 0 auto; padding: 2rem 1rem; color: #111; line-height: 1.5; }
-  h1 { margin-bottom: 0.25rem; }
-  .meta { color: #555; font-size: 0.9rem; margin-bottom: 2rem; }
-  section.sev { border-top: 1px solid #ddd; padding-top: 1rem; margin-top: 1.5rem; }
-  section.sev-high h2 { color: #b00020; }
-  section.sev-medium h2 { color: #a35200; }
-  blockquote { border-left: 3px solid #ccc; padding-left: 0.75rem; color: #333; font-style: italic; }
-  .empty { color: #555; }
+  /* Marginalia palette inlined: exported HTML must render the same off any host. */
+  body { font-family: 'Source Serif 4', 'Iowan Old Style', Georgia, serif; background: #faf6ee; color: #4a3f25; max-width: 65ch; margin: 0 auto; padding: 2rem 1rem; line-height: 1.55; }
+  h1 { font-weight: 600; color: #2a2316; margin-bottom: 0.25rem; }
+  h2, h3 { font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; color: #2a2316; }
+  .meta { font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; color: #7a6f57; font-size: 0.8125rem; margin-bottom: 2rem; }
+  section.sev { border-top: 1px solid #d6cdb6; padding-top: 1rem; margin-top: 1.5rem; }
+  section.sev-high h2 { color: #b1442d; }
+  section.sev-medium h2 { color: #b8862c; }
+  section.sev-low h2 { color: #5a7a5a; }
+  section.sev-info h2 { color: #6b7b8c; }
+  blockquote { background: #f3eddc; border: 1px solid #d6cdb6; border-radius: 2px; margin: 0.5rem 0; padding: 0.5rem 0.75rem; color: #4a3f25; font-style: italic; }
+  .empty { color: #7a6f57; }
   @media print {
-    body { max-width: none; padding: 0; }
+    body { background: transparent; max-width: none; padding: 0; }
     section.sev { page-break-inside: avoid; }
   }
 </style>

--- a/app/src/test/no-side-stripe.policy.test.ts
+++ b/app/src/test/no-side-stripe.policy.test.ts
@@ -1,68 +1,92 @@
 // Wave 45-A — policy test enforcing DESIGN.md Don't #1 ("no side-stripe
-// borders > 1px"). Reads every JSX file under app/src/ui and fails the
-// suite if any className string contains a `border-l-N` or `border-r-N`
-// (or arbitrary-px equivalent) where N > 1.
+// borders > 1px"). Two passes:
 //
-// Single-px hairlines are allowed and are how the system signals
-// blockquote / mono quote stripes. Anything thicker is the legacy
-// pattern that this wave retired; the policy keeps it retired.
+//   1. JSX className side-stripes (`border-l-N` / `border-r-N`, N > 1)
+//      across every .tsx file under app/src/ui.
+//   2. Inline-CSS side-stripes (`border-left: Npx …` / `border-right:
+//      Npx …`, N > 1) across every .ts/.tsx file under app/src — catches
+//      the export-HTML codepath (redline, exportHtml, sideLetter) that
+//      the JSX-only sweep used to miss.
+//
+// 1px hairlines are allowed everywhere; anything thicker is the legacy
+// pattern this wave retired.
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-// vitest runs from the `app/` workspace root, so `process.cwd()` resolves
-// to `app/`. Avoid `import.meta.url` here — vite serves source files via
-// http-style URLs in the test environment, which trips fileURLToPath.
-const UI_ROOT = join(process.cwd(), 'src', 'ui');
+const SRC_ROOT = join(process.cwd(), 'src');
+const UI_ROOT = join(SRC_ROOT, 'ui');
 
-// border-l-2, border-l-3, …, border-l-99 (Tailwind shorthand)
-// border-l-[2px], border-l-[3px], …, border-l-[99px] (arbitrary)
-// Same patterns for border-r. Captures the offending number for assertion
-// output, not for any branch logic — the test fails on any match.
-const FORBIDDEN = /\bborder-(l|r)-(?:(\[[2-9]\d*px\])|([2-9]\d*))\b/g;
+// border-l-2, …, border-l-[3px], … and same for -r. Tailwind shorthand
+// or arbitrary-px. Captures the offending fragment for assertion output.
+const FORBIDDEN_TW = /\bborder-(l|r)-(?:(\[[2-9]\d*px\])|([2-9]\d*))\b/g;
+// border-left: 2px …, border-right: 3px …, etc. CSS strings inside .ts
+// files (the export codepath emits inline <style> blocks).
+const FORBIDDEN_CSS = /\bborder-(left|right)\s*:\s*[2-9]\d*px\b/g;
 
-function walk(dir: string, out: string[] = []): string[] {
+function walk(dir: string, out: string[] = [], extensions: readonly string[] = ['.tsx']): string[] {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     const s = statSync(full);
     if (s.isDirectory()) {
-      walk(full, out);
-    } else if (entry.endsWith('.tsx')) {
+      walk(full, out, extensions);
+    } else if (extensions.some((ext) => entry.endsWith(ext))) {
       out.push(full);
     }
   }
   return out;
 }
 
+interface Violation {
+  file: string;
+  line: number;
+  match: string;
+}
+
+function scan(files: string[], pattern: RegExp): Violation[] {
+  const violations: Violation[] = [];
+  for (const file of files) {
+    const text = readFileSync(file, 'utf8');
+    const lines = text.split('\n');
+    lines.forEach((line, i) => {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('//') || trimmed.startsWith('*')) return;
+      let m: RegExpExecArray | null;
+      pattern.lastIndex = 0;
+      while ((m = pattern.exec(line)) !== null) {
+        violations.push({
+          file: file.slice(file.indexOf('app/src/')),
+          line: i + 1,
+          match: m[0],
+        });
+      }
+    });
+  }
+  return violations;
+}
+
 describe("no-side-stripe policy (DESIGN.md Don't #1)", () => {
   it('no JSX file in app/src/ui uses border-l or border-r > 1px', () => {
-    const files = walk(UI_ROOT);
-    const violations: { file: string; line: number; match: string }[] = [];
-    for (const file of files) {
-      const text = readFileSync(file, 'utf8');
-      const lines = text.split('\n');
-      lines.forEach((line, i) => {
-        // Skip lines that are obviously comments (single-line // and block
-        // comment bodies). The policy targets className/string literals,
-        // and an inline regex inside a JSDoc is not a violation.
-        const trimmed = line.trim();
-        if (trimmed.startsWith('//') || trimmed.startsWith('*')) return;
-        let m: RegExpExecArray | null;
-        FORBIDDEN.lastIndex = 0;
-        while ((m = FORBIDDEN.exec(line)) !== null) {
-          violations.push({
-            file: file.slice(file.indexOf('app/src/')),
-            line: i + 1,
-            match: m[0],
-          });
-        }
-      });
-    }
+    const violations = scan(walk(UI_ROOT, []), FORBIDDEN_TW);
     if (violations.length > 0) {
       const summary = violations.map((v) => `  ${v.file}:${v.line} — ${v.match}`).join('\n');
       throw new Error(
         `Side-stripe policy violation(s):\n${summary}\n\nUse <Card variant="severity-…"> + <Badge variant="severity"> instead. See DESIGN.md §5 / §6.`,
+      );
+    }
+    expect(violations).toHaveLength(0);
+  });
+
+  it('no inline CSS string in app/src uses border-left/right > 1px', () => {
+    const files = walk(SRC_ROOT, [], ['.ts', '.tsx']).filter(
+      (f) => !f.endsWith('.test.ts') && !f.endsWith('.test.tsx') && !f.endsWith('.stories.tsx'),
+    );
+    const violations = scan(files, FORBIDDEN_CSS);
+    if (violations.length > 0) {
+      const summary = violations.map((v) => `  ${v.file}:${v.line} — ${v.match}`).join('\n');
+      throw new Error(
+        `Inline-CSS side-stripe violation(s):\n${summary}\n\nReplace with full-perimeter 1px hairline + tonal background, or remove the stripe entirely. See DESIGN.md §6 (No-Side-Stripe Rule).`,
       );
     }
     expect(violations).toHaveLength(0);

--- a/app/src/workflow/sideLetterPdf.ts
+++ b/app/src/workflow/sideLetterPdf.ts
@@ -26,6 +26,8 @@ const LINE_HEIGHT = 14;
 const BODY_SIZE = 11;
 const HEADING_SIZE = 18;
 const META_SIZE = 10;
+// DESIGN.md "No-Pure-Black Rule" — body text uses Ink Black (#2a2316), not rgb(0,0,0).
+const INK_BLACK = rgb(42 / 255, 35 / 255, 22 / 255);
 
 /**
  * Greedy word-wrap for a fixed-width column. pdf-lib has no built-in
@@ -98,7 +100,7 @@ export async function buildSideLetterPdf(input: SideLetterInput): Promise<Uint8A
       y: cursorY - size,
       size,
       font: f,
-      color: rgb(0, 0, 0),
+      color: INK_BLACK,
     });
     cursorY -= size + 4;
   }
@@ -114,7 +116,7 @@ export async function buildSideLetterPdf(input: SideLetterInput): Promise<Uint8A
         y: cursorY - size,
         size,
         font: f,
-        color: rgb(0, 0, 0),
+        color: INK_BLACK,
       });
       cursorY -= LINE_HEIGHT;
     }

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -644,6 +644,14 @@ blob:` envelope. Done = `scripts/check-csp.mjs` stays green
       `20260429T124811Z`); shipped with this gap because mustFix=0 and
       the proper fix is non-trivial.
 
+### Polish pass deferrals (filed 2026-04-29 by /impeccable polish)
+
+P2 visual items surfaced during the all-surfaces polish walk; deferred from the export-brand PR because they need real-browser confirmation before committing.
+
+- [ ] **Empty home state has 60% vacant viewport.** Pre-upload, the lower 60% of the viewport is blank. Reads as "broken," not "calm." Candidates: a quiet privacy dossier line, the local-first architecture diagram, or a single restrained closing line. Brand-aligned, low risk.
+- [ ] **Native file-chooser text leaks into the upload control.** Dark-mode walk shows raw "Choose File / No file chosen" platform text adjacent to the styled "Upload lease" label. Verify `FileButton` fully suppresses the native control's visual; if not, swap to a label-on-button pattern with `aria-describedby` for the file name.
+- [ ] **Bottom-strip "Clear all saved data" lacks destructive treatment.** DESIGN.md reserves Negative Red for irrecoverable errors. Apply `--color-negative` to the label inside the existing Subtle button shell, or escalate to a dedicated destructive variant on the Button primitive.
+
 ### Wave 50 deferrals (filed after Wave 50 perf fix shipped)
 
 Slice 3 of `docs/audits/perf-probe-2026-04-29.md` was deferred when Wave 50 shipped the high-impact pair (pdf.js worker restoration + pipeline pre-emption). The remaining findings:


### PR DESCRIPTION
## Summary
The export codepath (findings HTML, redline HTML, side-letter HTML, side-letter PDF) shipped its own inline styles with hard-coded GitHub-ish colors (`#111`, `#555`, `#b00020`, `#a35200`, GitHub-green `#e6ffed/#036400` for ins, GitHub-red `#ffeef0/#86181d` for del) and a 3px side-stripe blockquote — the absolute-banned pattern from DESIGN.md.

These are the most-shared LeaseGuard artifacts (renters hand them to landlords and counsel). They're now Marginalia-Edition-aligned: Source Serif 4 body, Aged Cream paper, Walnut Body text, Court Slate accent, Terracotta/Mustard/Sage/Stone severity, full-perimeter 1px hairline blockquote on Folded Page tint. Side-letter PDF body draws in Ink Black (`#2a2316`) instead of pure `rgb(0,0,0)` (No-Pure-Black Rule).

`exportFindingsHtml` is now lazy-imported from `appHelpers.ts` — keeps the brand CSS string out of the app shell per the budget file's own "refactor, not bump" guidance.

`no-side-stripe.policy.test.ts` gains a second pass that scans `.ts`/`.tsx` files for inline-CSS `border-left/right: Npx` (N>1). The existing JSX-classname sweep was a blind spot for the export codepath; this would have caught the 3px blockquote.

P2 visual items (empty-home vacancy, native file-chooser leak, destructive-action treatment) filed as polish-pass deferrals in `docs/BACKLOG.md` — they need browser-driven confirmation before committing.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` 1643 passed
- [x] `npm run build` + `npm run check:budget` green (shell shrank via lazy import)
- [x] New 2nd policy-test case fires on the 3px blockquote (verified pre-fix)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)