### PR TITLE
wave53-b-3b: Current/analyzed view fills the viewport

### DIFF
--- a/app/src/index.css
+++ b/app/src/index.css
@@ -210,6 +210,32 @@ main {
   padding: 2rem 1rem;
 }
 
+/* Wave 53-B-3b — Current/analyzed view fills the viewport below the
+   52px AppHeader. Break out of <main>'s 72rem centering so the rail +
+   document + findings columns extend edge-to-edge, and let the inner
+   .split pane absorb remaining vertical space. Other views (Settings,
+   Audit, Portfolio, Redline) keep the centered layout. */
+main:has(.results) {
+  max-width: none;
+  padding: 0;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+}
+main:has(.results) > [id='viewmode-panel-current'] {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.results {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  padding: 1rem 1rem 0;
+}
+
 .split {
   display: grid;
   gap: 1rem;
@@ -220,11 +246,22 @@ main {
     grid-template-columns: minmax(18rem, 28rem) 1fr;
   }
 }
+.results .split {
+  flex: 1;
+  min-height: 0;
+  align-items: stretch;
+}
 .split aside[aria-label='findings'] {
   position: sticky;
   top: 1rem;
   max-height: calc(100vh - 2rem);
   overflow-y: auto;
+}
+.results .split aside[aria-label='findings'] {
+  position: relative;
+  top: 0;
+  max-height: none;
+  height: 100%;
 }
 
 /* Legacy PDF-viewer cascade — every selector from the pre-Wave-27


### PR DESCRIPTION
## Summary
- When the analyzed-Current pane mounts, \`<main>\` drops its 72rem centering + 2rem padding and becomes a flex column at 100dvh
- Current tabpanel + \`.results\` become flex children; \`.split\` (rail | document | findings) absorbs remaining vertical space — no more white space below the fold
- Findings \`<aside>\` drops its sticky positioning inside \`.results\`; height: 100% lets it scroll internally
- Other views (Settings, Audit, Portfolio, Redline) keep the centered layout via \`:has(.results)\` — the override only applies in analyzed-Current state

Wave 53 Part B-3b. CSS-only change; no JSX touched. Full vitest suite green (1743/1743).

## Test plan
- [x] Local typecheck + lint + full vitest
- [ ] CI verify
- [ ] CI smoke (chromium / firefox / webkit)
- [ ] Lighthouse + a11y
- [ ] Manual confirm: analyzed Current fills viewport edge-to-edge; Settings/Audit/Portfolio still centered