### PR TITLE
wave51-f: portfolio totals + redline header + audit footer

### DIFF
--- a/app/src/ui/AppRedlinePane.tsx
+++ b/app/src/ui/AppRedlinePane.tsx
@@ -26,8 +26,21 @@ export function AppRedlinePane({
   sectionForParagraph,
   safeAudit,
 }: AppRedlinePaneProps): JSX.Element {
+  const editCount = redline.redlineEdits.length;
   return (
     <>
+      <header aria-label="redline header" className="px-4 pt-4 pb-3 border-b border-rule">
+        <p className="text-mono uppercase text-fg-muted mb-1">Redline · counter-proposal</p>
+        <p className="text-heading text-fg-body">
+          {editCount === 0
+            ? 'No edits yet — start by editing a paragraph below.'
+            : `${editCount} paragraph${editCount === 1 ? '' : 's'} edited`}
+        </p>
+        <p className="text-small text-fg-muted italic mt-1">
+          Original on the left, what you&rsquo;d ask for on the right. Export as HTML or paste into
+          your reply.
+        </p>
+      </header>
       <RedlinePanel
         doc={doc}
         edits={redline.redlineEdits}

--- a/app/src/ui/AuditLogPanel.tsx
+++ b/app/src/ui/AuditLogPanel.tsx
@@ -75,43 +75,59 @@ export function AuditLogPanel({
           <em>No audit entries yet.</em>
         </p>
       ) : (
-        <div className="overflow-x-auto">
-          <table
-            aria-label="audit entries"
-            className="w-full text-small text-fg-body border-collapse"
-          >
-            <thead>
-              <tr className="border-b border-rule">
-                <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">
-                  #
-                </th>
-                <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">
-                  Time
-                </th>
-                <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">
-                  Kind
-                </th>
-                <th scope="col" className="text-left py-1 text-fg-muted font-sans">
-                  Payload
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {entries.map((e) => (
-                <tr key={e.seq} className="even:bg-paper-sunken border-b border-rule-subtle">
-                  <td className="py-1 pr-3">{e.seq}</td>
-                  <td className="py-1 pr-3">{e.timestamp}</td>
-                  <td className="py-1 pr-3">{e.kind}</td>
-                  <td className="py-1">
-                    <code className="font-mono text-mono text-fg-body">
-                      {summarizePayload(e.payload)}
-                    </code>
-                  </td>
+        <>
+          <div className="overflow-x-auto">
+            <table
+              aria-label="audit entries"
+              className="w-full text-small text-fg-body border-collapse"
+            >
+              <thead>
+                <tr className="border-b border-rule">
+                  <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">
+                    #
+                  </th>
+                  <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">
+                    Time
+                  </th>
+                  <th scope="col" className="text-left py-1 pr-3 text-fg-muted font-sans">
+                    Kind
+                  </th>
+                  <th scope="col" className="text-left py-1 text-fg-muted font-sans">
+                    Payload
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {entries.map((e) => (
+                  <tr key={e.seq} className="even:bg-paper-sunken border-b border-rule-subtle">
+                    <td className="py-1 pr-3">{e.seq}</td>
+                    <td className="py-1 pr-3">{e.timestamp}</td>
+                    <td className="py-1 pr-3">{e.kind}</td>
+                    <td className="py-1">
+                      <code className="font-mono text-mono text-fg-body">
+                        {summarizePayload(e.payload)}
+                      </code>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div
+            aria-label="audit chain footer"
+            className="pt-3 border-t border-rule font-mono text-mono text-fg-muted leading-relaxed"
+          >
+            <div>
+              ● {entries.length} entr{entries.length === 1 ? 'y' : 'ies'} · chain head{' '}
+              <span className="text-fg-body">
+                {shortHash(entries[entries.length - 1]?.entryHash)}
+              </span>
+            </div>
+            <div>
+              ● Tamper-evident hash chain · entries verify against the previous entry&rsquo;s hash
+            </div>
+          </div>
+        </>
       )}
     </Section>
   );
@@ -121,6 +137,12 @@ export function AuditLogPanel({
  * Keep the row compact. We intentionally truncate: the full payload is in
  * the downloaded JSON, the table is for at-a-glance scanning.
  */
+function shortHash(hash: string | undefined): string {
+  if (!hash) return '—';
+  if (hash.length <= 16) return hash;
+  return `${hash.slice(0, 8)}…${hash.slice(-8)}`;
+}
+
 function summarizePayload(payload: Record<string, unknown>): string {
   const keys = Object.keys(payload);
   if (keys.length === 0) return '{}';

--- a/app/src/ui/PortfolioPanel.tsx
+++ b/app/src/ui/PortfolioPanel.tsx
@@ -10,10 +10,7 @@
 //
 import { useEffect, useMemo, useState } from 'react';
 import type { LeaseMetadata } from '../storage/storage';
-import {
-  listLeasesFiltered,
-  type ListLeasesFilter,
-} from '../storage/listLeasesFiltered';
+import { listLeasesFiltered, type ListLeasesFilter } from '../storage/listLeasesFiltered';
 import type { Finding, Severity } from '../rules/types';
 import { PortfolioRollupsPanel } from './PortfolioRollupsPanel';
 import { aggregateFindings } from '../portfolio/ruleRollups';
@@ -80,9 +77,7 @@ export function PortfolioPanel({
 
   const baseVisible = filter && filtered ? filtered : leases;
   const restrictIds = drillIds ?? filterLeaseIds ?? null;
-  const visible = restrictIds
-    ? baseVisible.filter((l) => restrictIds.includes(l.id))
-    : baseVisible;
+  const visible = restrictIds ? baseVisible.filter((l) => restrictIds.includes(l.id)) : baseVisible;
 
   // Rollups computed from the unrestricted base set so users can always
   // see the cross-portfolio picture even after drilling through.
@@ -108,13 +103,23 @@ export function PortfolioPanel({
 
   const columns = rankRuleColumns(visible, findingsByLease);
 
+  const totals = severityTotals(visible, findingsByLease);
+
   return (
     <Section label="portfolio" className="space-y-3 px-4 py-4">
-      <h2 className="text-heading uppercase text-fg-muted">Portfolio</h2>
-      <PortfolioRollupsPanel
-        rollups={rollups}
-        onDrillThrough={(ids) => setDrillIds(ids)}
-      />
+      <div className="flex items-baseline justify-between gap-4 flex-wrap">
+        <h2 className="text-heading uppercase text-fg-muted">Portfolio</h2>
+        <div
+          aria-label="portfolio totals"
+          className="flex gap-5 items-baseline pl-5 border-l border-rule font-sans text-small"
+        >
+          <SeverityTotal label="High" count={totals.high} severity="high" />
+          <SeverityTotal label="Medium" count={totals.medium} severity="medium" />
+          <SeverityTotal label="Low" count={totals.low} severity="low" />
+          <SeverityTotal label="Info" count={totals.info} severity="info" />
+        </div>
+      </div>
+      <PortfolioRollupsPanel rollups={rollups} onDrillThrough={(ids) => setDrillIds(ids)} />
       {drillIds !== null && (
         <p>
           <Button type="button" variant="ghost" size="sm" onClick={() => setDrillIds(null)}>
@@ -126,11 +131,19 @@ export function PortfolioPanel({
         <table aria-label="portfolio" className="text-small text-fg-body border-collapse">
           <thead>
             <tr className="border-b border-rule">
-              <th scope="col" data-sticky="true" className="portfolio-sticky text-left py-1 pr-4 text-fg-muted font-sans">
+              <th
+                scope="col"
+                data-sticky="true"
+                className="portfolio-sticky text-left py-1 pr-4 text-fg-muted font-sans"
+              >
                 Lease
               </th>
               {columns.map((c) => (
-                <th key={c.ruleId} scope="col" className="text-left py-1 pr-3 text-fg-muted font-mono text-mono">
+                <th
+                  key={c.ruleId}
+                  scope="col"
+                  className="text-left py-1 pr-3 text-fg-muted font-mono text-mono"
+                >
                   {c.ruleId}
                 </th>
               ))}
@@ -141,8 +154,16 @@ export function PortfolioPanel({
               const findings = findingsByLease.get(lease.id) ?? [];
               const bestBySeverity = bestSeverityByRule(findings);
               return (
-                <tr key={lease.id} aria-label={lease.name} className="even:bg-paper-sunken border-b border-rule-subtle">
-                  <th scope="row" data-sticky="true" className="portfolio-sticky py-2 pr-4 text-left align-top font-normal">
+                <tr
+                  key={lease.id}
+                  aria-label={lease.name}
+                  className="even:bg-paper-sunken border-b border-rule-subtle"
+                >
+                  <th
+                    scope="row"
+                    data-sticky="true"
+                    className="portfolio-sticky py-2 pr-4 text-left align-top font-normal"
+                  >
                     <button
                       type="button"
                       onClick={() => onOpenLease(lease.id)}
@@ -161,7 +182,11 @@ export function PortfolioPanel({
                     const sev = bestBySeverity.get(c.ruleId);
                     return (
                       <td key={c.ruleId} className="py-2 pr-3 align-top">
-                        {sev ? <SeverityBadge severity={sev} /> : <span className="text-fg-muted">—</span>}
+                        {sev ? (
+                          <SeverityBadge severity={sev} />
+                        ) : (
+                          <span className="text-fg-muted">—</span>
+                        )}
                       </td>
                     );
                   })}
@@ -175,6 +200,42 @@ export function PortfolioPanel({
   );
 }
 
+function SeverityTotal({
+  label,
+  count,
+  severity,
+}: {
+  label: string;
+  count: number;
+  severity: Severity;
+}): JSX.Element {
+  const COLOR: Record<Severity, string> = {
+    high: 'text-severity-high',
+    medium: 'text-severity-medium',
+    low: 'text-severity-low',
+    info: 'text-severity-info',
+  };
+  return (
+    <span className="flex flex-col gap-0.5">
+      <span className="text-mono text-fg-muted uppercase">{label}</span>
+      <span className={`text-heading font-semibold ${COLOR[severity]}`}>{count}</span>
+    </span>
+  );
+}
+
+function severityTotals(
+  leases: LeaseMetadata[],
+  findingsByLease: Map<string, Finding[]>,
+): Record<Severity, number> {
+  const t: Record<Severity, number> = { high: 0, medium: 0, low: 0, info: 0 };
+  for (const lease of leases) {
+    for (const f of findingsByLease.get(lease.id) ?? []) {
+      t[f.severity]++;
+    }
+  }
+  return t;
+}
+
 function SeverityBadge({ severity }: { severity: Severity }): JSX.Element {
   const COLOR: Record<Severity, string> = {
     high: 'bg-severity-high/10 text-severity-high border-severity-high/30',
@@ -183,7 +244,10 @@ function SeverityBadge({ severity }: { severity: Severity }): JSX.Element {
     info: 'bg-severity-info/10 text-severity-info border-severity-info/30',
   };
   return (
-    <span className={`inline-flex items-center px-1.5 py-0.5 rounded-sm border text-small font-sans ${COLOR[severity]}`} data-severity={severity}>
+    <span
+      className={`inline-flex items-center px-1.5 py-0.5 rounded-sm border text-small font-sans ${COLOR[severity]}`}
+      data-severity={severity}
+    >
       {severity}
     </span>
   );


### PR DESCRIPTION
## Summary

Wave 51 Part F (final). Adds the Marginalia design handoff's visual
headers to the three remaining panels:

- **PortfolioPanel** — severity totals strip (High/Med/Low/Info counts
  across visible leases) sits beside the heading.
- **AppRedlinePane** — \"Redline · counter-proposal\" header with live
  edit count.
- **AuditLogPanel** — mono footer with entry count + truncated chain
  head hash.

Aria inventory preserved verbatim per plan §1.5; no test rewrites.

## Test plan

- [x] \`npm run typecheck && npm run lint\` clean
- [x] \`npm test\` — 1741 passed (PortfolioPanel + AppRedlinePane + AuditLogPanel suites green)
- [x] \`npm run build && npm run check:budget\` — under budget
- [ ] CI: smoke + Lighthouse + verify + npm-audit green

🤖 Generated with [Claude Code](https://claude.com/claude-code)