### PR TITLE
distill: hide LeaseFacts + TemplateMatches when empty

### DIFF
--- a/app/src/App.panels.test.tsx
+++ b/app/src/App.panels.test.tsx
@@ -227,10 +227,13 @@ async function uploadLease(name = 'lease.pdf'): Promise<void> {
 }
 
 describe('App panel wire-ups', () => {
-  it('renders the LeaseFacts panel after analysis', async () => {
+  it('hides the LeaseFacts panel when the synthetic lease has no extractable facts', async () => {
+    // Distill: LeaseFactsPanel renders nothing when isEmpty. The minimal
+    // makePdf fixture produces no rent / dates / definitions / cross-refs,
+    // so the rail correctly omits the panel.
     render(<App />);
     await uploadLease();
-    expect(screen.getByRole('region', { name: /lease facts/i })).toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: /lease facts/i })).not.toBeInTheDocument();
   });
 
   it('renders the WorkflowPanel with ics / copy / handoff buttons', async () => {

--- a/app/src/ui/LeaseFactsPanel.test.tsx
+++ b/app/src/ui/LeaseFactsPanel.test.tsx
@@ -18,11 +18,9 @@ function makeFacts(overrides: Partial<LeaseFacts> = {}): LeaseFacts {
 }
 
 describe('LeaseFactsPanel', () => {
-  it('renders an empty state when every fact is missing', () => {
-    render(<LeaseFactsPanel facts={makeFacts()} />);
-    expect(
-      screen.getByText(/no structured facts detected/i),
-    ).toBeInTheDocument();
+  it('renders nothing when every fact is missing (distill: hide-empty rail)', () => {
+    const { container } = render(<LeaseFactsPanel facts={makeFacts()} />);
+    expect(container).toBeEmptyDOMElement();
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 
@@ -120,25 +118,23 @@ describe('LeaseFactsPanel', () => {
   });
 
   it('does not render the definitions section when the list is empty', () => {
-    render(
-      <LeaseFactsPanel
-        facts={makeFacts({ termMonths: 12 })}
-      />,
-    );
+    render(<LeaseFactsPanel facts={makeFacts({ termMonths: 12 })} />);
     expect(screen.queryByRole('heading', { name: /definitions/i })).not.toBeInTheDocument();
   });
 
   it('does not render the cross-references section when the list is empty', () => {
-    render(
-      <LeaseFactsPanel
-        facts={makeFacts({ termMonths: 12 })}
-      />,
-    );
+    render(<LeaseFactsPanel facts={makeFacts({ termMonths: 12 })} />);
     expect(screen.queryByRole('heading', { name: /cross-references/i })).not.toBeInTheDocument();
   });
 
-  it('exposes an accessible region label', () => {
-    render(<LeaseFactsPanel facts={makeFacts()} />);
+  it('exposes an accessible region label when populated', () => {
+    render(
+      <LeaseFactsPanel
+        facts={makeFacts({
+          baseRent: { amount: 2500, currency: 'USD', raw: '$2,500', page: 1 },
+        })}
+      />,
+    );
     expect(screen.getByRole('region', { name: /lease facts/i })).toBeInTheDocument();
   });
 
@@ -153,9 +149,7 @@ describe('LeaseFactsPanel', () => {
         })}
       />,
     );
-    expect(
-      screen.getByRole('heading', { name: /rent schedule \(2\)/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /rent schedule \(2\)/i })).toBeInTheDocument();
     const scheduleTable = screen.getByRole('table', { name: /rent schedule/i });
     expect(within(scheduleTable).getByText('2026-01-01')).toBeInTheDocument();
     expect(within(scheduleTable).getByText('$1,030')).toBeInTheDocument();
@@ -178,8 +172,6 @@ describe('LeaseFactsPanel', () => {
 
   it('does not render the rent-schedule section when the list is missing or empty', () => {
     render(<LeaseFactsPanel facts={makeFacts({ termMonths: 12 })} />);
-    expect(
-      screen.queryByRole('heading', { name: /rent schedule/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /rent schedule/i })).not.toBeInTheDocument();
   });
 });

--- a/app/src/ui/LeaseFactsPanel.tsx
+++ b/app/src/ui/LeaseFactsPanel.tsx
@@ -17,7 +17,7 @@ interface LeaseFactsPanelProps {
   facts: LeaseFacts;
 }
 
-export function LeaseFactsPanel({ facts }: LeaseFactsPanelProps): JSX.Element {
+export function LeaseFactsPanel({ facts }: LeaseFactsPanelProps): JSX.Element | null {
   const rentSchedule = facts.rentSchedule ?? [];
   const isEmpty =
     facts.baseRent === null &&
@@ -30,14 +30,10 @@ export function LeaseFactsPanel({ facts }: LeaseFactsPanelProps): JSX.Element {
     facts.crossReferences.length === 0 &&
     rentSchedule.length === 0;
 
-  if (isEmpty) {
-    return (
-      <Section label="lease facts">
-        <h3 className="text-heading uppercase text-fg-muted mb-3">Lease facts</h3>
-        <p className="text-body text-fg-muted">No structured facts detected in this lease.</p>
-      </Section>
-    );
-  }
+  // Distill: a panel showing only "no structured facts detected" is noise.
+  // Hide it; the supporting rail collapses by one slot when extraction
+  // returns nothing usable.
+  if (isEmpty) return null;
 
   return (
     <Section label="lease facts" className="space-y-4">
@@ -88,10 +84,18 @@ export function LeaseFactsPanel({ facts }: LeaseFactsPanelProps): JSX.Element {
           <table aria-label="rent schedule" className="w-full text-body text-fg-body">
             <thead>
               <tr className="border-b border-rule">
-                <th scope="col" className="py-1 pr-3 text-left text-small text-fg-muted font-sans">From</th>
-                <th scope="col" className="py-1 pr-3 text-left text-small text-fg-muted font-sans">To</th>
-                <th scope="col" className="py-1 pr-3 text-left text-small text-fg-muted font-sans">Amount</th>
-                <th scope="col" className="py-1 text-left text-small text-fg-muted font-sans">Escalator</th>
+                <th scope="col" className="py-1 pr-3 text-left text-small text-fg-muted font-sans">
+                  From
+                </th>
+                <th scope="col" className="py-1 pr-3 text-left text-small text-fg-muted font-sans">
+                  To
+                </th>
+                <th scope="col" className="py-1 pr-3 text-left text-small text-fg-muted font-sans">
+                  Amount
+                </th>
+                <th scope="col" className="py-1 text-left text-small text-fg-muted font-sans">
+                  Escalator
+                </th>
               </tr>
             </thead>
             <tbody className="divide-y divide-rule">
@@ -129,7 +133,9 @@ interface FactRowProps {
 function FactRow({ label, value }: FactRowProps): JSX.Element {
   return (
     <tr>
-      <th scope="row" className="py-1 pr-4 text-left text-small text-fg-muted font-sans w-40">{label}</th>
+      <th scope="row" className="py-1 pr-4 text-left text-small text-fg-muted font-sans w-40">
+        {label}
+      </th>
       <td className="py-1 text-body text-fg-body font-sans">{value}</td>
     </tr>
   );

--- a/app/src/ui/TemplateMatchesPanel.test.tsx
+++ b/app/src/ui/TemplateMatchesPanel.test.tsx
@@ -32,9 +32,9 @@ describe('classifyMatch', () => {
 });
 
 describe('TemplateMatchesPanel', () => {
-  it('renders an empty-state message when there are no matches', () => {
-    render(<TemplateMatchesPanel matches={[]} />);
-    expect(screen.getByText(/no clause templates to compare/i)).toBeInTheDocument();
+  it('renders nothing when there are no matches (distill: hide-empty rail)', () => {
+    const { container } = render(<TemplateMatchesPanel matches={[]} />);
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('renders a matched badge and the snippet when score is high', () => {

--- a/app/src/ui/TemplateMatchesPanel.tsx
+++ b/app/src/ui/TemplateMatchesPanel.tsx
@@ -19,15 +19,10 @@ export function TemplateMatchesPanel({
   matches,
   matchedThreshold = 0.7,
   weakThreshold = 0.4,
-}: TemplateMatchesPanelProps): JSX.Element {
-  if (matches.length === 0) {
-    return (
-      <Section label="template matches">
-        <h3 className="text-heading uppercase text-fg-muted mb-3">Template matches</h3>
-        <p className="text-body text-fg-muted">No clause templates to compare against.</p>
-      </Section>
-    );
-  }
+}: TemplateMatchesPanelProps): JSX.Element | null {
+  // Distill: when there are no clause templates to compare against (the
+  // default for fresh users), don't render a panel that only says so.
+  if (matches.length === 0) return null;
   return (
     <Section label="template matches" className="space-y-2">
       <h3 className="text-heading uppercase text-fg-muted mb-3">Template matches</h3>

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -644,6 +644,14 @@ blob:` envelope. Done = `scripts/check-csp.mjs` stays green
       `20260429T124811Z`); shipped with this gap because mustFix=0 and
       the proper fix is non-trivial.
 
+### Distill pass deferrals (filed 2026-04-29 by /impeccable distill)
+
+The distill pass on the right-rail supporting context shipped the two highest-ROI moves (hide-empty for `LeaseFactsPanel` and `TemplateMatchesPanel`). The remaining surfaces from the distill triage were evaluated and deferred — each requires a flow / IA decision that wasn't unilateral.
+
+- [ ] **THIS LEASE / LIBRARY / GOVERNANCE accordion shell.** Three full-width disclosure bars where one nests Compare + Custom Rule Builder + Hybrid Precision sub-panels. Structure-on-structure. Distill candidates: collapse to a single density-toggle, hide GOVERNANCE on first-run until a destructive action is needed, or split LIBRARY contents into a top-level tab. Needs a flow decision: which sections does the renter actually need vs. the practitioner.
+- [ ] **Findings filter chips (4 severity + 4 category, all pressed by default).** The default state is "all visible," so chips do nothing on first paint. Distill candidates: collapse into one disclosure, only render category chips when ≥2 categories present, or surface as a single "Filter…" button that opens an inline sheet. Risk: this is the practitioner-density affordance — the dense bar may be the feature, not the noise. Validate with a practitioner before changing.
+- [ ] **Combine empty `AnnotationsPanel` + `CounterOfferPanel` into one selection-bound section.** Both currently render their own heading + "click a finding" hint when no finding is selected. Combine into a single "Notes & counter-offers" panel with one shared hint, expanding into both forms once selected. Requires shared state model and discoverability decision (how does the renter learn both affordances exist).
+
 ### Wave 50 deferrals (filed after Wave 50 perf fix shipped)
 
 Slice 3 of `docs/audits/perf-probe-2026-04-29.md` was deferred when Wave 50 shipped the high-impact pair (pdf.js worker restoration + pipeline pre-emption). The remaining findings:


### PR DESCRIPTION
## Summary
The right-rail supporting context under a loaded lease stacks five panels (Notes, Counter-offers, Template matches, Lease facts, Workflow). For a fresh user with a typical lease, two of those render only sentinels — "No structured facts detected" and "No clause templates to compare against" — so the renter sees four panel headings with little or no content.

Hide both panels when their data is empty. The rail collapses from five panels to three (Notes, Counter-offers, Workflow) on first paint and back up the moment there's something to say.

## What the renter sees
| Before | After |
|---|---|
| 5 stacked panels (Notes / Counter-offers / Template matches / Lease facts / Workflow), with two showing only "no X to display" placeholders | 3 panels (Notes, Counter-offers, Workflow). The two data-driven panels reappear when there's something in them. |

## Diminishing returns
The distill triage surfaced four candidates: hide-empty (this PR), the THIS LEASE / LIBRARY / GOVERNANCE accordion shell, the findings filter chips, and a Notes+Counter-offers selection-empty merge. Hide-empty is mechanical and risk-free; the other three each require a flow / IA decision that is not unilateral. They're filed in `docs/BACKLOG.md` under "Distill pass deferrals" with the specific candidates and risks for each.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` 1642 passed
- [x] `npm run build` + `npm run check:budget` green
- [x] Updated unit tests assert the new "render nothing when empty" contract
- [x] `App.panels.test.tsx` re-targeted to verify hide behavior on empty fixture
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)