### PR TITLE
wave51 closeout: BACKLOG Phase 20 done + DESIGN.md marginalia entry

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -360,6 +360,30 @@ description-below pattern.
 - **Mobile:** the rail collapses to a single-row tab strip; tap
   targets stay at 44px.
 
+### Marginalia Reader
+
+The default reading surface on the Current tab as of Wave 51. The
+PdfViewer is reachable behind a one-click `ReaderPdfToggle`; both
+share the selected-finding state.
+
+- **`MarginaliaReader`:** serif body text (`LeaseDocument.paragraphs`)
+  with inline `<mark>` highlights for finding excerpts and a margin
+  column of finding cards. Hybrid (LLM-classified) findings render in
+  the margin without an inline highlight — their `evidence.span` is a
+  paragraph-prefix, not ground truth.
+- **`FindingRail`:** 28px vertical heatmap to the left of the reader,
+  one cell per paragraph, colored by max severity, click-to-jump.
+- **`FindingDetailModal`:** scholarly-footnote two-pane modal (clause
+  on the left, footnote on the right with title / plain English / why
+  it matters / suggested edit / Apply / Counter-offer). Replaces the
+  inline `SelectedFindingCard`. Reuses `Dialog` (focus trap, Esc,
+  return-focus, `inert` siblings).
+- **Glossary popover:** `GlossaryTerm` renders a focusable trigger
+  with a `role="tooltip"` popover that opens on hover OR focus and
+  closes on Esc. When nested inside an outer button (e.g.
+  `FindingsPanel`'s `.finding-btn` snippet), the trigger downgrades
+  to a non-focusable `<span>` to avoid `nested-interactive`.
+
 ### PDF Highlight Layer
 
 - **Fill:** `rgba(255, 235, 59, 0.35)` (light mode) / `rgba(255, 235,

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -766,35 +766,35 @@ Decisions (settled 2026-04-29):
 
 ### Reading surface
 
-- [ ] New `MarginaliaReader` component — renders
+- [x] New `MarginaliaReader` component — renders
       `LeaseDocument.paragraphs` as serif body text with inline `<mark>`
       highlights for finding excerpts and a right-margin column of
       finding cards (severity-coded left border, plain-English snippet,
       paragraph reference). Source: `document-pane.jsx`. Default view
       on the Current tab; PdfViewer reachable behind an in-tab toggle.
-- [ ] In-tab "Reader / PDF" toggle on Current — shared selected-finding
+- [x] In-tab "Reader / PDF" toggle on Current — shared selected-finding
       state, shared scroll-into-view contract for the active highlight,
       keyboard parity (`/` focus search, ↑/↓/Enter through findings).
-- [ ] New `FindingRail` component — 28px vertical column, one cell per
+- [x] New `FindingRail` component — 28px vertical column, one cell per
       paragraph, colored by max severity, click-to-jump. Source:
       `app-main.jsx` `FindingRail`. Pure derived state from
       `findings + paragraphs`.
-- [ ] Marginalia paragraph numbering + heading detection re-use of
+- [x] Marginalia paragraph numbering + heading detection re-use of
       existing `paragraphs[].kind` (`title` / `h2` / `meta` / body).
       Verify parser already emits these kinds; backfill `meta` if not.
-- [ ] Glossary tooltip — restyle the existing `highlightDefinedTerms`
+- [x] Glossary tooltip — restyle the existing `highlightDefinedTerms`
       output to use the handoff's `GlossaryTip` popover (dark inverted
       card, term + definition, hover/focus). Source: `document-pane.jsx`.
 
 ### Findings panel + detail
 
-- [ ] New `FindingDetailModal` — scholarly-footnote two-pane modal
+- [x] New `FindingDetailModal` — scholarly-footnote two-pane modal
       (clause-as-page on the left, footnote with title / plain English /
       "why it matters" / suggested edit / apply buttons on the right,
       prev/next nav). Source: `findings-panel.jsx` `FindingDetail`.
       Replaces the inline `SelectedFindingCard`; preserves
       apply-suggestion + save-as-counter + promote-to-standard hooks.
-- [ ] Restyle `FindingsPanel` header — large "N worth a closer look"
+- [x] Restyle `FindingsPanel` header — large "N worth a closer look"
       display + severity chips with counts inline. Preserve existing
       category filters, collapsible severity sections, hybrid LLM badge,
       explainer disclosure, apply-suggestion + promote-to-standard
@@ -802,64 +802,64 @@ Decisions (settled 2026-04-29):
 
 ### Header + landing
 
-- [ ] Slim `AppHeader` — wordmark + filename + tab pills +
+- [x] Slim `AppHeader` — wordmark + filename + tab pills +
       offline-on-device indicator + "New lease" reset. Privacy
       `<details>`, locale picker, theme toggle, and the upload control
       relocate to the Settings tab; the empty-state `UploadView`
       carries the upload affordance for first-run.
-- [ ] New `UploadView` empty state — "Most leases are *fine.* Three
+- [x] New `UploadView` empty state — "Most leases are *fine.* Three
       clauses are *not.*" headline, drop-zone row, "what you'll see"
       sample column, footer chips (local-first / 10 rules / Ed25519 /
       audit log). Source: `app-shell.jsx`.
-- [ ] New `LoadingView` staged ticker — "Reading PDF…",
+- [x] New `LoadingView` staged ticker — "Reading PDF…",
       "Reconstructing paragraphs…", etc. Drive stages off
       `usePipeline` lifecycle events instead of a `setTimeout` chain.
 
 ### Portfolio + redline + audit
 
-- [ ] Restyle `PortfolioPanel` to the card-grid layout — status badge,
+- [x] Restyle `PortfolioPanel` to the card-grid layout — status badge,
       mini severity heatmap (one cell per finding), totals strip in the
       header. Wire to existing `listAllLeaseRecords()`; do not ship the
       handoff's hard-coded sample list.
-- [ ] Restyle `AppRedlinePane` — side-by-side diff with apply-all /
+- [x] Restyle `AppRedlinePane` — side-by-side diff with apply-all /
       clear-all / per-finding chip toggles. The handoff's "Export PDF"
       button routes to the existing signed-JSON / HTML export paths;
       no new redline-PDF export.
-- [ ] Restyle `AuditLogPanel` — mono-font 4-column table
+- [x] Restyle `AuditLogPanel` — mono-font 4-column table
       (time / verb / object / hash) + Merkle-root / public-key footer.
       Preserve verify-chain + download buttons.
 
 ### Settings tab (5th view)
 
-- [ ] Add `'settings'` to `AppViewMode`; add a 5th tab pill in the slim
+- [x] Add `'settings'` to `AppViewMode`; add a 5th tab pill in the slim
       header; mount a new `AppSettingsPane` under
       `viewmode-panel-settings`.
-- [ ] Move `AppLibraryAndPacksPane` (library, pack manager,
+- [x] Move `AppLibraryAndPacksPane` (library, pack manager,
       marketplace, jurisdiction picker, severity overrides, custom
       rule builder, clause templates, standard suite, signing key,
       encrypted archive, share review, bulk import) under the
       Settings tab.
-- [ ] Move privacy `<details>`, `LocalePickerPanel`, and `ThemeToggle`
+- [x] Move privacy `<details>`, `LocalePickerPanel`, and `ThemeToggle`
       under the Settings tab. Theme toggle stays the dark-mode entry
       point.
-- [ ] Footer "About / Privacy / Settings" link routes to Settings; the
+- [x] Footer "About / Privacy / Settings" link routes to Settings; the
       old `AppFooterControls` (encrypted archive + clear-all) folds
       into the Settings tab too.
 
 ### Migration hygiene
 
-- [ ] Ensure new components follow the four-file convention
+- [x] Ensure new components follow the four-file convention
       (component / test / story / wire-up) per `docs/CLAUDE.md`.
-- [ ] No-side-stripe policy still passes (handoff uses 2px
+- [x] No-side-stripe policy still passes (handoff uses 2px
       borderLeft on margin notes — update the policy's allow-list or
       switch to a 1px hairline + tinted background, per DESIGN.md
       Hairline rule).
-- [ ] All new severity surfaces use `<Card variant="severity-…">` +
+- [x] All new severity surfaces use `<Card variant="severity-…">` +
       leading `<Badge variant="severity">`; no ad-hoc
       `border-l-${color}` shortcuts.
-- [ ] axe + Lighthouse a11y gates remain green; new components covered
+- [x] axe + Lighthouse a11y gates remain green; new components covered
       by `src/ui/__tests__/all-stories.a11y.test.tsx`.
-- [ ] Once IA settles, archive `claude_design_handoff_leaseguard/`
+- [x] Once IA settles, archive `claude_design_handoff_leaseguard/`
       (move under `docs/design-archives/` or delete) so it stops
       shadowing the live code.
 


### PR DESCRIPTION
## Summary

Wave 51 closeout per `docs/plans/wave51-marginalia-integration.md` §9.

- All 22 Phase 20 boxes in `docs/BACKLOG.md` flipped to done.
- `DESIGN.md` §5 grows a Marginalia Reader entry — `MarginaliaReader`,
  `FindingRail`, `FindingDetailModal`, `GlossaryTerm` are now
  canonical; PdfViewer is the `ReaderPdfToggle` fallback.
- Untracked design handoff (`claude_design_handoff_leaseguard/`)
  removed from working tree (never tracked).
- Memory entry `feedback_marginalia_default.md` saved so future
  agents don't re-litigate the IA decision.

## Test plan

- [x] No code changes — docs-only.
- [ ] CI: docs-only, smoke + verify should pass trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)