### PR TITLE
wave53-b-1: promote Audit to a top-level view

### DIFF
--- a/app/src/App.panels.test.tsx
+++ b/app/src/App.panels.test.tsx
@@ -461,7 +461,9 @@ describe('App panel wire-ups', () => {
   it('AuditLogPanel populates entries after an analyze and verifies the chain', async () => {
     render(<App />);
     await uploadLease('Auditing.pdf');
-    // At least the analyze start/complete entries should appear.
+    // Wave 53-B-1: audit log is now a top-level view (peer of Current /
+    // Portfolio / Redline). Switch to it before reaching for the table.
+    await userEvent.click(screen.getByRole('tab', { name: /^audit$/i }));
     await waitFor(() => {
       expect(screen.getByRole('table', { name: /audit entries/i })).toBeInTheDocument();
     });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -73,6 +73,7 @@ const AppCurrentPane = lazy(() =>
 import { AnalyzedPaneBoundary } from './ui/AnalyzedPaneBoundary';
 import { AppLibraryAndPacksPane } from './ui/AppLibraryAndPacksPane';
 import { AppSettingsPane } from './ui/AppSettingsPane';
+import { AppAuditPane } from './ui/AppAuditPane';
 // UploadView + LoadingView are state-specific and bulky together (~3 KB);
 // lazy-load both to keep the app shell under budget. UploadView is the
 // idle-state landing — its chunk warms on first paint behind a no-op
@@ -126,7 +127,9 @@ function AppContent(): JSX.Element {
   const [templates, setTemplates] = useState<ClauseTemplate[]>([]);
   const [auditEntries, setAuditEntries] = useState<AuditEntry[]>([]);
   const [auditVerification, setAuditVerification] = useState<ChainVerification | null>(null);
-  const [view, setView] = useState<'current' | 'portfolio' | 'redline' | 'settings'>('current');
+  const [view, setView] = useState<'current' | 'portfolio' | 'redline' | 'audit' | 'settings'>(
+    'current',
+  );
   const [portfolioFindings, setPortfolioFindings] = useState<Map<string, Finding[]>>(new Map());
   const [standardSuite, setStandardSuite] = useState<StandardClause[]>([]);
 
@@ -562,7 +565,6 @@ function AppContent(): JSX.Element {
         }
         customRuleBuilderDoc={status.kind === 'analyzed' ? status.result.doc : null}
         auditEntries={auditEntries}
-        auditVerification={auditVerification}
         signingKey={signingKey}
         comparison={comparison}
         onOpenLibrary={(id) => void onOpenLibrary(id)}
@@ -573,20 +575,34 @@ function AppContent(): JSX.Element {
         onSaveTemplate={(input) => void saveTemplate(input).then(refreshTemplates)}
         onUpdateTemplate={(id, patch) => void updateTemplate(id, patch).then(refreshTemplates)}
         onDeleteTemplate={(id) => void deleteTemplate(id).then(refreshTemplates)}
-        onRefreshAuditLog={() => void refreshAuditLog()}
-        onVerifyAuditChain={() => {
-          void (async (): Promise<void> => {
-            setAuditVerification(await verifyAuditChain());
-          })();
-        }}
-        onDownloadAuditLog={(entries, verification) => {
-          const json = buildAuditLogJson(entries, verification);
-          downloadAuditLogBlob(
-            json,
-            `leaseguard-audit-${new Date().toISOString().slice(0, 10)}.json`,
-          );
-        }}
       />
+
+      <div
+        role="tabpanel"
+        id="viewmode-panel-audit"
+        aria-labelledby="viewmode-tab-audit"
+        hidden={view !== 'audit'}
+      >
+        {view === 'audit' && (
+          <AppAuditPane
+            entries={auditEntries}
+            verification={auditVerification}
+            onRefresh={() => void refreshAuditLog()}
+            onVerify={() => {
+              void (async (): Promise<void> => {
+                setAuditVerification(await verifyAuditChain());
+              })();
+            }}
+            onDownload={(entries, verification) => {
+              const json = buildAuditLogJson(entries, verification);
+              downloadAuditLogBlob(
+                json,
+                `leaseguard-audit-${new Date().toISOString().slice(0, 10)}.json`,
+              );
+            }}
+          />
+        )}
+      </div>
 
       <div
         role="tabpanel"

--- a/app/src/i18n/locales/es.ts
+++ b/app/src/i18n/locales/es.ts
@@ -17,6 +17,7 @@ export const es: Partial<Messages> = {
   'header.view.current': 'Contrato actual',
   'header.view.portfolio': 'Cartera',
   'header.view.redline': 'Edición',
+  'header.view.audit': 'Auditoría',
   'header.view.settings': 'Configuración',
   'settings.section.preferences': 'Preferencias',
   'settings.section.privacy': 'Privacidad',

--- a/app/src/i18n/messages.ts
+++ b/app/src/i18n/messages.ts
@@ -24,6 +24,7 @@ export const en = {
   'header.view.current': 'Current lease',
   'header.view.portfolio': 'Portfolio',
   'header.view.redline': 'Redline',
+  'header.view.audit': 'Audit',
   'header.view.settings': 'Settings',
   'settings.section.preferences': 'Preferences',
   'settings.section.privacy': 'Privacy',

--- a/app/src/ui/AppAuditPane.test.tsx
+++ b/app/src/ui/AppAuditPane.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AppAuditPane } from './AppAuditPane';
+import type { AuditEntry } from '../audit/auditLog';
+
+function entry(seq: number, kind = 'analyze'): AuditEntry {
+  return {
+    seq,
+    timestamp: `2026-04-30T0${seq}:00:00.000Z`,
+    kind,
+    payload: { fileName: `lease-${seq}.pdf` },
+    prevHash: seq === 1 ? '' : 'a'.repeat(64),
+    entryHash: 'b'.repeat(64),
+  };
+}
+
+describe('AppAuditPane', () => {
+  it('renders the audit log table after lazy load', async () => {
+    render(
+      <AppAuditPane
+        entries={[entry(1), entry(2, 'export')]}
+        verification={null}
+        onRefresh={vi.fn()}
+        onVerify={vi.fn()}
+        onDownload={vi.fn()}
+      />,
+    );
+    // AuditLogPanel is lazy; resolves async.
+    expect(await screen.findByRole('table', { name: /audit entries/i })).toBeInTheDocument();
+    expect(screen.getByText('analyze')).toBeInTheDocument();
+    expect(screen.getByText('export')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when no entries', async () => {
+    render(
+      <AppAuditPane
+        entries={[]}
+        verification={null}
+        onRefresh={vi.fn()}
+        onVerify={vi.fn()}
+        onDownload={vi.fn()}
+      />,
+    );
+    expect(await screen.findByText(/no audit entries yet/i)).toBeInTheDocument();
+  });
+
+  it('passes the current entries + verification through to onDownload', async () => {
+    const onDownload = vi.fn();
+    const entries = [entry(1)];
+    const verification = { ok: true } as const;
+    render(
+      <AppAuditPane
+        entries={entries}
+        verification={verification}
+        onRefresh={vi.fn()}
+        onVerify={vi.fn()}
+        onDownload={onDownload}
+      />,
+    );
+    const downloadBtn = await screen.findByRole('button', { name: /download audit log/i });
+    downloadBtn.click();
+    expect(onDownload).toHaveBeenCalledWith(entries, verification);
+  });
+});

--- a/app/src/ui/AppAuditPane.tsx
+++ b/app/src/ui/AppAuditPane.tsx
@@ -1,0 +1,43 @@
+import { Suspense, lazy } from 'react';
+import type { AuditEntry, ChainVerification } from '../audit/auditLog';
+
+// Wave 53-B-1 — Audit promoted to a top-level view (peer of Current /
+// Portfolio / Redline) per the design handoff. Previously the
+// AuditLogPanel lived inside the GOVERNANCE accordion on Current; that
+// stacked the chain table beneath several lease-management panels and
+// made it hard to reach. The pane is intentionally thin — the existing
+// AuditLogPanel does the heavy lifting.
+
+const AuditLogPanel = lazy(() =>
+  import('./AuditLogPanel').then((m) => ({ default: m.AuditLogPanel })),
+);
+
+interface AppAuditPaneProps {
+  entries: AuditEntry[];
+  verification: ChainVerification | null;
+  onRefresh: () => void;
+  onVerify: () => void;
+  onDownload: (entries: AuditEntry[], verification: ChainVerification | null) => void;
+}
+
+export function AppAuditPane({
+  entries,
+  verification,
+  onRefresh,
+  onVerify,
+  onDownload,
+}: AppAuditPaneProps): JSX.Element {
+  return (
+    <div className="mx-auto max-w-[1080px]">
+      <Suspense fallback={null}>
+        <AuditLogPanel
+          entries={entries}
+          verification={verification}
+          onRefresh={onRefresh}
+          onVerify={onVerify}
+          onDownload={() => onDownload(entries, verification)}
+        />
+      </Suspense>
+    </div>
+  );
+}

--- a/app/src/ui/AppHeader.tsx
+++ b/app/src/ui/AppHeader.tsx
@@ -25,7 +25,7 @@ import { OfflineDot } from './OfflineDot';
 // UploadView; tests that uploaded a *second* lease after analysis
 // click "New lease" first.
 
-export type AppViewMode = 'current' | 'portfolio' | 'redline' | 'settings';
+export type AppViewMode = 'current' | 'portfolio' | 'redline' | 'audit' | 'settings';
 
 interface AppHeaderProps {
   view: AppViewMode;
@@ -103,6 +103,19 @@ export function AppHeader({
             {t('header.view.redline')}
           </Button>
         )}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          pressed={view === 'audit'}
+          role="tab"
+          id="viewmode-tab-audit"
+          aria-selected={view === 'audit'}
+          aria-controls="viewmode-panel-audit"
+          onClick={() => onViewChange('audit')}
+        >
+          {t('header.view.audit')}
+        </Button>
         <Button
           type="button"
           variant="ghost"

--- a/app/src/ui/AppLibraryAndPacksPane.accordion.test.tsx
+++ b/app/src/ui/AppLibraryAndPacksPane.accordion.test.tsx
@@ -67,7 +67,6 @@ function renderPane(over: Partial<React.ComponentProps<typeof AppLibraryAndPacks
     severityOverridesPanelOnChange: vi.fn(),
     customRuleBuilderDoc: null,
     auditEntries: [],
-    auditVerification: null,
     signingKey: fakeSigning,
     comparison: null,
     onOpenLibrary: vi.fn(),
@@ -78,9 +77,6 @@ function renderPane(over: Partial<React.ComponentProps<typeof AppLibraryAndPacks
     onSaveTemplate: vi.fn(),
     onUpdateTemplate: vi.fn(),
     onDeleteTemplate: vi.fn(),
-    onRefreshAuditLog: vi.fn(),
-    onVerifyAuditChain: vi.fn(),
-    onDownloadAuditLog: vi.fn(),
     ...over,
   };
   return render(
@@ -132,22 +128,20 @@ describe('AppLibraryAndPacksPane accordion grouping (Wave 28 Part C / Wave 30 Pa
     expect(screen.getByRole('heading', { name: /my leases/i })).toBeInTheDocument();
   });
 
-  // Quarantined as a known flake; see app/src/test/known-flakes.md.
-  it(
-    'governance group expands on header click — AuditLog enters the DOM',
-    { retry: 2 },
-    async () => {
-      renderPane();
-      // AuditLogPanel renders <div role="group" aria-label="audit log actions">.
-      expect(screen.queryByRole('group', { name: /audit log actions/i })).toBeNull();
-      await userEvent.click(screen.getByRole('button', { name: /governance/i }));
-      expect(screen.getByRole('button', { name: /governance/i })).toHaveAttribute(
-        'aria-expanded',
-        'true',
-      );
-      expect(screen.getByRole('group', { name: /audit log actions/i })).toBeInTheDocument();
-    },
-  );
+  // Wave 53-B-1: AuditLog moved to AppAuditPane (top-level view); the
+  // governance group still expands but no longer contains the audit
+  // log. Verify expansion via the SeverityOverrides panel instead,
+  // which is the next-most-prominent governance affordance.
+  it('governance group expands on header click', async () => {
+    renderPane();
+    expect(screen.queryByRole('region', { name: /severity overrides/i })).toBeNull();
+    await userEvent.click(screen.getByRole('button', { name: /governance/i }));
+    expect(screen.getByRole('button', { name: /governance/i })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByRole('region', { name: /severity overrides/i })).toBeInTheDocument();
+  });
 
   it('toggling a group is reversible and persists to localStorage', async () => {
     renderPane();

--- a/app/src/ui/AppLibraryAndPacksPane.test.tsx
+++ b/app/src/ui/AppLibraryAndPacksPane.test.tsx
@@ -1,6 +1,5 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { AppLibraryAndPacksPane } from './AppLibraryAndPacksPane';
 import { I18nProvider } from '../i18n/I18nProvider';
 
@@ -70,7 +69,6 @@ function defaults(over: Partial<React.ComponentProps<typeof AppLibraryAndPacksPa
     severityOverridesPanelOnChange: vi.fn(),
     customRuleBuilderDoc: null,
     auditEntries: [],
-    auditVerification: null,
     signingKey: fakeSigning,
     comparison: null,
     onOpenLibrary: vi.fn(),
@@ -81,9 +79,6 @@ function defaults(over: Partial<React.ComponentProps<typeof AppLibraryAndPacksPa
     onSaveTemplate: vi.fn(),
     onUpdateTemplate: vi.fn(),
     onDeleteTemplate: vi.fn(),
-    onRefreshAuditLog: vi.fn(),
-    onVerifyAuditChain: vi.fn(),
-    onDownloadAuditLog: vi.fn(),
     ...over,
   };
   return render(
@@ -99,16 +94,12 @@ describe('AppLibraryAndPacksPane', () => {
     expandAllSectionsViaStorage();
   });
 
-  it('renders the library / templates / pack-manager / audit-log panels', async () => {
+  it('renders the library / templates / pack-manager panels', () => {
     defaults();
     expect(screen.getByRole('heading', { name: /my leases/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /diff rule pack/i })).toBeInTheDocument();
-    // Wave 28 Part C: SectionGroup wrappers also expose role="region";
-    // AuditLogPanel renders its own region with the same accessible name,
-    // so we assert at least one match. Wave 33-B made AuditLogPanel lazy,
-    // so the audit-log region resolves async on first paint.
-    const regions = await screen.findAllByRole('region', { name: /audit log/i });
-    expect(regions.length).toBeGreaterThanOrEqual(1);
+    // Wave 53-B-1: audit log moved to AppAuditPane (top-level view);
+    // covered there now.
   });
 
   it('hides the ComparePanel when comparison is null', () => {
@@ -116,13 +107,6 @@ describe('AppLibraryAndPacksPane', () => {
     expect(screen.queryByRole('region', { name: /^compare$/i })).toBeNull();
   });
 
-  it('fires onRefreshAuditLog when the audit-log refresh button is clicked', async () => {
-    const onRefreshAuditLog = vi.fn();
-    defaults({ onRefreshAuditLog });
-    // Wave 33-B: AuditLogPanel is lazy; await its render before
-    // querying its refresh button.
-    const refreshBtn = await screen.findByRole('button', { name: /^refresh$/i });
-    await userEvent.click(refreshBtn);
-    expect(onRefreshAuditLog).toHaveBeenCalledTimes(1);
-  });
+  // Wave 53-B-1: AuditLogPanel moved to AppAuditPane (top-level view);
+  // covered by AppAuditPane tests now.
 });

--- a/app/src/ui/AppLibraryAndPacksPane.tsx
+++ b/app/src/ui/AppLibraryAndPacksPane.tsx
@@ -37,12 +37,8 @@ import { JurisdictionPickerPanel } from './JurisdictionPickerPanel';
 import { SeverityOverridesPanel } from './SeverityOverridesPanel';
 import { PackDiffPanel } from './PackDiffPanel';
 import { BulkImportPanel } from './BulkImportPanel';
-// Wave 33-B — AuditLogPanel renders inside the `governance` SectionGroup
-// which is `defaultOpen: false`. Lazy-load to keep the audit-log code
-// path (and its dependencies) out of the eager shell.
-const AuditLogPanel = lazy(() =>
-  import('./AuditLogPanel').then((m) => ({ default: m.AuditLogPanel })),
-);
+// Wave 53-B-1 — AuditLogPanel moved out to AppAuditPane (top-level
+// view). The lazy import + governance-section mount was removed.
 import { SigningKeyPanel } from './SigningKeyPanel';
 import { ComparePanel } from './ComparePanel';
 import { Section } from './system/Section';
@@ -55,7 +51,6 @@ import type { Finding } from '../rules/types';
 import type { LeaseDocument } from '../parser/types';
 import type { UseSigningKeyApi } from '../App/useSigningKey';
 import type { UsePackManagerApi } from '../App/usePackManager';
-import type { ChainVerification } from '../audit/auditLog';
 import type { AuditEntry } from '../audit/auditLog';
 
 interface AppLibraryAndPacksPaneProps {
@@ -73,8 +68,8 @@ interface AppLibraryAndPacksPaneProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   severityOverridesPanelOnChange: (ruleId: string, sev: any) => void;
   customRuleBuilderDoc: LeaseDocument | null;
+  /** Read by HybridPrecisionDisclosure to surface llm-classify entries. */
   auditEntries: AuditEntry[];
-  auditVerification: ChainVerification | null;
   signingKey: UseSigningKeyApi;
   comparison: { a: LeaseRecord; b: LeaseRecord } | null;
   onOpenLibrary: (id: string) => void;
@@ -85,9 +80,6 @@ interface AppLibraryAndPacksPaneProps {
   onSaveTemplate: (input: { name: string; text: string }) => void;
   onUpdateTemplate: (id: string, patch: { name?: string; text?: string }) => void;
   onDeleteTemplate: (id: string) => void;
-  onRefreshAuditLog: () => void;
-  onVerifyAuditChain: () => void;
-  onDownloadAuditLog: (entries: AuditEntry[], verification: ChainVerification | null) => void;
 }
 
 export function AppLibraryAndPacksPane({
@@ -102,7 +94,6 @@ export function AppLibraryAndPacksPane({
   severityOverridesPanelOnChange,
   customRuleBuilderDoc,
   auditEntries,
-  auditVerification,
   signingKey,
   comparison,
   onOpenLibrary,
@@ -113,9 +104,6 @@ export function AppLibraryAndPacksPane({
   onSaveTemplate,
   onUpdateTemplate,
   onDeleteTemplate,
-  onRefreshAuditLog,
-  onVerifyAuditChain,
-  onDownloadAuditLog,
 }: AppLibraryAndPacksPaneProps): JSX.Element {
   const groupById = (k: string) => SECTION_GROUPS.find((g) => g.id === k)!;
   const thisLease = groupById('bottom-pane-this-lease');
@@ -234,15 +222,6 @@ export function AppLibraryAndPacksPane({
             overrides={severityOverridesPanelMap}
             onChange={severityOverridesPanelOnChange}
           />
-          <Suspense fallback={null}>
-            <AuditLogPanel
-              entries={auditEntries}
-              verification={auditVerification}
-              onRefresh={onRefreshAuditLog}
-              onVerify={onVerifyAuditChain}
-              onDownload={() => onDownloadAuditLog(auditEntries, auditVerification)}
-            />
-          </Suspense>
           <SigningKeyPanel
             state={{ publicKey: signingKey.publicKey }}
             onCreateKey={(pp) => void signingKey.createKey(pp)}

--- a/app/src/ui/OnboardingTour.tsx
+++ b/app/src/ui/OnboardingTour.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react';
 import { Dialog } from './system/Dialog';
 import { Button } from './system/Button';
 
-export type OnboardingViewMode = 'current' | 'portfolio' | 'redline' | 'settings';
+export type OnboardingViewMode = 'current' | 'portfolio' | 'redline' | 'audit' | 'settings';
 
 interface OnboardingTourProps {
   /** Existing dismissal timestamp; if non-null, the tour renders nothing. */

--- a/app/src/ui/__tests__/accordion.a11y.test.tsx
+++ b/app/src/ui/__tests__/accordion.a11y.test.tsx
@@ -50,7 +50,6 @@ function renderPane(over: Partial<ComponentProps<typeof AppLibraryAndPacksPane>>
     severityOverridesPanelOnChange: vi.fn(),
     customRuleBuilderDoc: null,
     auditEntries: [],
-    auditVerification: null,
     signingKey: fakeSigning,
     comparison: null,
     onOpenLibrary: vi.fn(),
@@ -61,9 +60,6 @@ function renderPane(over: Partial<ComponentProps<typeof AppLibraryAndPacksPane>>
     onSaveTemplate: vi.fn(),
     onUpdateTemplate: vi.fn(),
     onDeleteTemplate: vi.fn(),
-    onRefreshAuditLog: vi.fn(),
-    onVerifyAuditChain: vi.fn(),
-    onDownloadAuditLog: vi.fn(),
     ...over,
   };
   return render(

--- a/app/src/ui/__tests__/viewmode.a11y.test.tsx
+++ b/app/src/ui/__tests__/viewmode.a11y.test.tsx
@@ -12,7 +12,7 @@ import { I18nProvider } from '../../i18n/I18nProvider';
 import { expectAxeClean } from '../../test/axe';
 
 function renderShell(
-  view: 'current' | 'portfolio' | 'redline' | 'settings',
+  view: 'current' | 'portfolio' | 'redline' | 'audit' | 'settings',
   showRedlineToggle: boolean,
 ) {
   return render(
@@ -35,6 +35,11 @@ function renderShell(
           redline
         </div>
       )}
+      {view === 'audit' && (
+        <div role="tabpanel" id="viewmode-panel-audit" aria-labelledby="viewmode-tab-audit">
+          audit
+        </div>
+      )}
       {view === 'settings' && (
         <div role="tabpanel" id="viewmode-panel-settings" aria-labelledby="viewmode-tab-settings">
           settings
@@ -45,23 +50,23 @@ function renderShell(
 }
 
 describe('view-mode shell a11y (Wave 29-E)', () => {
-  it('renders a tablist with selected tab + matching tabpanel (current + portfolio + settings)', () => {
+  it('renders a tablist with selected tab + matching tabpanel (current + portfolio + audit + settings)', () => {
     renderShell('current', false);
     const tablist = screen.getByRole('tablist', { name: /view mode/i });
     expect(tablist).toBeInTheDocument();
     const tabs = screen.getAllByRole('tab');
-    // Wave 51-A — Current + Portfolio + Settings; redline gates on showRedlineToggle.
-    expect(tabs).toHaveLength(3);
+    // Wave 53-B-1 — Current + Portfolio + Audit + Settings; redline gates on showRedlineToggle.
+    expect(tabs).toHaveLength(4);
     const selected = tabs.find((t) => t.getAttribute('aria-selected') === 'true');
     expect(selected).toBeDefined();
     expect(selected?.getAttribute('aria-controls')).toBe('viewmode-panel-current');
     expect(screen.getByRole('tabpanel')).toHaveAttribute('aria-labelledby', 'viewmode-tab-current');
   });
 
-  it('exposes four tabs when redline is enabled', () => {
+  it('exposes five tabs when redline is enabled', () => {
     renderShell('redline', true);
-    // Wave 51-A — Current + Portfolio + Redline + Settings.
-    expect(screen.getAllByRole('tab')).toHaveLength(4);
+    // Wave 53-B-1 — Current + Portfolio + Redline + Audit + Settings.
+    expect(screen.getAllByRole('tab')).toHaveLength(5);
     expect(screen.getByRole('tab', { name: /redline/i })).toHaveAttribute('aria-selected', 'true');
   });
 

--- a/tests/e2e/golden.spec.ts
+++ b/tests/e2e/golden.spec.ts
@@ -37,13 +37,9 @@ test.describe('LeaseGuard happy path', () => {
     await page.getByRole('tab', { name: /^portfolio$/i }).click();
     await expect(page.getByRole('region', { name: /portfolio/i }).first()).toBeVisible();
 
-    // Back to current view so the audit log is rendered alongside.
-    await page.getByRole('tab', { name: /^current lease$/i }).click();
-
-    // Audit log lives inside the bottom-pane "Governance" disclosure, which
-    // Wave 30-B made default-closed. Expand it before reaching for the
-    // audit log region.
-    await page.getByRole('button', { name: /^Governance\b/i }).click();
+    // Wave 53-B-1: audit log is now its own top-level view (peer of
+    // Current / Portfolio / Redline). Click the Audit tab directly.
+    await page.getByRole('tab', { name: /^audit$/i }).click();
 
     // Audit log: section always exists; assert ≥ 1 entry from the analyze + save
     // events the sample-lease flow already produced. The panel renders a

--- a/tests/e2e/hybrid-golden.spec.ts
+++ b/tests/e2e/hybrid-golden.spec.ts
@@ -97,10 +97,9 @@ test.describe('Phase 18 real-model golden', () => {
     const findings = page.getByRole('complementary', { name: /findings/i });
     await expect(findings).toBeVisible();
 
-    // Audit log lives inside the bottom-pane "Governance" disclosure,
-    // which Wave 30-B made default-closed. Expand it before reaching for
-    // the Refresh button.
-    await page.getByRole('button', { name: /^Governance\b/i }).click();
+    // Wave 53-B-1: audit log is its own top-level view; click the
+    // Audit tab to reach the Refresh button.
+    await page.getByRole('tab', { name: /^audit$/i }).click();
 
     // First proof the classifier actually ran: an `llm-classify` audit
     // entry. Audit log isn't virtualized so this is the stable signal


### PR DESCRIPTION
First slice of Wave 53 Part B. Audit becomes a peer top-level view (Current / Portfolio / Redline / Audit / Settings) instead of nesting inside the GOVERNANCE accordion on Current.

Header restyle + viewport-filling layout follow as B-2 and B-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)