### PR TITLE
test: cover storeZip + customRuleDraft

### DIFF
--- a/app/src/ui/customRuleDraft.test.ts
+++ b/app/src/ui/customRuleDraft.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildDraftRule,
+  validateDraftRule,
+  regexCompileError,
+  EMPTY_DRAFT,
+  SEVERITIES,
+  CATEGORIES,
+  MATCHER_TYPES,
+  LEAF_MATCHER_TYPES,
+  type CustomRuleDraftForm,
+} from './customRuleDraft';
+
+function draft(overrides: Partial<CustomRuleDraftForm>): CustomRuleDraftForm {
+  return { ...EMPTY_DRAFT, ...overrides };
+}
+
+describe('customRuleDraft constants', () => {
+  it('exports the four canonical severities', () => {
+    expect(SEVERITIES).toEqual(['high', 'medium', 'low', 'info']);
+  });
+
+  it('exports all rule-engine categories', () => {
+    expect(CATEGORIES).toContain('general');
+    expect(CATEGORIES).toContain('termination');
+    expect(CATEGORIES).toContain('liability');
+  });
+
+  it('lists the three top-level matcher types', () => {
+    expect(MATCHER_TYPES).toEqual(['regex', 'keywordProximity', 'sectionAnchored']);
+  });
+
+  it('restricts leaf matcher types to regex + keywordProximity', () => {
+    expect(LEAF_MATCHER_TYPES).toEqual(['regex', 'keywordProximity']);
+  });
+
+  it('seeds an empty draft with sensible defaults', () => {
+    expect(EMPTY_DRAFT.severity).toBe('medium');
+    expect(EMPTY_DRAFT.matcherType).toBe('regex');
+    expect(EMPTY_DRAFT.regexFlags).toBe('i');
+    expect(EMPTY_DRAFT.windowRaw).toBe('60');
+  });
+});
+
+describe('buildDraftRule — regex matcher', () => {
+  it('builds a regex rule with the form pattern + flags', () => {
+    const rule = buildDraftRule(
+      draft({
+        id: 'auto-renew',
+        title: 'Auto-renew',
+        explanation: 'Detects auto-renewal language.',
+        severity: 'high',
+        category: 'termination',
+        matcherType: 'regex',
+        regexPattern: 'auto[- ]?renew',
+        regexFlags: 'i',
+      }),
+    );
+    expect(rule.id).toBe('auto-renew');
+    expect(rule.severity).toBe('high');
+    expect(rule.category).toBe('termination');
+    expect(rule.match).toEqual({
+      type: 'regex',
+      pattern: 'auto[- ]?renew',
+      flags: 'i',
+    });
+    expect(rule.citation).toBeNull();
+  });
+
+  it('omits flags when the form leaves them empty', () => {
+    const rule = buildDraftRule(
+      draft({ matcherType: 'regex', regexPattern: 'foo', regexFlags: '' }),
+    );
+    expect(rule.match).toEqual({ type: 'regex', pattern: 'foo' });
+  });
+});
+
+describe('buildDraftRule — keywordProximity matcher', () => {
+  it('parses the comma-separated keyword list and trims whitespace', () => {
+    const rule = buildDraftRule(
+      draft({
+        matcherType: 'keywordProximity',
+        keywordsRaw: ' jury , waive , rights ',
+        windowRaw: '40',
+      }),
+    );
+    expect(rule.match).toEqual({
+      type: 'keywordProximity',
+      keywords: ['jury', 'waive', 'rights'],
+      window: 40,
+    });
+  });
+
+  it('drops empty entries from the keyword CSV', () => {
+    const rule = buildDraftRule(
+      draft({
+        matcherType: 'keywordProximity',
+        keywordsRaw: 'a,,b, ,c',
+        windowRaw: '60',
+      }),
+    );
+    expect(rule.match).toMatchObject({ keywords: ['a', 'b', 'c'] });
+  });
+
+  it('coerces a non-numeric window to 0', () => {
+    const rule = buildDraftRule(
+      draft({
+        matcherType: 'keywordProximity',
+        keywordsRaw: 'a,b',
+        windowRaw: 'NaN-ish',
+      }),
+    );
+    expect(rule.match).toMatchObject({ window: 0 });
+  });
+});
+
+describe('buildDraftRule — sectionAnchored matcher', () => {
+  it('nests a regex child under the heading pattern', () => {
+    const rule = buildDraftRule(
+      draft({
+        matcherType: 'sectionAnchored',
+        headingPattern: '^indemnification',
+        childType: 'regex',
+        regexPattern: 'tenant shall',
+        regexFlags: 'i',
+      }),
+    );
+    expect(rule.match).toEqual({
+      type: 'sectionAnchored',
+      headingPattern: '^indemnification',
+      child: { type: 'regex', pattern: 'tenant shall', flags: 'i' },
+    });
+  });
+
+  it('nests a keywordProximity child', () => {
+    const rule = buildDraftRule(
+      draft({
+        matcherType: 'sectionAnchored',
+        headingPattern: '^arbitration',
+        childType: 'keywordProximity',
+        keywordsRaw: 'binding,arbitration',
+        windowRaw: '30',
+      }),
+    );
+    expect(rule.match).toMatchObject({
+      type: 'sectionAnchored',
+      headingPattern: '^arbitration',
+      child: {
+        type: 'keywordProximity',
+        keywords: ['binding', 'arbitration'],
+        window: 30,
+      },
+    });
+  });
+});
+
+describe('buildDraftRule — optional metadata', () => {
+  it('includes jurisdictions only when the CSV is non-empty', () => {
+    const withJ = buildDraftRule(
+      draft({ matcherType: 'regex', regexPattern: 'x', jurisdictionsRaw: 'CA, NY' }),
+    );
+    expect(withJ.jurisdictions).toEqual(['CA', 'NY']);
+    const without = buildDraftRule(
+      draft({ matcherType: 'regex', regexPattern: 'x', jurisdictionsRaw: '' }),
+    );
+    expect(without.jurisdictions).toBeUndefined();
+  });
+
+  it('includes plainEnglish + suggestedEdit only when non-empty', () => {
+    const filled = buildDraftRule(
+      draft({
+        matcherType: 'regex',
+        regexPattern: 'x',
+        plainEnglish: 'In plain English…',
+        suggestedEdit: 'Strike this clause.',
+      }),
+    );
+    expect(filled.plainEnglish).toBe('In plain English…');
+    expect(filled.suggestedEdit).toBe('Strike this clause.');
+
+    const empty = buildDraftRule(draft({ matcherType: 'regex', regexPattern: 'x' }));
+    expect(empty.plainEnglish).toBeUndefined();
+    expect(empty.suggestedEdit).toBeUndefined();
+  });
+});
+
+describe('validateDraftRule', () => {
+  it('returns ok for a fully-formed regex rule', () => {
+    const rule = buildDraftRule(
+      draft({
+        id: 'good-rule',
+        title: 'Good',
+        explanation: 'Always matches the word foo.',
+        matcherType: 'regex',
+        regexPattern: 'foo',
+        regexFlags: 'i',
+      }),
+    );
+    const result = validateDraftRule(rule);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('reports schema errors for an empty id', () => {
+    const rule = buildDraftRule(
+      draft({ matcherType: 'regex', regexPattern: 'foo', regexFlags: 'i' }),
+    );
+    const result = validateDraftRule(rule);
+    expect(result.ok).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('strips the rules[0]. prefix from validator messages so UI errors read naturally', () => {
+    const rule = buildDraftRule(draft({ matcherType: 'regex', regexPattern: 'foo' }));
+    const result = validateDraftRule(rule);
+    for (const err of result.errors) {
+      expect(err.startsWith('rules[0]')).toBe(false);
+    }
+  });
+});
+
+describe('regexCompileError', () => {
+  it('returns null for an empty regex pattern', () => {
+    expect(regexCompileError(draft({ matcherType: 'regex', regexPattern: '' }))).toBeNull();
+  });
+
+  it('returns null for a valid regex pattern', () => {
+    expect(
+      regexCompileError(
+        draft({ matcherType: 'regex', regexPattern: 'foo[a-z]+', regexFlags: 'i' }),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns the error message for an invalid regex pattern', () => {
+    const err = regexCompileError(draft({ matcherType: 'regex', regexPattern: '(unbalanced' }));
+    expect(err).toBeTruthy();
+    expect(typeof err).toBe('string');
+  });
+
+  it('returns null for keywordProximity matcher type (no regex involved)', () => {
+    expect(
+      regexCompileError(
+        draft({ matcherType: 'keywordProximity', keywordsRaw: 'a,b', windowRaw: '50' }),
+      ),
+    ).toBeNull();
+  });
+
+  it('flags an invalid heading pattern under sectionAnchored', () => {
+    const err = regexCompileError(
+      draft({
+        matcherType: 'sectionAnchored',
+        headingPattern: '(bad',
+        childType: 'regex',
+        regexPattern: 'foo',
+      }),
+    );
+    expect(err).toBeTruthy();
+  });
+
+  it('flags an invalid child regex under sectionAnchored even if the heading is valid', () => {
+    const err = regexCompileError(
+      draft({
+        matcherType: 'sectionAnchored',
+        headingPattern: '^arbitration',
+        childType: 'regex',
+        regexPattern: '(bad',
+      }),
+    );
+    expect(err).toBeTruthy();
+  });
+
+  it('returns null for sectionAnchored with a keywordProximity child', () => {
+    expect(
+      regexCompileError(
+        draft({
+          matcherType: 'sectionAnchored',
+          headingPattern: '^arbitration',
+          childType: 'keywordProximity',
+          keywordsRaw: 'a,b',
+          windowRaw: '40',
+        }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/app/src/workflow/storeZip.test.ts
+++ b/app/src/workflow/storeZip.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { buildStoreZip } from './storeZip';
+
+function u8(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function readU16LE(buf: Uint8Array, off: number): number {
+  return buf[off]! | (buf[off + 1]! << 8);
+}
+function readU32LE(buf: Uint8Array, off: number): number {
+  return (buf[off]! | (buf[off + 1]! << 8) | (buf[off + 2]! << 16) | (buf[off + 3]! << 24)) >>> 0;
+}
+
+const SIG_LFH = 0x04034b50;
+const SIG_CDH = 0x02014b50;
+const SIG_EOCD = 0x06054b50;
+
+describe('buildStoreZip — byte layout', () => {
+  it('produces a zero-entry archive that is exactly 22 bytes (EOCD only)', () => {
+    const zip = buildStoreZip([]);
+    expect(zip.length).toBe(22);
+    expect(readU32LE(zip, 0)).toBe(SIG_EOCD);
+    expect(readU16LE(zip, 8)).toBe(0); // entries on disk
+    expect(readU16LE(zip, 10)).toBe(0); // total entries
+    expect(readU32LE(zip, 12)).toBe(0); // CD size
+    expect(readU32LE(zip, 16)).toBe(0); // CD offset
+  });
+
+  it('starts with the PK\\x03\\x04 local file header for non-empty archives', () => {
+    const zip = buildStoreZip([{ name: 'a.txt', data: u8('hi') }]);
+    expect(zip[0]).toBe(0x50);
+    expect(zip[1]).toBe(0x4b);
+    expect(zip[2]).toBe(0x03);
+    expect(zip[3]).toBe(0x04);
+    expect(readU32LE(zip, 0)).toBe(SIG_LFH);
+  });
+
+  it('ends with the PK\\x05\\x06 end-of-central-directory signature', () => {
+    const zip = buildStoreZip([{ name: 'a.txt', data: u8('hi') }]);
+    expect(readU32LE(zip, zip.length - 22)).toBe(SIG_EOCD);
+  });
+
+  it('writes STORE method (0) and uses uncompressed-equals-compressed sizes', () => {
+    const data = u8('hello world');
+    const zip = buildStoreZip([{ name: 'a.txt', data }]);
+    // method at offset 8 in LFH
+    expect(readU16LE(zip, 8)).toBe(0);
+    // comp size at offset 18, uncomp size at offset 22 — both equal data length
+    expect(readU32LE(zip, 18)).toBe(data.length);
+    expect(readU32LE(zip, 22)).toBe(data.length);
+  });
+
+  it('encodes the EOCD with correct entry count, CD size, and CD offset', () => {
+    const files = [
+      { name: 'a.txt', data: u8('hi') },
+      { name: 'dir/b.bin', data: new Uint8Array([1, 2, 3, 4, 5]) },
+    ];
+    const zip = buildStoreZip(files);
+    const eocd = zip.length - 22;
+    expect(readU32LE(zip, eocd)).toBe(SIG_EOCD);
+    expect(readU16LE(zip, eocd + 8)).toBe(2);
+    expect(readU16LE(zip, eocd + 10)).toBe(2);
+
+    const cdOffset = readU32LE(zip, eocd + 16);
+    const cdSize = readU32LE(zip, eocd + 12);
+    // CD must start with a CDH signature, end where EOCD begins.
+    expect(readU32LE(zip, cdOffset)).toBe(SIG_CDH);
+    expect(cdOffset + cdSize).toBe(eocd);
+  });
+
+  it('writes a CDH per entry, each pointing back at its LFH offset', () => {
+    const files = [
+      { name: 'a.txt', data: u8('hi') },
+      { name: 'b.txt', data: u8('there') },
+    ];
+    const zip = buildStoreZip(files);
+    const eocd = zip.length - 22;
+    let cur = readU32LE(zip, eocd + 16);
+    const lfhOffsets: number[] = [];
+    for (let i = 0; i < 2; i++) {
+      expect(readU32LE(zip, cur)).toBe(SIG_CDH);
+      lfhOffsets.push(readU32LE(zip, cur + 42));
+      const nameLen = readU16LE(zip, cur + 28);
+      cur += 46 + nameLen;
+    }
+    // First LFH is always at offset 0; second LFH is past first entry payload.
+    expect(lfhOffsets[0]).toBe(0);
+    expect(readU32LE(zip, lfhOffsets[0]!)).toBe(SIG_LFH);
+    expect(readU32LE(zip, lfhOffsets[1]!)).toBe(SIG_LFH);
+    expect(lfhOffsets[1]).toBeGreaterThan(lfhOffsets[0]!);
+  });
+
+  it('encodes UTF-8 multi-byte filenames correctly', () => {
+    const name = 'résumé.txt'; // 11 bytes UTF-8 (é = 2 bytes ×2)
+    const expectedNameBytes = new TextEncoder().encode(name);
+    const zip = buildStoreZip([{ name, data: u8('x') }]);
+    // LFH name length at offset 26
+    expect(readU16LE(zip, 26)).toBe(expectedNameBytes.length);
+    const inZip = zip.slice(30, 30 + expectedNameBytes.length);
+    expect(Array.from(inZip)).toEqual(Array.from(expectedNameBytes));
+  });
+});
+
+describe('buildStoreZip — CRC-32', () => {
+  // Known CRC-32/ISO-HDLC vectors.
+  it('computes the canonical CRC32 of "123456789" (0xCBF43926)', () => {
+    const zip = buildStoreZip([{ name: 'x', data: u8('123456789') }]);
+    expect(readU32LE(zip, 14)).toBe(0xcbf43926);
+  });
+
+  it('computes CRC32 of empty input as 0', () => {
+    const zip = buildStoreZip([{ name: 'x', data: new Uint8Array(0) }]);
+    expect(readU32LE(zip, 14)).toBe(0);
+  });
+
+  it('writes the same CRC32 in the LFH and the matching CDH entry', () => {
+    const zip = buildStoreZip([{ name: 'x', data: u8('hello') }]);
+    const lfhCrc = readU32LE(zip, 14);
+    // Find CDH via EOCD pointer.
+    const eocd = zip.length - 22;
+    const cdOffset = readU32LE(zip, eocd + 16);
+    expect(readU32LE(zip, cdOffset)).toBe(SIG_CDH);
+    expect(readU32LE(zip, cdOffset + 16)).toBe(lfhCrc);
+  });
+});
+
+describe('buildStoreZip — size invariants', () => {
+  it('total bytes = sum(LFH + name + payload) + sum(CDH + name) + 22', () => {
+    const files = [
+      { name: 'a', data: u8('xx') },
+      { name: 'longer-name.txt', data: new Uint8Array(100) },
+      { name: 'c', data: u8('!') },
+    ];
+    let lfh = 0;
+    let cdh = 0;
+    for (const f of files) {
+      const nameLen = new TextEncoder().encode(f.name).length;
+      lfh += 30 + nameLen + f.data.length;
+      cdh += 46 + nameLen;
+    }
+    const expected = lfh + cdh + 22;
+    expect(buildStoreZip(files).length).toBe(expected);
+  });
+
+  it('preserves payload bytes verbatim (STORE = no transformation)', () => {
+    const data = new Uint8Array(256);
+    for (let i = 0; i < 256; i++) data[i] = i;
+    const zip = buildStoreZip([{ name: 'a', data }]);
+    // Payload begins at 30 (LFH) + 1 (name "a") = 31.
+    const payload = zip.slice(31, 31 + 256);
+    expect(Array.from(payload)).toEqual(Array.from(data));
+  });
+});


### PR DESCRIPTION
## Summary
Two highest-risk untested modules from `/test-gaps`:
- **`workflow/storeZip.ts`** (139 LOC, RFC-spec ZIP writer underpinning every signed-export bundle): 12 tests covering ZIP signatures (LFH/CDH/EOCD), STORE-method size invariants, EOCD pointer math, CDH↔LFH offset linkage, UTF-8 multi-byte filenames, the canonical CRC32 vector (`"123456789"` → `0xCBF43926`), CRC consistency between LFH and CDH, and byte-level payload preservation.
- **`ui/customRuleDraft.ts`** (219 LOC, custom-rule authoring form serializer): 24 tests covering all three matcher types (regex, keywordProximity, sectionAnchored), CSV parsing edge cases, optional metadata gating, `validateDraftRule` pass/fail + `rules[0]` prefix stripping, and `regexCompileError` across every relevant matcher path.

`useFocusTrap`, `useReanalyzeOnRulesChange`, and `highlightDefinedTerms` were also flagged but turned out to have `.tsx` test files paired with `.ts` sources — false positives in the gap scan.

## Test plan
- [x] `npm test` — 1679/1680 pass (1 todo, no new failures)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)