### PR TITLE
test: bump uploadLease waitFor timeouts for CI

### DIFF
--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -174,15 +174,17 @@ async function uploadLease(name = 'lease.pdf'): Promise<void> {
   // UploadView is lazy-loaded; wait for its chunk before grabbing the input.
   const input = (await screen.findByLabelText(/upload lease/i)) as HTMLInputElement;
   await userEvent.upload(input, file);
-  // "auto-renewal" now also appears in the SeverityOverridesPanel row; use
-  // `findAllByText` so we pass as soon as the findings panel renders.
-  await waitFor(() => expect(screen.getAllByText(/auto-renewal/i).length).toBeGreaterThan(0));
-  // Wait for the findings aside to render so click/scroll assertions downstream
-  // find their targets.
+  // Wait for the findings aside to render first — that's the surface that
+  // surfaces rule titles. After Wave 53-B-3a moved SeverityOverridesPanel
+  // off Current, FindingsPanel is the only "auto-renewal" source on
+  // Current. CI is slower than local; bump the timeout to 5s.
   await waitFor(
     () => expect(screen.getByRole('complementary', { name: /findings/i })).toBeInTheDocument(),
     { timeout: 5000 },
   );
+  await waitFor(() => expect(screen.getAllByText(/auto-renewal/i).length).toBeGreaterThan(0), {
+    timeout: 5000,
+  });
 }
 
 describe('App', () => {


### PR DESCRIPTION
## Summary
After Wave 53-B-3a moved \`SeverityOverridesPanel\` off the Current tab, \`FindingsPanel\` is the only surface that renders rule titles like "auto-renewal" on Current. The waitFor on that text was using the default 1s timeout — fine on local but tight on GitHub-runner CPU where parse + analyze can take longer.

- Bump both waitFors in \`App.test.tsx\` \`uploadLease\` helper to 5s
- Reorder so we wait for the findings \`<aside>\` to mount first (cheaper signal), then for the rule title to surface

Two App.test.tsx tests have been flaking on PR #209 verify CI; this should stabilize them.

## Test plan
- [x] Local App.test.tsx 21/21
- [ ] CI verify