### PR TITLE
wave53-b-3a: gate AppLibraryAndPacksPane behind the Settings tab

### DIFF
--- a/app/src/App.panels.test.tsx
+++ b/app/src/App.panels.test.tsx
@@ -227,6 +227,12 @@ async function uploadLease(name = 'lease.pdf'): Promise<void> {
   );
 }
 
+// Wave 53-B-3 — pack manager / library / governance panels live under the
+// Settings tab now. Tests that reach into them switch first.
+async function gotoSettings(): Promise<void> {
+  await userEvent.click(screen.getByRole('tab', { name: /^settings$/i }));
+}
+
 describe('App panel wire-ups', () => {
   it('hides the LeaseFacts panel when the synthetic lease has no extractable facts', async () => {
     // Distill: LeaseFactsPanel renders nothing when isEmpty. The minimal
@@ -291,6 +297,7 @@ describe('App panel wire-ups', () => {
 
   it('PackManagerPanel imports, toggles, and deletes a pack', async () => {
     render(<App />);
+    await gotoSettings();
     const pack = {
       schema: 'leaseguard.rulepack.v1',
       id: 'custom-pack',
@@ -339,7 +346,10 @@ describe('App panel wire-ups', () => {
     expect(
       screen.queryByRole('button', { name: /export findings \(signed json\)/i }),
     ).not.toBeInTheDocument();
+    await gotoSettings();
     await userEvent.click(screen.getByRole('button', { name: /create key/i }));
+    // Signed-export button lives on Current; switch back to verify it appears.
+    await userEvent.click(screen.getByRole('tab', { name: /^current lease$/i }));
     await waitFor(() =>
       expect(
         screen.getByRole('button', { name: /export findings \(signed json\)/i }),
@@ -390,6 +400,7 @@ describe('App panel wire-ups', () => {
   it('JurisdictionPickerPanel toggles and re-runs analysis', async () => {
     render(<App />);
     await uploadLease('JurisLease.pdf');
+    await gotoSettings();
     const cb = await screen.findByRole('checkbox', { name: /jurisdiction US-CA/i });
     await userEvent.click(cb);
     // Selection persists via packStorage.
@@ -408,6 +419,7 @@ describe('App panel wire-ups', () => {
   it('SeverityOverridesPanel persists overrides and triggers reanalyze', async () => {
     render(<App />);
     await uploadLease('OverrideLease.pdf');
+    await gotoSettings();
     const select = await screen.findByRole('combobox', {
       name: /override severity for auto-renewal/i,
     });
@@ -427,6 +439,7 @@ describe('App panel wire-ups', () => {
 
   it('PackDiffPanel renders a diff from an uploaded pack file', async () => {
     render(<App />);
+    await gotoSettings();
     const pack = {
       schema: 'leaseguard.rulepack.v1',
       id: 'diff-pack',
@@ -475,6 +488,7 @@ describe('App panel wire-ups', () => {
 
   it('BulkImportPanel imports multiple PDFs into the library', async () => {
     render(<App />);
+    await gotoSettings();
     // Two distinct lease fixtures — bulk-import dedups by content hash.
     const bytesA = await makePdf([
       {
@@ -530,6 +544,7 @@ describe('App panel wire-ups', () => {
   it('CustomRuleBuilderPanel saves a rule as an installed pack and re-analyzes', async () => {
     render(<App />);
     await uploadLease('Custom.pdf');
+    await gotoSettings();
     // Fill the form through the builder.
     await userEvent.type(screen.getByLabelText(/rule id/i), 'banana-clause');
     await userEvent.type(screen.getByLabelText(/^title$/i), 'Banana clause');
@@ -688,6 +703,7 @@ describe('App panel wire-ups', () => {
 
   it('PackManagerPanel imports a signed envelope and shows Verified badge', async () => {
     render(<App />);
+    await gotoSettings();
     const pack = {
       schema: 'leaseguard.rulepack.v1' as const,
       id: 'signed-pack',
@@ -800,6 +816,7 @@ describe('App panel wire-ups', () => {
 
   it('PackManagerPanel reports "Invalid signature" on a tampered envelope', async () => {
     render(<App />);
+    await gotoSettings();
     const pack = {
       schema: 'leaseguard.rulepack.v1' as const,
       id: 'tampered-pack',
@@ -888,6 +905,7 @@ describe('App panel wire-ups', () => {
     });
 
     render(<App />);
+    await gotoSettings();
     // Wait for refreshLibrary to populate the picker with both leases.
     await waitFor(() => {
       const sel = screen.getByLabelText(/lease A/i) as HTMLSelectElement;

--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -163,6 +163,13 @@ async function uploadLease(name = 'lease.pdf'): Promise<void> {
   // return to the upload landing before grabbing the input.
   const reset = screen.queryByRole('button', { name: /new lease/i });
   if (reset) await userEvent.click(reset);
+  // Wave 53-B-3 — UploadView only renders on the Current tab. If a prior
+  // step moved the user into Settings (etc.), switch back so the upload
+  // input mounts.
+  const currentTab = screen.queryByRole('tab', { name: /^current lease$/i });
+  if (currentTab && currentTab.getAttribute('aria-selected') !== 'true') {
+    await userEvent.click(currentTab);
+  }
   const file = await makeLeaseFile(name);
   // UploadView is lazy-loaded; wait for its chunk before grabbing the input.
   const input = (await screen.findByLabelText(/upload lease/i)) as HTMLInputElement;
@@ -198,6 +205,7 @@ describe('App', () => {
   it('saves to the library after analysis and shows it in My Leases', async () => {
     render(<App />);
     await uploadLease();
+    await gotoSettings();
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /open lease\.pdf/i })).toBeInTheDocument();
     });
@@ -228,11 +236,15 @@ describe('App', () => {
     const bytes = await makePdf([
       { blocks: [{ text: 'This lease shall auto-renew annually.', x: 72, y: 72 }] },
     ]);
+    // Wave 53-B-3 — return a fresh Response per fetch call. mockResolvedValue
+    // hands back the same Response object whose body can only be read once,
+    // and the App may issue background fetches before the sample-lease
+    // click that would otherwise drain it.
     const fetchMock = vi
       .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(new Response(bytes as BlobPart, { status: 200 }));
+      .mockImplementation(async () => new Response(bytes as BlobPart, { status: 200 }));
     render(<App />);
-    await userEvent.click(screen.getByRole('button', { name: /try a sample lease/i }));
+    await userEvent.click(await screen.findByRole('button', { name: /try a sample lease/i }));
     await waitFor(() => expect(screen.getAllByText(/auto-renewal/i).length).toBeGreaterThan(0));
     fetchMock.mockRestore();
   });
@@ -251,6 +263,7 @@ describe('App', () => {
     const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('Renamed.pdf');
     render(<App />);
     await uploadLease('Original.pdf');
+    await gotoSettings();
     await userEvent.click(screen.getByRole('button', { name: /rename original\.pdf/i }));
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /open renamed\.pdf/i })).toBeInTheDocument();
@@ -261,6 +274,7 @@ describe('App', () => {
   it('deletes a library entry', async () => {
     render(<App />);
     await uploadLease('Gone.pdf');
+    await gotoSettings();
     await userEvent.click(screen.getByRole('button', { name: /delete gone\.pdf/i }));
     await waitFor(() => {
       expect(screen.queryByRole('button', { name: /open gone\.pdf/i })).not.toBeInTheDocument();
@@ -270,11 +284,13 @@ describe('App', () => {
   it('set-as-standard marks the badge and triggers auto-compare on next upload', async () => {
     render(<App />);
     await uploadLease('Standard.pdf');
+    await gotoSettings();
     await userEvent.click(screen.getByRole('button', { name: /set standard\.pdf as standard/i }));
     await waitFor(async () => {
       expect(await getStandardId()).toBeTruthy();
     });
     await uploadLease('New.pdf');
+    await gotoSettings();
     await waitFor(() => {
       expect(screen.getByRole('region', { name: /compare/i })).toBeInTheDocument();
     });
@@ -350,6 +366,7 @@ describe('App', () => {
       (await screen.findByLabelText(/upload lease/i)) as HTMLInputElement,
       await makeLeaseFile('Other.pdf'),
     );
+    await gotoSettings();
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /open reopen\.pdf/i })).toBeInTheDocument(),
     );
@@ -475,6 +492,7 @@ describe('App', () => {
   it('severity-override flow: change a rule severity → reanalyze fires and findings re-render', async () => {
     render(<App />);
     await uploadLease();
+    await gotoSettings();
 
     // Auto-renewal is medium-severity by default. Bump to high via the
     // SeverityOverridesPanel.
@@ -483,6 +501,9 @@ describe('App', () => {
     // Rule severities use info / warn / error (the display layer maps
     // these to Info / Medium / High in FindingsPanel).
     await userEvent.selectOptions(select, 'error');
+
+    // FindingsPanel is on Current; switch back to verify the re-render.
+    await userEvent.click(screen.getByRole('tab', { name: /^current lease$/i }));
 
     // useReanalyzeOnRulesChange picks up the override change and re-runs
     // analyze. After it completes, the auto-renewal finding should be in

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -498,85 +498,6 @@ function AppContent(): JSX.Element {
         )}
       </div>
 
-      <AppLibraryAndPacksPane
-        library={library}
-        standardId={standardId}
-        templates={templates}
-        packs={packs}
-        marketplace={{
-          loadManifest: loadCuratedManifest,
-          onInstall: async (entry: CuratedPackEntry) => {
-            const res = await fetch(entry.path);
-            if (!res.ok) throw new Error(`Failed to load curated pack: HTTP ${res.status}`);
-            const text = await res.text();
-            const parsed: unknown = JSON.parse(text);
-            let signature: 'verified' | 'invalid' = 'verified';
-            if (
-              parsed !== null &&
-              typeof parsed === 'object' &&
-              'algorithm' in parsed &&
-              'payload' in parsed &&
-              'signature' in parsed
-            ) {
-              const v = await verifySignedPack(parsed);
-              signature = v.ok ? 'verified' : 'invalid';
-            }
-            const file = new File([text], `${entry.id}.lgpack.json`, {
-              type: 'application/json',
-            });
-            await packs.importPackFile(file);
-            return { ok: true, signature };
-          },
-          onPreviewDiff: async (entry: CuratedPackEntry) => {
-            const res = await fetch(entry.path);
-            if (!res.ok) throw new Error(`Failed to load curated pack: HTTP ${res.status}`);
-            const parsed: unknown = await res.json();
-            let candidate: unknown = parsed;
-            if (
-              parsed !== null &&
-              typeof parsed === 'object' &&
-              'algorithm' in parsed &&
-              'payload' in parsed &&
-              'signature' in parsed
-            ) {
-              const v = await verifySignedPack(parsed);
-              if (v.ok && v.pack) candidate = v.pack;
-              else throw new Error(`Invalid signed pack: ${v.reason ?? 'unknown'}`);
-            }
-            const result = validatePackFile(candidate);
-            if (!result.ok) throw new Error(`Invalid pack: ${result.errors.join('; ')}`);
-            const d = diffPack(packs.activeRules, result.pack);
-            return {
-              added: d.added.map((r) => r.id),
-              removed: d.removed.map((r) => r.id),
-              changed: d.changed.map((c) => c.ruleId),
-            };
-          },
-        }}
-        jurisdictionOptions={JURISDICTION_OPTIONS}
-        severityOverridesPanelRows={packs.activeRules.map((r) => ({
-          id: r.id,
-          title: r.title,
-          severity: severityToOverrideSeverity(r.severity),
-        }))}
-        severityOverridesPanelMap={overridesToPanel(packs.severityOverrides)}
-        severityOverridesPanelOnChange={(ruleId, sev) =>
-          void packs.setSeverityOverride(ruleId, sev)
-        }
-        customRuleBuilderDoc={status.kind === 'analyzed' ? status.result.doc : null}
-        auditEntries={auditEntries}
-        signingKey={signingKey}
-        comparison={comparison}
-        onOpenLibrary={(id) => void onOpenLibrary(id)}
-        onDeleteLibrary={(id) => void onDeleteLibrary(id)}
-        onSetStandard={(id) => void setStandardId(id).then(refreshLibrary)}
-        onRenameLibrary={(id, name) => void renameLease(id, name).then(refreshLibrary)}
-        onCompare={(a, b) => void onCompare(a, b)}
-        onSaveTemplate={(input) => void saveTemplate(input).then(refreshTemplates)}
-        onUpdateTemplate={(id, patch) => void updateTemplate(id, patch).then(refreshTemplates)}
-        onDeleteTemplate={(id) => void deleteTemplate(id).then(refreshTemplates)}
-      />
-
       <div
         role="tabpanel"
         id="viewmode-panel-audit"
@@ -611,20 +532,102 @@ function AppContent(): JSX.Element {
         hidden={view !== 'settings'}
       >
         {view === 'settings' && (
-          <AppSettingsPane
-            onExportArchive={() => void exportEncryptedArchiveFlow()}
-            onImportArchive={(e) => void onImportArchiveFile(e)}
-            onClearAll={() => {
-              void clearAllFlow({
-                onCleared: async () => {
-                  await refreshLibrary();
-                  await refreshTemplates();
-                  pipeline.reset();
-                  setSelected(null);
+          <>
+            <AppSettingsPane
+              onExportArchive={() => void exportEncryptedArchiveFlow()}
+              onImportArchive={(e) => void onImportArchiveFile(e)}
+              onClearAll={() => {
+                void clearAllFlow({
+                  onCleared: async () => {
+                    await refreshLibrary();
+                    await refreshTemplates();
+                    pipeline.reset();
+                    setSelected(null);
+                  },
+                });
+              }}
+            />
+            <AppLibraryAndPacksPane
+              library={library}
+              standardId={standardId}
+              templates={templates}
+              packs={packs}
+              marketplace={{
+                loadManifest: loadCuratedManifest,
+                onInstall: async (entry: CuratedPackEntry) => {
+                  const res = await fetch(entry.path);
+                  if (!res.ok) throw new Error(`Failed to load curated pack: HTTP ${res.status}`);
+                  const text = await res.text();
+                  const parsed: unknown = JSON.parse(text);
+                  let signature: 'verified' | 'invalid' = 'verified';
+                  if (
+                    parsed !== null &&
+                    typeof parsed === 'object' &&
+                    'algorithm' in parsed &&
+                    'payload' in parsed &&
+                    'signature' in parsed
+                  ) {
+                    const v = await verifySignedPack(parsed);
+                    signature = v.ok ? 'verified' : 'invalid';
+                  }
+                  const file = new File([text], `${entry.id}.lgpack.json`, {
+                    type: 'application/json',
+                  });
+                  await packs.importPackFile(file);
+                  return { ok: true, signature };
                 },
-              });
-            }}
-          />
+                onPreviewDiff: async (entry: CuratedPackEntry) => {
+                  const res = await fetch(entry.path);
+                  if (!res.ok) throw new Error(`Failed to load curated pack: HTTP ${res.status}`);
+                  const parsed: unknown = await res.json();
+                  let candidate: unknown = parsed;
+                  if (
+                    parsed !== null &&
+                    typeof parsed === 'object' &&
+                    'algorithm' in parsed &&
+                    'payload' in parsed &&
+                    'signature' in parsed
+                  ) {
+                    const v = await verifySignedPack(parsed);
+                    if (v.ok && v.pack) candidate = v.pack;
+                    else throw new Error(`Invalid signed pack: ${v.reason ?? 'unknown'}`);
+                  }
+                  const result = validatePackFile(candidate);
+                  if (!result.ok) throw new Error(`Invalid pack: ${result.errors.join('; ')}`);
+                  const d = diffPack(packs.activeRules, result.pack);
+                  return {
+                    added: d.added.map((r) => r.id),
+                    removed: d.removed.map((r) => r.id),
+                    changed: d.changed.map((c) => c.ruleId),
+                  };
+                },
+              }}
+              jurisdictionOptions={JURISDICTION_OPTIONS}
+              severityOverridesPanelRows={packs.activeRules.map((r) => ({
+                id: r.id,
+                title: r.title,
+                severity: severityToOverrideSeverity(r.severity),
+              }))}
+              severityOverridesPanelMap={overridesToPanel(packs.severityOverrides)}
+              severityOverridesPanelOnChange={(ruleId, sev) =>
+                void packs.setSeverityOverride(ruleId, sev)
+              }
+              customRuleBuilderDoc={status.kind === 'analyzed' ? status.result.doc : null}
+              auditEntries={auditEntries}
+              signingKey={signingKey}
+              comparison={comparison}
+              onOpenLibrary={(id) => void onOpenLibrary(id)}
+              onDeleteLibrary={(id) => void onDeleteLibrary(id)}
+              onSetStandard={(id) => void setStandardId(id).then(refreshLibrary)}
+              onRenameLibrary={(id, name) => void renameLease(id, name).then(refreshLibrary)}
+              onCompare={(a, b) => void onCompare(a, b)}
+              onSaveTemplate={(input) => void saveTemplate(input).then(refreshTemplates)}
+              onUpdateTemplate={(id, patch) =>
+                void updateTemplate(id, patch).then(refreshTemplates)
+              }
+              onDeleteTemplate={(id) => void deleteTemplate(id).then(refreshTemplates)}
+            />
+          </>
         )}
       </div>
     </main>

--- a/tests/e2e/annotation-flow.spec.ts
+++ b/tests/e2e/annotation-flow.spec.ts
@@ -43,16 +43,17 @@ test.describe('Annotation persistence', () => {
     // Reload — the in-memory React state goes away; IDB persists.
     await page.reload();
 
-    // Wave 30-B: bottom-pane accordions default closed. Expand "Library"
-    // before reaching for the saved-lease row. The button's accessible
-    // name includes a count badge ("Library 1") once leases exist, so
-    // match by prefix not exact.
+    // Wave 53-B-3: Library accordion now lives under the Settings tab.
+    // Switch tabs first, then expand the Library accordion.
+    await page.getByRole('tab', { name: /^settings$/i }).click();
     await page.getByRole('button', { name: /^Library\b/i }).click();
 
     // The library row's "Open" button surfaces the saved lease.
     const openSample = page.getByRole('button', { name: /open sample lease\.pdf/i });
     await expect(openSample).toBeVisible({ timeout: 10_000 });
     await openSample.click();
+    // Findings + annotations live on the Current tab; switch back.
+    await page.getByRole('tab', { name: /^current lease$/i }).click();
 
     // Findings panel re-renders from the saved record. Click the same
     // finding to re-set paragraphIndex; the note should still be there.

--- a/tests/e2e/save-and-library.spec.ts
+++ b/tests/e2e/save-and-library.spec.ts
@@ -17,10 +17,11 @@ test.describe('LeaseGuard library flow', () => {
     const findingButtons = findings.locator('button.finding-btn');
     await expect(findingButtons.first()).toBeVisible({ timeout: 15_000 });
 
-    // Wave 30-B: bottom-pane accordions default closed. Expand "Library"
-    // before reaching for the saved-lease row. The button's accessible
-    // name includes a count badge ("Library 1") once leases exist, so
+    // Wave 53-B-3: Library accordion now lives under the Settings tab.
+    // Switch tabs first, then expand. The button's accessible name
+    // includes a count badge ("Library 1") once leases exist, so
     // match by prefix not exact.
+    await page.getByRole('tab', { name: /^settings$/i }).click();
     await page.getByRole('button', { name: /^Library\b/i }).click();
 
     // usePipeline auto-saves analyzed leases. The library row's "open" button
@@ -39,6 +40,9 @@ test.describe('LeaseGuard library flow', () => {
     // on the severity-group heading instead, which is always rendered
     // and includes the finding count.
     await openSample.click();
+    // Findings live on the Current tab; switch back to verify the reopen
+    // rehydrated them.
+    await page.getByRole('tab', { name: /^current lease$/i }).click();
     // Wave 51-E added a severity-chip filter row whose label also reads
     // "High (N)", so plain getByText now resolves two elements. Match
     // the section heading specifically via the toggle button's aria-label.


### PR DESCRIPTION
## Summary
- Move AppLibraryAndPacksPane (THIS LEASE / LIBRARY / GOVERNANCE accordions) out of the unconditional App.tsx mount and into the settings tabpanel — handoff puts these surfaces on Settings, not Current
- Update App.test.tsx + App.panels.test.tsx (15 tests) to click the Settings tab before reaching into pack manager / signing key / severity overrides / library rows; add a `gotoSettings()` helper
- `uploadLease` helper switches back to Current if a prior step left the user on another tab
- e2e save-and-library + annotation-flow specs route through Settings to expand the Library accordion, then back to Current to verify findings re-render
- Sample-lease test: fix a pre-existing fetch-mock bug (mockResolvedValue hands back the same Response whose body drains on first read) by using mockImplementation per call. Surfaced because removing the unconditional pane changed initial-fetch ordering

Wave 53 Part B-3a of the design-fidelity plan. B-3b (viewport-fill flex on Current) ships separately so the layout-shift risk lands in a clean PR.

## Test plan
- [x] Local typecheck + lint + full vitest (1743 passed, 1 todo, 0 failures)
- [ ] CI verify
- [ ] CI smoke (chromium / firefox / webkit) — golden + save-and-library + annotation-flow re-routed
- [ ] Lighthouse + a11y
- [ ] Manual confirm: Current/Portfolio/Redline/Audit no longer show accordion stack; Settings tab carries it