### PR TITLE
wave51-b: slim header + UploadView + LoadingView + OfflineDot

### DIFF
--- a/app/src/App.panels.test.tsx
+++ b/app/src/App.panels.test.tsx
@@ -215,7 +215,8 @@ async function makeLeaseFile(name = 'lease.pdf'): Promise<File> {
 
 async function uploadLease(name = 'lease.pdf'): Promise<void> {
   const file = await makeLeaseFile(name);
-  const input = screen.getByLabelText(/upload lease/i) as HTMLInputElement;
+  // UploadView is lazy-loaded; wait for its chunk before grabbing the input.
+  const input = (await screen.findByLabelText(/upload lease/i)) as HTMLInputElement;
   await userEvent.upload(input, file);
   // Wait until the findings <aside> mounts — rule titles also surface in the
   // SeverityOverridesPanel even before analysis finishes, so we scope to the

--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -158,6 +158,11 @@ async function makeLeaseFile(name = 'lease.pdf'): Promise<File> {
 }
 
 async function uploadLease(name = 'lease.pdf'): Promise<void> {
+  // Wave 51-B — UploadView only renders when status === 'idle'. If a
+  // lease is already loaded, click the header's "New lease" reset to
+  // return to the upload landing before grabbing the input.
+  const reset = screen.queryByRole('button', { name: /new lease/i });
+  if (reset) await userEvent.click(reset);
   const file = await makeLeaseFile(name);
   const input = screen.getByLabelText(/upload lease/i) as HTMLInputElement;
   await userEvent.upload(input, file);
@@ -335,6 +340,9 @@ describe('App', () => {
   it('opens a library entry and re-shows its findings', async () => {
     render(<App />);
     await uploadLease('Reopen.pdf');
+    // Wave 51-B — UploadView only mounts in idle state; click "New lease"
+    // before grabbing a fresh upload input for the second lease.
+    await userEvent.click(screen.getByRole('button', { name: /new lease/i }));
     await userEvent.upload(
       screen.getByLabelText(/upload lease/i) as HTMLInputElement,
       await makeLeaseFile('Other.pdf'),

--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -164,7 +164,8 @@ async function uploadLease(name = 'lease.pdf'): Promise<void> {
   const reset = screen.queryByRole('button', { name: /new lease/i });
   if (reset) await userEvent.click(reset);
   const file = await makeLeaseFile(name);
-  const input = screen.getByLabelText(/upload lease/i) as HTMLInputElement;
+  // UploadView is lazy-loaded; wait for its chunk before grabbing the input.
+  const input = (await screen.findByLabelText(/upload lease/i)) as HTMLInputElement;
   await userEvent.upload(input, file);
   // "auto-renewal" now also appears in the SeverityOverridesPanel row; use
   // `findAllByText` so we pass as soon as the findings panel renders.
@@ -178,10 +179,11 @@ async function uploadLease(name = 'lease.pdf'): Promise<void> {
 }
 
 describe('App', () => {
-  it('renders the upload control in idle state', () => {
+  it('renders the upload control in idle state', async () => {
     render(<App />);
     expect(screen.getByRole('heading', { name: /leaseguard/i })).toBeInTheDocument();
-    expect(screen.getByLabelText(/upload lease/i)).toBeInTheDocument();
+    // UploadView is lazy-loaded — wait for the chunk to land before asserting.
+    await waitFor(() => expect(screen.getByLabelText(/upload lease/i)).toBeInTheDocument());
   });
 
   it('shows findings after a successful upload and analysis', async () => {
@@ -204,7 +206,7 @@ describe('App', () => {
   it('surfaces a parse error without crashing', async () => {
     render(<App />);
     const bogus = new File([new Uint8Array([1, 2, 3])], 'bad.pdf', { type: 'application/pdf' });
-    const input = screen.getByLabelText(/upload lease/i) as HTMLInputElement;
+    const input = (await screen.findByLabelText(/upload lease/i)) as HTMLInputElement;
     await userEvent.upload(input, bogus);
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
   });
@@ -344,7 +346,7 @@ describe('App', () => {
     // before grabbing a fresh upload input for the second lease.
     await userEvent.click(screen.getByRole('button', { name: /new lease/i }));
     await userEvent.upload(
-      screen.getByLabelText(/upload lease/i) as HTMLInputElement,
+      (await screen.findByLabelText(/upload lease/i)) as HTMLInputElement,
       await makeLeaseFile('Other.pdf'),
     );
     await waitFor(() =>

--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -376,8 +376,10 @@ describe('App', () => {
       screen.getByRole('button', { name: /export findings \(printable html\)/i }),
     );
 
+    // HTML export lazy-imports `storage/exportHtml`; userEvent doesn't
+    // await that dynamic import, so wait for the download to land.
+    await waitFor(() => expect(aClicks).toContain('Report-findings.html'));
     expect(aClicks).toContain('Report-findings.json');
-    expect(aClicks).toContain('Report-findings.html');
     createSpy.mockRestore();
   });
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -67,6 +67,8 @@ import { AppHeader } from './ui/AppHeader';
 import { AppCurrentPane } from './ui/AppCurrentPane';
 import { AppLibraryAndPacksPane } from './ui/AppLibraryAndPacksPane';
 import { AppSettingsPane } from './ui/AppSettingsPane';
+import { UploadView } from './ui/UploadView';
+import { LoadingView } from './ui/LoadingView';
 import { useAppCallbacks } from './App/useAppCallbacks';
 import { StandardSuitePanel } from './ui/StandardSuitePanel';
 import {
@@ -337,11 +339,12 @@ function AppContent(): JSX.Element {
       <AppHeader
         view={view}
         showRedlineToggle={status.kind === 'analyzed'}
-        onUpload={async (file) => {
-          await handleBytes(await readFileBytes(file), file.name);
-        }}
-        onTrySample={() => void onTrySample()}
         onViewChange={(next) => setView(next)}
+        fileName={status.kind === 'analyzed' ? status.fileName : null}
+        onNewLease={() => {
+          setSelected(null);
+          pipeline.reset();
+        }}
       />
 
       <div
@@ -401,10 +404,16 @@ function AppContent(): JSX.Element {
         aria-labelledby="viewmode-tab-current"
         hidden={view !== 'current'}
       >
+        {view === 'current' && status.kind === 'idle' && (
+          <UploadView
+            onUpload={async (file) => {
+              await handleBytes(await readFileBytes(file), file.name);
+            }}
+            onTrySample={() => void onTrySample()}
+          />
+        )}
         {view === 'current' && status.kind === 'loading' && (
-          <p role="status" aria-live="polite">
-            Analyzing {status.fileName}…
-          </p>
+          <LoadingView fileName={status.fileName} />
         )}
         {view === 'current' && status.kind === 'error' && (
           <p role="alert">Could not analyze this file: {status.message}</p>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -67,8 +67,15 @@ import { AppHeader } from './ui/AppHeader';
 import { AppCurrentPane } from './ui/AppCurrentPane';
 import { AppLibraryAndPacksPane } from './ui/AppLibraryAndPacksPane';
 import { AppSettingsPane } from './ui/AppSettingsPane';
-import { UploadView } from './ui/UploadView';
-import { LoadingView } from './ui/LoadingView';
+// UploadView + LoadingView are state-specific and bulky together (~3 KB);
+// lazy-load both to keep the app shell under budget. UploadView is the
+// idle-state landing — its chunk warms on first paint behind a no-op
+// fallback (the shell renders the slim header instantly). LoadingView's
+// chunk loads in parallel with the analyze worker.
+const UploadView = lazy(() => import('./ui/UploadView').then((m) => ({ default: m.UploadView })));
+const LoadingView = lazy(() =>
+  import('./ui/LoadingView').then((m) => ({ default: m.LoadingView })),
+);
 import { useAppCallbacks } from './App/useAppCallbacks';
 import { StandardSuitePanel } from './ui/StandardSuitePanel';
 import {
@@ -405,15 +412,19 @@ function AppContent(): JSX.Element {
         hidden={view !== 'current'}
       >
         {view === 'current' && status.kind === 'idle' && (
-          <UploadView
-            onUpload={async (file) => {
-              await handleBytes(await readFileBytes(file), file.name);
-            }}
-            onTrySample={() => void onTrySample()}
-          />
+          <Suspense fallback={null}>
+            <UploadView
+              onUpload={async (file) => {
+                await handleBytes(await readFileBytes(file), file.name);
+              }}
+              onTrySample={() => void onTrySample()}
+            />
+          </Suspense>
         )}
         {view === 'current' && status.kind === 'loading' && (
-          <LoadingView fileName={status.fileName} />
+          <Suspense fallback={null}>
+            <LoadingView fileName={status.fileName} />
+          </Suspense>
         )}
         {view === 'current' && status.kind === 'error' && (
           <p role="alert">Could not analyze this file: {status.message}</p>

--- a/app/src/ui/AppHeader.test.tsx
+++ b/app/src/ui/AppHeader.test.tsx
@@ -8,8 +8,6 @@ function renderHeader(props: Partial<React.ComponentProps<typeof AppHeader>> = {
   const defaults: React.ComponentProps<typeof AppHeader> = {
     view: 'current',
     showRedlineToggle: false,
-    onUpload: vi.fn(),
-    onTrySample: vi.fn(),
     onViewChange: vi.fn(),
   };
   return render(
@@ -20,17 +18,40 @@ function renderHeader(props: Partial<React.ComponentProps<typeof AppHeader>> = {
 }
 
 describe('AppHeader', () => {
-  it('renders title, upload control, sample-lease button, and view-mode tablist', () => {
+  it('renders title and the view-mode tablist', () => {
     renderHeader();
     expect(screen.getByRole('heading', { name: /leaseguard/i })).toBeInTheDocument();
-    expect(screen.getByLabelText(/upload lease/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /try a sample lease/i })).toBeInTheDocument();
     // Wave 29-E — view-mode shell is now a tablist.
     expect(screen.getByRole('tablist', { name: /view mode/i })).toBeInTheDocument();
     // Wave 51-A — Settings tab joins Current + Portfolio (Redline gates on showRedlineToggle).
     expect(screen.getByRole('tab', { name: /current lease/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /portfolio/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /settings/i })).toBeInTheDocument();
+  });
+
+  it('does not render upload / sample controls (Wave 51-B moved them to UploadView)', () => {
+    renderHeader();
+    expect(screen.queryByLabelText(/upload lease/i)).toBeNull();
+    expect(screen.queryByRole('button', { name: /try a sample lease/i })).toBeNull();
+  });
+
+  it('renders the offline-on-device indicator', () => {
+    renderHeader();
+    expect(screen.getByRole('status', { name: /offline.*on-device/i })).toBeInTheDocument();
+  });
+
+  it('hides filename + new-lease controls until a lease is loaded', () => {
+    renderHeader({ fileName: null });
+    expect(screen.queryByLabelText(/lease file name/i)).toBeNull();
+    expect(screen.queryByRole('button', { name: /new lease/i })).toBeNull();
+  });
+
+  it('renders the filename pill and a New lease reset when a lease is loaded', async () => {
+    const onNewLease = vi.fn();
+    renderHeader({ fileName: 'cortland.pdf', onNewLease });
+    expect(screen.getByLabelText(/lease file name/i)).toHaveTextContent('cortland.pdf');
+    await userEvent.click(screen.getByRole('button', { name: /new lease/i }));
+    expect(onNewLease).toHaveBeenCalledTimes(1);
   });
 
   it('marks the Settings tab active when view=settings', () => {
@@ -56,13 +77,7 @@ describe('AppHeader', () => {
     expect(screen.queryByRole('tab', { name: /redline/i })).toBeNull();
     rerender(
       <I18nProvider>
-        <AppHeader
-          view="current"
-          showRedlineToggle={true}
-          onUpload={vi.fn()}
-          onTrySample={vi.fn()}
-          onViewChange={vi.fn()}
-        />
+        <AppHeader view="current" showRedlineToggle={true} onViewChange={vi.fn()} />
       </I18nProvider>,
     );
     expect(screen.getByRole('tab', { name: /redline/i })).toBeInTheDocument();
@@ -73,22 +88,5 @@ describe('AppHeader', () => {
     renderHeader({ showRedlineToggle: true, onViewChange });
     await userEvent.click(screen.getByRole('tab', { name: /portfolio/i }));
     expect(onViewChange).toHaveBeenCalledWith('portfolio');
-  });
-
-  it('fires onTrySample when the sample-lease button is clicked', async () => {
-    const onTrySample = vi.fn();
-    renderHeader({ onTrySample });
-    await userEvent.click(screen.getByRole('button', { name: /try a sample lease/i }));
-    expect(onTrySample).toHaveBeenCalledTimes(1);
-  });
-
-  it('fires onUpload with the selected file when a PDF is chosen', async () => {
-    const onUpload = vi.fn();
-    renderHeader({ onUpload });
-    const input = screen.getByLabelText(/upload lease/i) as HTMLInputElement;
-    const file = new File([new Uint8Array([1, 2, 3])], 'test.pdf', { type: 'application/pdf' });
-    await userEvent.upload(input, file);
-    expect(onUpload).toHaveBeenCalledTimes(1);
-    expect(onUpload.mock.calls[0]?.[0]).toBeInstanceOf(File);
   });
 });

--- a/app/src/ui/AppHeader.tsx
+++ b/app/src/ui/AppHeader.tsx
@@ -1,117 +1,130 @@
 import { useI18n } from '../i18n/I18nContext';
 import { Button } from './system/Button';
+import { OfflineDot } from './OfflineDot';
 
-// Aria/data inventory (preserved verbatim):
-//   aria-label="upload lease" (input)
+// Aria/data inventory:
 //   role="tablist" + aria-label="view mode" (div) — Wave 29-E
 //   role="tab" + aria-selected + aria-controls on each view-mode
 //     button. aria-pressed retained for back-compat with existing
 //     toggle-pill styling and tests that probe it.
+//   aria-label="new lease" (Button — appears only when analyzed)
+//   aria-label="lease file name" (filename pill — appears only when
+//     analyzed; lets axe + screen readers identify the active doc)
 //
-// Wave 51-A — locale picker, theme toggle, and the privacy disclosure
-// move under the new Settings tab. The header keeps the upload control
-// + sample-lease button + view-mode tablist; Wave 51-B will further
-// slim it once the marginalia upload landing lands.
+// Wave 51-A — privacy `<details>` + locale picker + theme toggle
+// moved to the Settings tab.
+//
+// Wave 51-B — header slimmed further: the upload `<input>` and the
+// "Try sample" button moved to UploadView (rendered when the app is
+// in the idle / empty state). The header now carries:
+//   - wordmark (h1)
+//   - filename pill + "New lease" reset (when analyzed)
+//   - tab pills (current / portfolio / redline / settings)
+//   - offline-on-device indicator
+// Tests that uploaded a fresh PDF via the header now go through
+// UploadView; tests that uploaded a *second* lease after analysis
+// click "New lease" first.
 
 export type AppViewMode = 'current' | 'portfolio' | 'redline' | 'settings';
 
 interface AppHeaderProps {
   view: AppViewMode;
   showRedlineToggle: boolean;
-  onUpload: (file: File) => void | Promise<void>;
-  onTrySample: () => void;
   onViewChange: (next: AppViewMode) => void;
+  /** Filename of the analyzed lease, or null if no lease is loaded. */
+  fileName?: string | null;
+  /** Reset back to the upload landing. Only rendered when fileName is set. */
+  onNewLease?: () => void;
 }
 
 export function AppHeader({
   view,
   showRedlineToggle,
-  onUpload,
-  onTrySample,
   onViewChange,
+  fileName = null,
+  onNewLease,
 }: AppHeaderProps): JSX.Element {
   const { t } = useI18n();
+  const hasLease = Boolean(fileName);
   return (
-    <header className="bg-paper border-b border-rule px-4 py-3 space-y-2">
-      <div className="flex items-baseline gap-3">
-        <h1 className="text-display font-display text-fg">{t('app.title')}</h1>
-        <p className="text-small text-fg-muted">{t('app.tagline')}</p>
-      </div>
-      <div className="flex flex-wrap items-center gap-2">
-        <label className="inline-flex items-center gap-1 text-body text-fg-body cursor-pointer">
-          <span className="visually-hidden">Upload lease</span>
-          <input
-            type="file"
-            accept="application/pdf"
-            aria-label="upload lease"
-            className="text-small"
-            onChange={async (e) => {
-              const file = e.target.files?.[0];
-              if (!file) return;
-              await onUpload(file);
-            }}
-          />
-        </label>
-        <Button type="button" variant="default" size="sm" onClick={onTrySample}>
-          {t('header.trySample')}
+    <header className="bg-paper border-b border-rule px-4 py-3 flex flex-wrap items-center gap-3">
+      <h1 className="text-display font-display text-fg" style={{ marginRight: 12 }}>
+        {t('app.title')}
+      </h1>
+
+      {hasLease && fileName && (
+        <span
+          aria-label="lease file name"
+          className="font-display italic text-small text-fg-muted truncate max-w-[36ch]"
+        >
+          {fileName}
+        </span>
+      )}
+
+      <div role="tablist" aria-label="view mode" className="view-toggle flex gap-1 ml-auto">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          pressed={view === 'current'}
+          role="tab"
+          id="viewmode-tab-current"
+          aria-selected={view === 'current'}
+          aria-controls="viewmode-panel-current"
+          onClick={() => onViewChange('current')}
+        >
+          {t('header.view.current')}
         </Button>
-        <div role="tablist" aria-label="view mode" className="view-toggle flex gap-1">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          pressed={view === 'portfolio'}
+          role="tab"
+          id="viewmode-tab-portfolio"
+          aria-selected={view === 'portfolio'}
+          aria-controls="viewmode-panel-portfolio"
+          onClick={() => onViewChange('portfolio')}
+        >
+          {t('header.view.portfolio')}
+        </Button>
+        {showRedlineToggle && (
           <Button
             type="button"
             variant="ghost"
             size="sm"
-            pressed={view === 'current'}
+            pressed={view === 'redline'}
             role="tab"
-            id="viewmode-tab-current"
-            aria-selected={view === 'current'}
-            aria-controls="viewmode-panel-current"
-            onClick={() => onViewChange('current')}
+            id="viewmode-tab-redline"
+            aria-selected={view === 'redline'}
+            aria-controls="viewmode-panel-redline"
+            onClick={() => onViewChange('redline')}
           >
-            {t('header.view.current')}
+            {t('header.view.redline')}
           </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            pressed={view === 'portfolio'}
-            role="tab"
-            id="viewmode-tab-portfolio"
-            aria-selected={view === 'portfolio'}
-            aria-controls="viewmode-panel-portfolio"
-            onClick={() => onViewChange('portfolio')}
-          >
-            {t('header.view.portfolio')}
-          </Button>
-          {showRedlineToggle && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              pressed={view === 'redline'}
-              role="tab"
-              id="viewmode-tab-redline"
-              aria-selected={view === 'redline'}
-              aria-controls="viewmode-panel-redline"
-              onClick={() => onViewChange('redline')}
-            >
-              {t('header.view.redline')}
-            </Button>
-          )}
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            pressed={view === 'settings'}
-            role="tab"
-            id="viewmode-tab-settings"
-            aria-selected={view === 'settings'}
-            aria-controls="viewmode-panel-settings"
-            onClick={() => onViewChange('settings')}
-          >
-            {t('header.view.settings')}
-          </Button>
-        </div>
+        )}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          pressed={view === 'settings'}
+          role="tab"
+          id="viewmode-tab-settings"
+          aria-selected={view === 'settings'}
+          aria-controls="viewmode-panel-settings"
+          onClick={() => onViewChange('settings')}
+        >
+          {t('header.view.settings')}
+        </Button>
       </div>
+
+      <OfflineDot />
+
+      {hasLease && onNewLease && (
+        <Button type="button" variant="ghost" size="sm" aria-label="new lease" onClick={onNewLease}>
+          New lease
+        </Button>
+      )}
     </header>
   );
 }

--- a/app/src/ui/LoadingView.stories.tsx
+++ b/app/src/ui/LoadingView.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LoadingView } from './LoadingView';
+
+const meta: Meta<typeof LoadingView> = {
+  title: 'App / LoadingView',
+  component: LoadingView,
+};
+export default meta;
+
+type Story = StoryObj<typeof LoadingView>;
+
+export const Default: Story = { args: { fileName: '1428 Cortland Ave — Residential Lease.pdf' } };
+
+export const Static: Story = {
+  args: { fileName: 'snapshot.pdf', intervalMs: 0 },
+};

--- a/app/src/ui/LoadingView.test.tsx
+++ b/app/src/ui/LoadingView.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { LoadingView } from './LoadingView';
+
+describe('LoadingView', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders the file name and an aria-live status region', () => {
+    render(<LoadingView fileName="cortland.pdf" intervalMs={0} />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+    expect(screen.getByText(/cortland\.pdf/)).toBeInTheDocument();
+  });
+
+  it('renders five loader stages', () => {
+    render(<LoadingView fileName="x.pdf" intervalMs={0} />);
+    expect(screen.getAllByTestId('loading-stage')).toHaveLength(5);
+  });
+
+  it('starts with the first stage active and the rest pending', () => {
+    render(<LoadingView fileName="x.pdf" intervalMs={0} />);
+    const stages = screen.getAllByTestId('loading-stage');
+    expect(stages[0]).toHaveAttribute('data-stage', 'active');
+    expect(stages[1]).toHaveAttribute('data-stage', 'pending');
+  });
+
+  it('advances stages on the timer', () => {
+    render(<LoadingView fileName="x.pdf" intervalMs={100} />);
+    expect(screen.getAllByTestId('loading-stage')[0]).toHaveAttribute('data-stage', 'active');
+    act(() => {
+      vi.advanceTimersByTime(110);
+    });
+    const stages = screen.getAllByTestId('loading-stage');
+    expect(stages[0]).toHaveAttribute('data-stage', 'done');
+    expect(stages[1]).toHaveAttribute('data-stage', 'active');
+  });
+});

--- a/app/src/ui/LoadingView.tsx
+++ b/app/src/ui/LoadingView.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+
+// Aria/data inventory:
+//   role="status" + aria-live="polite" (announces stage transitions)
+//
+// Wave 51-B — staged loader ticker. Adopted from the Claude Design
+// handoff (`app-shell.jsx > LoadingView`).
+//
+// usePipeline doesn't currently emit fine-grained sub-stages — it
+// transitions `idle -> loading -> analyzed` as a single step, with
+// the heavy lifting inside the worker. The ticker animates a fixed
+// 5-step narrative client-side as a perception-management device,
+// and the parent unmounts this component the moment the pipeline
+// resolves to `analyzed`. Tests can pass `intervalMs={0}` to disable
+// the timer for deterministic snapshots.
+
+interface LoadingViewProps {
+  fileName: string;
+  intervalMs?: number;
+}
+
+const STAGES = [
+  'Reading PDF in worker…',
+  'Reconstructing paragraphs…',
+  'Resolving defined terms…',
+  'Running rules pack…',
+  'Building the margin notes…',
+] as const;
+
+export function LoadingView({ fileName, intervalMs = 480 }: LoadingViewProps): JSX.Element {
+  const [stage, setStage] = useState(0);
+
+  useEffect(() => {
+    if (intervalMs <= 0) return;
+    let cancelled = false;
+    let i = 0;
+    function tick(): void {
+      if (cancelled) return;
+      i++;
+      if (i >= STAGES.length) return;
+      setStage(i);
+      timer = setTimeout(tick, intervalMs);
+    }
+    let timer = setTimeout(tick, intervalMs);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [intervalMs]);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="max-w-[520px] mx-auto px-6 py-24 flex flex-col gap-4"
+    >
+      <p className="font-sans text-small uppercase tracking-wide text-fg-muted">Analyzing</p>
+      <p className="font-display text-fg leading-snug text-[1.4rem]">{fileName}</p>
+      <hr className="border-0 h-px bg-rule-subtle mt-1" />
+      <ul className="list-none p-0 m-0 font-mono text-mono text-fg-muted">
+        {STAGES.map((s, i) => (
+          <li
+            key={s}
+            data-testid="loading-stage"
+            data-stage={i < stage ? 'done' : i === stage ? 'active' : 'pending'}
+            className={`py-1 flex gap-2.5 ${i <= stage ? 'text-fg-body' : 'text-fg-faint'}`}
+          >
+            <span
+              aria-hidden="true"
+              className={`w-3 inline-block ${
+                i < stage ? 'text-positive' : i === stage ? 'text-ink' : 'text-fg-faint'
+              }`}
+            >
+              {i < stage ? '✓' : i === stage ? '›' : '·'}
+            </span>
+            {s}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/src/ui/OfflineDot.stories.tsx
+++ b/app/src/ui/OfflineDot.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { OfflineDot } from './OfflineDot';
+
+const meta: Meta<typeof OfflineDot> = {
+  title: 'App / OfflineDot',
+  component: OfflineDot,
+};
+export default meta;
+
+type Story = StoryObj<typeof OfflineDot>;
+
+export const Default: Story = {};

--- a/app/src/ui/OfflineDot.test.tsx
+++ b/app/src/ui/OfflineDot.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { OfflineDot } from './OfflineDot';
+
+describe('OfflineDot', () => {
+  it('renders an accessible status label', () => {
+    render(<OfflineDot />);
+    expect(screen.getByRole('status', { name: /offline.*on-device/i })).toBeInTheDocument();
+  });
+
+  it('shows the visible "Offline · On-device" text', () => {
+    render(<OfflineDot />);
+    expect(screen.getByText(/offline.*on-device/i)).toBeInTheDocument();
+  });
+});

--- a/app/src/ui/OfflineDot.tsx
+++ b/app/src/ui/OfflineDot.tsx
@@ -1,0 +1,22 @@
+// Wave 51-B — Offline / on-device indicator.
+//
+// Pure presentation. The app is local-first by construction (CSP
+// `default-src 'self'`, no network egress after load), so this badge
+// is informational, not a live connectivity probe. Its job is to
+// telegraph "nothing leaves your device" the moment the page loads.
+
+export function OfflineDot(): JSX.Element {
+  return (
+    <span
+      role="status"
+      aria-label="offline, on-device"
+      className="inline-flex items-center gap-1.5 font-sans text-small text-fg-muted uppercase tracking-wide"
+    >
+      <span
+        aria-hidden="true"
+        className="inline-block w-1.5 h-1.5 rounded-full bg-positive shadow-[0_0_0_3px_color-mix(in_oklab,var(--color-positive)_18%,transparent)]"
+      />
+      Offline · On-device
+    </span>
+  );
+}

--- a/app/src/ui/UploadView.stories.tsx
+++ b/app/src/ui/UploadView.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { UploadView } from './UploadView';
+import { I18nProvider } from '../i18n/I18nProvider';
+
+const meta: Meta<typeof UploadView> = {
+  title: 'App / UploadView',
+  component: UploadView,
+  decorators: [
+    (Story) => (
+      <I18nProvider>
+        <Story />
+      </I18nProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof UploadView>;
+
+export const Default: Story = {
+  args: {
+    onUpload: () => undefined,
+    onTrySample: () => undefined,
+  },
+};

--- a/app/src/ui/UploadView.test.tsx
+++ b/app/src/ui/UploadView.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UploadView } from './UploadView';
+import { I18nProvider } from '../i18n/I18nProvider';
+
+function renderView(props: Partial<React.ComponentProps<typeof UploadView>> = {}) {
+  const defaults: React.ComponentProps<typeof UploadView> = {
+    onUpload: vi.fn(),
+    onTrySample: vi.fn(),
+  };
+  return render(
+    <I18nProvider>
+      <UploadView {...defaults} {...props} />
+    </I18nProvider>,
+  );
+}
+
+describe('UploadView', () => {
+  it('renders the annotated headline and the upload affordances', () => {
+    renderView();
+    expect(screen.getByRole('region', { name: /upload/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading')).toHaveTextContent(/most leases are/i);
+    expect(screen.getByRole('heading')).toHaveTextContent(/three clauses/i);
+    expect(screen.getByLabelText(/upload lease/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try a sample lease/i })).toBeInTheDocument();
+  });
+
+  it('renders the "what you\'ll see" sample preview column', () => {
+    renderView();
+    const preview = screen.getByLabelText(/what you will see/i);
+    expect(preview).toBeInTheDocument();
+    expect(preview).toHaveTextContent(/renewal clauses/i);
+    expect(preview).toHaveTextContent(/late fees/i);
+  });
+
+  it('fires onUpload when a PDF is selected via the file input', async () => {
+    const onUpload = vi.fn();
+    renderView({ onUpload });
+    const input = screen.getByLabelText(/upload lease/i) as HTMLInputElement;
+    const file = new File([new Uint8Array([1, 2, 3])], 't.pdf', { type: 'application/pdf' });
+    await userEvent.upload(input, file);
+    expect(onUpload).toHaveBeenCalledTimes(1);
+    expect(onUpload.mock.calls[0]?.[0]).toBeInstanceOf(File);
+  });
+
+  it('fires onTrySample when the sample-lease button is clicked', async () => {
+    const onTrySample = vi.fn();
+    renderView({ onTrySample });
+    await userEvent.click(screen.getByRole('button', { name: /try a sample lease/i }));
+    expect(onTrySample).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/ui/UploadView.tsx
+++ b/app/src/ui/UploadView.tsx
@@ -1,0 +1,157 @@
+import { useState, type DragEvent } from 'react';
+import { Button } from './system/Button';
+import { useI18n } from '../i18n/I18nContext';
+
+// Aria/data inventory:
+//   aria-label="upload lease" (input — preserved verbatim from the
+//     pre-Wave-51-A AppHeader so existing tests + screen readers
+//     keep finding the upload affordance)
+//   role="region" + aria-label="upload" (section root)
+//
+// Wave 51-B — annotated landing for the empty / first-run state.
+// Adopted from the Claude Design handoff (`app-shell.jsx > UploadView`).
+// Left column is the editorial pitch + drop-zone row + footer chips;
+// right column is the "what you'll see" sample preview. Renders only
+// when `status.kind === 'idle'`; once a lease is loading or analyzed
+// the AppCurrentPane swaps to the loading / results layout.
+
+interface UploadViewProps {
+  onUpload: (file: File) => void | Promise<void>;
+  onTrySample: () => void | Promise<void>;
+}
+
+// NOTE: kept abstract — must NOT contain real rule excerpts (e.g.
+// "auto-renewal", "waiver of jury trial") because App-level tests
+// `waitFor` on those sentinels and would short-circuit on this
+// preview before the real analysis completes.
+const SAMPLE_PREVIEW: ReadonlyArray<{
+  severity: 'high' | 'medium' | 'low';
+  label: string;
+  text: string;
+}> = [
+  {
+    severity: 'high',
+    label: 'High',
+    text: 'Renewal clauses that lock you in past your notice window.',
+  },
+  {
+    severity: 'high',
+    label: 'High',
+    text: 'Rent escalators with a hard floor over CPI.',
+  },
+  {
+    severity: 'medium',
+    label: 'Medium',
+    text: 'Compounding late fees that may be unenforceable penalties.',
+  },
+  {
+    severity: 'low',
+    label: 'Low',
+    text: 'Outsized security deposits — worth a small-landlord exemption check.',
+  },
+];
+
+export function UploadView({ onUpload, onTrySample }: UploadViewProps): JSX.Element {
+  const { t } = useI18n();
+  const [drag, setDrag] = useState(false);
+
+  function onDrop(e: DragEvent<HTMLDivElement>): void {
+    e.preventDefault();
+    setDrag(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file && file.type === 'application/pdf') void onUpload(file);
+  }
+
+  return (
+    <section
+      role="region"
+      aria-label="upload"
+      className="grid w-full max-w-[1080px] mx-auto gap-12 px-6 py-12 md:grid-cols-[1fr_280px]"
+    >
+      {/* Left: editorial headline + drop zone + footer chips */}
+      <div>
+        <p className="font-sans text-small uppercase tracking-wide text-fg-muted mb-3">
+          {t('app.title')} · v1.0
+        </p>
+        <h2 className="font-display text-fg leading-[1.05] mb-5 text-[clamp(2.25rem,4vw,3.25rem)] font-semibold">
+          Most leases are <span className="italic text-severity-high">fine.</span>
+          <br />
+          Three clauses
+          <br />
+          are <span className="border-b-2 border-severity-medium">not.</span>
+        </h2>
+        <p className="font-display text-fg-body leading-relaxed mb-7 max-w-[44ch] text-[16.5px]">
+          LeaseGuard reads a lease PDF on this device, marks the clauses worth pushing back on, and
+          explains them in plain language. Nothing leaves your browser.
+        </p>
+
+        <div
+          onDragOver={(e) => {
+            e.preventDefault();
+            setDrag(true);
+          }}
+          onDragLeave={() => setDrag(false)}
+          onDrop={onDrop}
+          className={`flex flex-wrap items-center gap-3 transition-[border-color,padding] duration-150 ${
+            drag
+              ? 'p-3 border border-dashed border-ink'
+              : 'p-0 border border-dashed border-transparent'
+          }`}
+        >
+          <label className="inline-flex items-center cursor-pointer">
+            <span className="visually-hidden">{t('header.upload.label')}</span>
+            <input
+              type="file"
+              accept="application/pdf"
+              aria-label="upload lease"
+              className="text-small"
+              onChange={async (e) => {
+                const file = e.target.files?.[0];
+                if (!file) return;
+                await onUpload(file);
+              }}
+            />
+          </label>
+          <Button type="button" variant="default" size="sm" onClick={() => void onTrySample()}>
+            {t('header.trySample')}
+          </Button>
+          <span className="font-display italic text-small text-fg-muted">
+            …or drag a file anywhere on this row.
+          </span>
+        </div>
+
+        <div className="mt-9 pt-4 border-t border-rule-subtle flex flex-wrap gap-7 font-sans text-small text-fg-muted">
+          <span>● Local-first · no uploads</span>
+          <span>● 10 rules · 4 jurisdictions</span>
+          <span>● Ed25519-signed exports</span>
+          <span>● Hash-chained audit log</span>
+        </div>
+      </div>
+
+      {/* Right: "what you'll see" sample preview */}
+      <div
+        aria-label="what you will see"
+        className="border-l border-rule pl-6 font-mono text-mono text-fg-faint leading-relaxed"
+      >
+        <div className="mb-3 uppercase tracking-wide">// what you&apos;ll see</div>
+        {SAMPLE_PREVIEW.map((row, i) => (
+          <div
+            key={i}
+            className="pl-2.5 mb-3"
+            style={{ borderLeft: `2px solid var(--color-severity-${row.severity})` }}
+          >
+            <div
+              className="uppercase tracking-wide font-semibold mb-0.5"
+              style={{ color: `var(--color-severity-${row.severity})` }}
+            >
+              {row.label}
+            </div>
+            <div className="font-display italic text-fg-body text-[12.5px] leading-snug">
+              {row.text}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/src/ui/__tests__/viewmode.a11y.test.tsx
+++ b/app/src/ui/__tests__/viewmode.a11y.test.tsx
@@ -17,13 +17,7 @@ function renderShell(
 ) {
   return render(
     <I18nProvider>
-      <AppHeader
-        view={view}
-        showRedlineToggle={showRedlineToggle}
-        onUpload={() => {}}
-        onTrySample={() => {}}
-        onViewChange={() => {}}
-      />
+      <AppHeader view={view} showRedlineToggle={showRedlineToggle} onViewChange={() => {}} />
       {/* Matching tabpanels with the same ids the tabs reference, so
           aria-controls resolves and axe doesn't flag a dangling ref. */}
       {view === 'current' && (


### PR DESCRIPTION
## Summary

- Wave 51 Part B — moves first-run upload chrome out of the persistent header into a dedicated empty-state landing, and replaces the bare "Analyzing X…" line with a staged loader.
- New `UploadView` (annotated headline + drop-zone + sample preview column + footer chips) renders when `status.kind === 'idle'`. Adopted from the Claude Design handoff (`app-shell.jsx`).
- New `LoadingView` (5-step staged ticker, `role="status"` / `aria-live="polite"`) replaces the inline `<p>Analyzing…</p>`.
- New `OfflineDot` indicator (local-first / on-device badge) sits in the slim header.
- `AppHeader` slimmed to **wordmark + filename pill + tab pills + offline-dot + "New lease" reset** (when analyzed). The `<input type=file>` and "Try sample" button moved to UploadView.
- `App.tsx` wires UploadView for idle, LoadingView for loading, filename + onNewLease for the analyzed header.

## Test fallout

- `App.test.tsx` `uploadLease` helper auto-clicks "New lease" if a lease is already loaded so multi-lease flows still find the upload input.
- `viewmode.a11y.test.tsx` updated for the new prop shape.
- New tests: UploadView (4), LoadingView (4), OfflineDot (2).
- One axe rule fired on the first pass — `landmark-complementary-is-top-level` because the sample preview was an `<aside>` nested inside `<section role="region">`. Switched to a labelled `<div>`; story sweep clean.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test:coverage` — 1699 tests pass; coverage thresholds hold
- [x] `npm run build` clean
- [ ] Browser walk: cold load → annotated headline → drop a PDF → staged loader rolls through 4–5 stages → analyzed view → click "New lease" → returns to landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)