### PR TITLE
fix(test): kill fake-indexeddb InvalidStateError flake in useSigningKey.test

### DIFF
--- a/app/src/App.panels.test.tsx
+++ b/app/src/App.panels.test.tsx
@@ -181,7 +181,7 @@ beforeEach(async () => {
   _resetPacksDbForTests();
   _resetAnnotationsDbForTests();
   _resetCountersDbForTests();
-  _resetSigningDbForTests();
+  await _resetSigningDbForTests();
   _resetAuditDbForTests();
   _resetBulkDedupDbForTests();
   _resetRedlineDbForTests();

--- a/app/src/App/useSigningKey.test.ts
+++ b/app/src/App/useSigningKey.test.ts
@@ -32,14 +32,15 @@ afterAll(() => {
 afterEach(async () => {
   cleanup();
   // Drain any in-flight `refresh` IDB reads from the just-unmounted hook
-  // before the next test's `beforeEach` nulls the cached db promise.
+  // before we close the cached db handle — otherwise a concurrent getAll()
+  // races the close and rejects with InvalidStateError.
   await new Promise<void>((r) => setTimeout(r, 0));
   await new Promise<void>((r) => setTimeout(r, 0));
+  await _resetSigningDbForTests();
 });
 
 beforeEach(async () => {
-  _resetSigningDbForTests();
-  await new Promise<void>((r) => setTimeout(r, 0));
+  await _resetSigningDbForTests();
   await new Promise<void>((resolve) => {
     const req = indexedDB.deleteDatabase('leaseguard-signing');
     req.onsuccess = (): void => resolve();

--- a/app/src/security/signingKeys.migration.test.ts
+++ b/app/src/security/signingKeys.migration.test.ts
@@ -16,8 +16,7 @@ const V1_STORE = 'keypair';
 const V1_KEY_ID = 'active';
 
 async function wipe(): Promise<void> {
-  _resetSigningDbForTests();
-  await Promise.resolve();
+  await _resetSigningDbForTests();
   await new Promise<void>((resolve, reject) => {
     const req = indexedDB.deleteDatabase(SIGNING_DB_NAME);
     req.onsuccess = () => resolve();
@@ -70,7 +69,7 @@ describe('signingKeys: v1 -> v2 migration (Wave 8 Part D)', () => {
   it('preserves the existing keypair as a single key in the v2 layout, defaulted to id "k0"', async () => {
     const { publicKeyB64 } = await seedV1Record();
     // Force the module to re-open the db so its v2 upgrade path runs.
-    _resetSigningDbForTests();
+    await _resetSigningDbForTests();
 
     const all = await listKeys();
     expect(all).toHaveLength(1);

--- a/app/src/security/signingKeys.rotation.test.ts
+++ b/app/src/security/signingKeys.rotation.test.ts
@@ -19,8 +19,7 @@ import {
 import { at } from '../test/assert';
 
 async function wipeSigningDb(): Promise<void> {
-  _resetSigningDbForTests();
-  await Promise.resolve();
+  await _resetSigningDbForTests();
   await new Promise<void>((resolve, reject) => {
     const req = indexedDB.deleteDatabase(SIGNING_DB_NAME);
     req.onsuccess = () => resolve();
@@ -43,12 +42,7 @@ async function verifyB64(
     ['verify'],
   );
   const sigBytes = Uint8Array.from(atob(signature), (c) => c.charCodeAt(0));
-  return crypto.subtle.verify(
-    'Ed25519',
-    pubKey,
-    sigBytes as BufferSource,
-    payload as BufferSource,
-  );
+  return crypto.subtle.verify('Ed25519', pubKey, sigBytes as BufferSource, payload as BufferSource);
 }
 
 describe('signingKeys: key rotation (Wave 8 Part D)', () => {
@@ -113,8 +107,6 @@ describe('signingKeys: key rotation (Wave 8 Part D)', () => {
     const all = await listKeys();
     expect(all).toHaveLength(3);
     // The oldest key's public key is still present and still verifies.
-    expect(await verifyB64(sigFromK1.publicKey, sigFromK1.signature, payload)).toBe(
-      true,
-    );
+    expect(await verifyB64(sigFromK1.publicKey, sigFromK1.signature, payload)).toBe(true);
   });
 });

--- a/app/src/security/signingKeys.test.ts
+++ b/app/src/security/signingKeys.test.ts
@@ -12,9 +12,7 @@ import { WrongPassphraseError } from '../storage/archive';
 
 // Helper to wipe the signing DB between tests so we always start clean.
 async function wipeSigningDb(): Promise<void> {
-  _resetSigningDbForTests();
-  // Give the close() microtask a tick to land.
-  await Promise.resolve();
+  await _resetSigningDbForTests();
   await new Promise<void>((resolve, reject) => {
     const req = indexedDB.deleteDatabase(SIGNING_DB_NAME);
     req.onsuccess = () => resolve();

--- a/app/src/security/signingKeys.ts
+++ b/app/src/security/signingKeys.ts
@@ -62,14 +62,22 @@ export interface KeyRecord {
 
 let dbPromise: Promise<IDBPDatabase<SigningSchema>> | null = null;
 
-export function _resetSigningDbForTests(): void {
+export async function _resetSigningDbForTests(): Promise<void> {
   // Close the cached handle so fake-indexeddb's deleteDatabase isn't blocked.
-  if (dbPromise) {
-    void dbPromise.then((db) => {
-      db.close();
-    });
-  }
+  // Await the close so any in-flight reads on the previous handle settle
+  // before the next test reopens — otherwise a concurrent getAll() can race
+  // the close and reject with InvalidStateError as an unhandled rejection.
+  const prev = dbPromise;
   dbPromise = null;
+  if (prev) {
+    try {
+      const db = await prev;
+      db.close();
+    } catch {
+      // Swallow open failures from the previous test — the handle is being
+      // discarded anyway.
+    }
+  }
 }
 
 async function openSigningDb(): Promise<IDBPDatabase<SigningSchema>> {
@@ -93,9 +101,7 @@ async function openSigningDb(): Promise<IDBPDatabase<SigningSchema>> {
   return dbPromise;
 }
 
-async function migrateV1ToV2IfNeeded(
-  db: IDBPDatabase<SigningSchema>,
-): Promise<void> {
+async function migrateV1ToV2IfNeeded(db: IDBPDatabase<SigningSchema>): Promise<void> {
   const legacy = await db.get(STORE, V1_KEY_ID);
   if (!legacy) return;
   const migrated: StoredKeypair = {
@@ -182,9 +188,7 @@ export async function createSigningKey(passphrase: string): Promise<void> {
   await db.put(STORE, record);
 }
 
-export async function rotateKey(
-  passphrase: string,
-): Promise<{ id: string; publicKey: string }> {
+export async function rotateKey(passphrase: string): Promise<{ id: string; publicKey: string }> {
   const db = await openSigningDb();
   const all = await getAll(db);
   const prev = findActive(all);
@@ -204,10 +208,7 @@ export async function rotateKey(
   return { id: record.id, publicKey: record.publicKeyB64 };
 }
 
-async function buildKeyRecord(
-  passphrase: string,
-  id: string,
-): Promise<StoredKeypair> {
+async function buildKeyRecord(passphrase: string, id: string): Promise<StoredKeypair> {
   const kp = (await crypto.subtle.generateKey({ name: 'Ed25519' }, true, [
     'sign',
     'verify',
@@ -277,16 +278,10 @@ async function signWithRecord(
   } catch {
     throw new WrongPassphraseError();
   }
-  const privKey = await crypto.subtle.importKey(
-    'pkcs8',
-    privPkcs8,
-    { name: 'Ed25519' },
-    false,
-    ['sign'],
-  );
-  const sig = new Uint8Array(
-    await crypto.subtle.sign('Ed25519', privKey, payload as BufferSource),
-  );
+  const privKey = await crypto.subtle.importKey('pkcs8', privPkcs8, { name: 'Ed25519' }, false, [
+    'sign',
+  ]);
+  const sig = new Uint8Array(await crypto.subtle.sign('Ed25519', privKey, payload as BufferSource));
   return {
     signature: bytesToBase64(sig),
     publicKey: record.publicKeyB64,

--- a/app/src/storage/exportReport.test.ts
+++ b/app/src/storage/exportReport.test.ts
@@ -1,9 +1,5 @@
 import { beforeEach, describe, it, expect } from 'vitest';
-import {
-  exportFindingsJson,
-  signExport,
-  verifySignedExport,
-} from './exportReport';
+import { exportFindingsJson, signExport, verifySignedExport } from './exportReport';
 import type { LeaseDocument } from '../parser/types';
 import type { Finding } from '../rules/types';
 import {
@@ -13,8 +9,7 @@ import {
 } from '../security/signingKeys';
 
 async function wipeSigningDb(): Promise<void> {
-  _resetSigningDbForTests();
-  await Promise.resolve();
+  await _resetSigningDbForTests();
   await new Promise<void>((resolve, reject) => {
     const req = indexedDB.deleteDatabase(SIGNING_DB_NAME);
     req.onsuccess = () => resolve();
@@ -81,17 +76,13 @@ describe('exportFindingsJson', () => {
   });
 
   it('handles empty findings', () => {
-    const parsed = JSON.parse(
-      exportFindingsJson({ name: 'X', doc: doc(), findings: [] }),
-    );
+    const parsed = JSON.parse(exportFindingsJson({ name: 'X', doc: doc(), findings: [] }));
     expect(parsed.findings).toEqual([]);
     expect(parsed.rulePackVersion).toBe(null);
   });
 
   it('includes inputHash=null by default', () => {
-    const parsed = JSON.parse(
-      exportFindingsJson({ name: 'X', doc: doc(), findings: [] }),
-    );
+    const parsed = JSON.parse(exportFindingsJson({ name: 'X', doc: doc(), findings: [] }));
     expect(parsed.inputHash).toBeNull();
   });
 
@@ -147,8 +138,7 @@ describe('signExport / verifySignedExport', () => {
     const parsed = JSON.parse(signed);
     // Flip one byte in the signature by swapping the first base64 char.
     const sig = parsed.signature.signature as string;
-    parsed.signature.signature =
-      (sig.startsWith('A') ? 'B' : 'A') + sig.slice(1);
+    parsed.signature.signature = (sig.startsWith('A') ? 'B' : 'A') + sig.slice(1);
     const bad = JSON.stringify(parsed, null, 2);
     expect(await verifySignedExport(bad)).toBe(false);
   });


### PR DESCRIPTION
## Summary
- Race between `_resetSigningDbForTests` (fire-and-forget close) and an in-flight `refresh()` `getAll()` from a just-unmounted `useSigningKey` hook produced a `fake-indexeddb` `InvalidStateError` (code 11) unhandled rejection. The test file's `unhandledRejection` swallower masked it from CI but vitest still surfaced it as `Errors 1`.
- Made `_resetSigningDbForTests` async: awaits the cached open before `db.close()`, so callers can sequence the close after pending reads.
- `useSigningKey.test.ts` `afterEach` now drains microtasks then awaits the close (kills the race for the last test in the file too).
- Updated 5 other call sites to `await` the reset and removed their now-redundant `await Promise.resolve()` warm-up ticks.

## Test plan
- [x] `npm test -- --run` — 1699 passed, 0 errors logged (was 1 unhandled-rejection error before)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] Re-ran the 6 affected test files in a 3x stability loop — green every run