### PR TITLE
wave53-a: tokens + Source Serif 4 fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
           cache: 'npm'
           cache-dependency-path: app/package-lock.json
       - run: npm ci
+      - run: npm run build:design-fonts
+      - run: npm run check:fonts
       - run: npm run typecheck
       - run: npm run lint
       - run: npm run test:coverage

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,6 +35,9 @@ jobs:
           restore-keys: ms-playwright-${{ runner.os }}-${{ matrix.browser }}-
       - name: Install ${{ matrix.browser }} + system deps
         run: npx playwright install --with-deps ${{ matrix.browser }}
+      - name: Fetch design fonts
+        working-directory: app
+        run: npm run build:design-fonts
       - name: Build app
         working-directory: app
         run: npm run build

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -20,6 +20,8 @@ jobs:
           cache-dependency-path: app/package-lock.json
       - name: Install dependencies
         run: npm ci
+      - name: Fetch design fonts
+        run: npm run build:design-fonts
       - name: Build production bundle
         run: npm run build
       - name: Run Lighthouse CI

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ app/public/classifier/*
 .superpowers/
 logs_ci_verify/
 .impeccable-live.json
+docs/design_handoff_leaseguard/

--- a/app/package.json
+++ b/app/package.json
@@ -23,6 +23,7 @@
     "postinstall": "node scripts/build-tesseract-assets.mjs",
     "check:budget": "node scripts/check-bundle-budget.mjs",
     "check:csp": "node scripts/check-csp.mjs",
+    "check:fonts": "node scripts/check-fonts.mjs",
     "audit:prod": "node scripts/audit-prod.mjs",
     "hybrid:stats": "node scripts/hybrid-stats-report.mjs",
     "lhci": "lhci autorun",

--- a/app/scripts/check-fonts.mjs
+++ b/app/scripts/check-fonts.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Wave 53-A — validate that every font file referenced by index.css is
+// (a) present in public/fonts/, (b) non-empty, (c) starts with the wOF2
+// magic. Without this, a missing or stub font silently falls through
+// font-display: swap to platform-serif fallbacks (Iowan / Georgia) and
+// every typography decision in DESIGN.md is rendered through the wrong
+// metrics.
+//
+// Caught during Wave 52: the dev server returned an HTML 404 page for
+// /fonts/source-serif-4-{400,600}.woff2 because public/fonts/ contained
+// only a .gitkeep. Browser parsed the HTML as a font and reported
+// "OTS parsing error: invalid sfntVersion: 1008821359" (== '<!DO').
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FONTS_DIR = join(__dirname, '..', 'public', 'fonts');
+
+const REQUIRED = ['source-serif-4-400.woff2', 'source-serif-4-600.woff2'];
+const WOF2_MAGIC = Buffer.from([0x77, 0x4f, 0x46, 0x32]); // 'wOF2'
+
+const failures = [];
+for (const name of REQUIRED) {
+  const path = join(FONTS_DIR, name);
+  if (!existsSync(path)) {
+    failures.push(`${name}: missing`);
+    continue;
+  }
+  const size = statSync(path).size;
+  if (size === 0) {
+    failures.push(`${name}: empty file`);
+    continue;
+  }
+  const head = Buffer.alloc(4);
+  const fd = readFileSync(path).subarray(0, 4);
+  if (!fd.equals(WOF2_MAGIC)) {
+    failures.push(`${name}: bad magic (${fd.toString('hex')}); not a woff2`);
+    continue;
+  }
+  console.log(`  ${name} OK (${(size / 1024).toFixed(1)} KiB)`);
+}
+
+if (failures.length > 0) {
+  console.error('\n[check-fonts] failed:');
+  for (const f of failures) console.error('  ' + f);
+  console.error('\nRun `npm run build:design-fonts` to fetch the woff2s.');
+  process.exit(1);
+}
+console.log('[check-fonts] OK.');

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -42,6 +42,8 @@
 
   /* Single accent */
   --color-ink: #1f3a4d;
+  /* Wave 53-A — hover step (handoff `--ink-90`). 10% lighter than ink. */
+  --color-ink-90: #233f54;
 
   /* Severity (functional color, never the sole signal) */
   --color-severity-high: #b1442d;
@@ -108,6 +110,13 @@
   /* Single shadow */
   --shadow-paper: 0 1px 0 rgba(42, 35, 22, 0.05);
 
+  /* Wave 53-A — document rhythm tokens. Drive paragraph spacing and
+     line-height in the marginalia reader so future density variants
+     can override at the @theme level. Defaults match the handoff's
+     `data-density="default"` row in styles.css. */
+  --para-pad: 12px;
+  --line-h: 1.65;
+
   /* PDF highlight overlay — semi-transparent by design; no opaque hex form exists */
   --color-highlight: rgba(255, 235, 59, 0.35);
   --color-highlight-border: rgba(255, 193, 7, 0.9);
@@ -147,6 +156,8 @@
 
   /* Single accent — lifted steel blue */
   --color-ink: #7ba9c4;
+  /* Wave 53-A — hover step on dark. Slightly brighter (closer to white). */
+  --color-ink-90: #8db5cd;
 
   /* Severity (functional color, never the sole signal) — brightened
      for legibility on dark surfaces. severity-bg / severity-border


### PR DESCRIPTION
Part A of Wave 53 design fidelity. Tokens (`--color-ink-90`, `--para-pad`, `--line-h`) and the Source Serif 4 woff2 fix that should have shipped with Wave 27.

Caught during Wave 52 live walkthrough: dev server was returning HTML 404s for the font paths because public/fonts was empty. Browser parsed the HTML as a font and threw `OTS parsing error` warnings. Every Wave 51/52 typography choice was rendered through Iowan / Georgia fallback, not Source Serif 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)