### PR TITLE
wave53-d: RedlinePanel renders a word-level diff

### DIFF
--- a/app/src/index.css
+++ b/app/src/index.css
@@ -264,6 +264,30 @@ main:has(.results) > [id='viewmode-panel-current'] {
   height: 100%;
 }
 
+/* Wave 53-D — word-level redline diff. The strike + add tokens render
+   inline inside the paragraph; tinting comes from severity high (for
+   removed text) and a subtle positive ink (for added text). The
+   foreground stays --color-fg-body so the surrounding paragraph reads
+   normally. */
+.diff-strike {
+  background-color: color-mix(in oklab, var(--color-severity-high) 12%, transparent);
+  text-decoration: line-through;
+  text-decoration-color: color-mix(in oklab, var(--color-severity-high) 70%, transparent);
+  color: var(--color-fg-body);
+  padding: 0 2px;
+  border-radius: 1px;
+}
+.diff-add {
+  background-color: color-mix(in oklab, var(--color-ink) 8%, transparent);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklab, var(--color-ink) 70%, transparent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  color: var(--color-fg);
+  padding: 0 2px;
+  border-radius: 1px;
+}
+
 /* Legacy PDF-viewer cascade — every selector from the pre-Wave-27
    index.css that targets `.pdf-*` gets prefixed with
    `.pdf-viewer-legacy ` so it can't bleed into Tailwind utilities.

--- a/app/src/ui/RedlinePanel.test.tsx
+++ b/app/src/ui/RedlinePanel.test.tsx
@@ -60,7 +60,7 @@ describe('RedlinePanel', () => {
   });
 
   it('renders the edited text and an "(edited)" badge when an edit exists', () => {
-    render(
+    const { container } = render(
       <RedlinePanel
         doc={docOf('alpha', 'beta')}
         edits={[mkEdit({ paragraphIndex: 1, before: 'beta', after: 'BETA!' })]}
@@ -69,8 +69,15 @@ describe('RedlinePanel', () => {
         onExportHtml={noop}
       />,
     );
-    expect(screen.getByText('BETA!')).toBeInTheDocument();
-    expect(screen.queryByText('beta')).not.toBeInTheDocument();
+    // Wave 53-D — RedlinePanel now renders a word-level diff: the original
+    // text appears inside a `.diff-strike` span and the new text inside a
+    // `.diff-add` span. Both must be present so the diff is legible.
+    const strike = container.querySelector('.diff-strike');
+    const add = container.querySelector('.diff-add');
+    expect(strike).not.toBeNull();
+    expect(strike?.textContent).toMatch(/beta/);
+    expect(add).not.toBeNull();
+    expect(add?.textContent).toMatch(/BETA!/);
     expect(screen.getByLabelText(/paragraph 2 edited badge/i)).toBeInTheDocument();
   });
 
@@ -168,9 +175,7 @@ describe('RedlinePanel', () => {
         onExportHtml={noop}
       />,
     );
-    expect(
-      screen.queryByRole('button', { name: /revert paragraph/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /revert paragraph/i })).not.toBeInTheDocument();
   });
 
   it('Export button fires onExportHtml', async () => {
@@ -184,9 +189,7 @@ describe('RedlinePanel', () => {
         onExportHtml={onExportHtml}
       />,
     );
-    await userEvent.click(
-      screen.getByRole('button', { name: /export redlined html/i }),
-    );
+    await userEvent.click(screen.getByRole('button', { name: /export redlined html/i }));
     expect(onExportHtml).toHaveBeenCalledTimes(1);
   });
 

--- a/app/src/ui/RedlinePanel.tsx
+++ b/app/src/ui/RedlinePanel.tsx
@@ -11,7 +11,7 @@
 //
 import { useEffect, useRef, useState } from 'react';
 import type { LeaseDocument } from '../parser/types';
-import type { RedlineEdit } from '../redline/redline';
+import { computeParagraphDiff, type RedlineEdit } from '../redline/redline';
 import { CounterSignPanel } from './CounterSignPanel';
 import { Section } from './system/Section';
 import { Button } from './system/Button';
@@ -166,9 +166,25 @@ export function RedlinePanel({
               ) : (
                 <>
                   <p
-                    className={`font-serif text-[14.5px] leading-[1.65] ${edit ? 'text-fg-muted line-through decoration-severity-high/60' : 'text-fg-body'}`}
+                    className="font-serif text-[14.5px] leading-[1.65] text-fg-body"
+                    aria-label={edit ? `paragraph ${i + 1} redlined diff` : undefined}
                   >
-                    {displayText}
+                    {edit
+                      ? computeParagraphDiff(edit.before, edit.after).map((chunk, k) => {
+                          if (chunk.kind === 'unchanged') return <span key={k}>{chunk.text}</span>;
+                          if (chunk.kind === 'removed')
+                            return (
+                              <span key={k} className="diff-strike">
+                                {chunk.text}
+                              </span>
+                            );
+                          return (
+                            <span key={k} className="diff-add">
+                              {chunk.text}
+                            </span>
+                          );
+                        })
+                      : displayText}
                   </p>
                   <div className="flex items-center gap-2 flex-wrap">
                     {edit ? (


### PR DESCRIPTION
## Summary
- RedlinePanel previously struck the entire edited paragraph and showed the new text below — losing word-level signal
- Reuse the existing \`computeParagraphDiff\` (LCS over whitespace-aware tokens, already in \`redline.ts\`) and render fragments as inline spans:
  - unchanged → plain text
  - removed → \`.diff-strike\` (severity-high tint + line-through)
  - added → \`.diff-add\` (ink tint + underline)
- CSS classes ported from \`docs/design_handoff_leaseguard/styles.css\` with project token names substituted in
- New aria-label \`paragraph N redlined diff\` exposes the inline diff to screen readers

Wave 53 Part D scoped to the diff visual. The audit-row restyle (italic for object, mono for ts/seq) and the apply-all/clear-all controls in AppRedlinePane are deferred — keeping this PR small.

## Test plan
- [x] Local typecheck + lint + full vitest (1743/1743)
- [x] RedlinePanel test updated to assert .diff-strike + .diff-add presence
- [ ] CI verify
- [ ] CI smoke (redline-flow.spec.ts e2e)
- [ ] Manual confirm: edit a paragraph → diff shows old struck + new added inline