### PR TITLE
wave53-d: AppRedlinePane — apply-all + clear-all controls

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -417,6 +417,8 @@ function AppContent(): JSX.Element {
               redline={redline}
               versionHistory={versionHistory}
               sideLetter={sideLetter}
+              findings={status.result.findings}
+              suggestedTextByRuleId={suggestedTextByRuleId}
               sectionForParagraph={sectionForParagraph}
               safeAudit={safeAudit}
             />

--- a/app/src/ui/AppRedlinePane.test.tsx
+++ b/app/src/ui/AppRedlinePane.test.tsx
@@ -60,6 +60,8 @@ describe('AppRedlinePane', () => {
         redline={makeRedline()}
         versionHistory={makeVersionHistory()}
         sideLetter={makeSideLetter()}
+        findings={[]}
+        suggestedTextByRuleId={{}}
         sectionForParagraph={() => undefined}
         safeAudit={vi.fn(() => Promise.resolve())}
       />,
@@ -79,6 +81,8 @@ describe('AppRedlinePane', () => {
         redline={makeRedline()}
         versionHistory={makeVersionHistory()}
         sideLetter={sideLetter}
+        findings={[]}
+        suggestedTextByRuleId={{}}
         sectionForParagraph={() => undefined}
         safeAudit={safeAudit}
       />,

--- a/app/src/ui/AppRedlinePane.tsx
+++ b/app/src/ui/AppRedlinePane.tsx
@@ -1,7 +1,9 @@
 import { RedlinePanel } from './RedlinePanel';
 import { VersionHistoryPanel } from './VersionHistoryPanel';
 import { SideLetterPanel } from './SideLetterPanel';
+import { Button } from './system/Button';
 import type { LeaseDocument } from '../parser/types';
+import type { Finding } from '../rules/types';
 import type { UseRedlineStateApi } from '../App/useRedlineState';
 import type { UseVersionHistoryApi } from '../App/useVersionHistory';
 import type { UseSideLetterApi } from '../App/useSideLetter';
@@ -13,6 +15,9 @@ interface AppRedlinePaneProps {
   redline: UseRedlineStateApi;
   versionHistory: UseVersionHistoryApi;
   sideLetter: UseSideLetterApi;
+  /** Findings with suggested edits — used by the apply-all bulk action. */
+  findings: Finding[];
+  suggestedTextByRuleId: Record<string, string> | undefined;
   sectionForParagraph: (paragraphIndex: number) => string | undefined;
   safeAudit: (input: { kind: string; payload: Record<string, unknown> }) => Promise<void>;
 }
@@ -23,26 +28,98 @@ export function AppRedlinePane({
   redline,
   versionHistory,
   sideLetter,
+  findings,
+  suggestedTextByRuleId,
   sectionForParagraph,
   safeAudit,
 }: AppRedlinePaneProps): JSX.Element {
   const editCount = redline.redlineEdits.length;
+  const editedParagraphIndices = new Set(redline.redlineEdits.map((e) => e.paragraphIndex));
+  // "Apply all" candidates: every finding that has a suggested text and
+  // whose paragraph has no redline edit yet. Idempotent — re-clicking
+  // applies nothing additional.
+  const applyableFindings = suggestedTextByRuleId
+    ? findings.filter((f) => {
+        const t = suggestedTextByRuleId[f.ruleId];
+        return (
+          typeof t === 'string' && t.length > 0 && !editedParagraphIndices.has(f.paragraphIndex)
+        );
+      })
+    : [];
+  const applyableCount = applyableFindings.length;
   return (
     <>
-      <header aria-label="redline header" className="px-4 pt-5 pb-4 border-b border-rule">
-        <p className="text-mono uppercase tracking-[0.08em] text-fg-faint mb-2">
-          Redline · counter-proposal
-        </p>
-        <h2 className="font-serif text-[24px] font-semibold leading-tight text-fg m-0">
-          {editCount === 0
-            ? 'No edits yet'
-            : `${editCount} paragraph${editCount === 1 ? '' : 's'} edited`}
-        </h2>
-        <p className="font-serif italic text-fg-muted mt-1.5 max-w-[60ch]">
-          {editCount === 0
-            ? 'Start by editing any paragraph below — your changes will export as a redline document.'
-            : 'Original on the left, what you’d ask for on the right. Export as HTML or paste into your reply.'}
-        </p>
+      <header
+        aria-label="redline header"
+        className="px-4 pt-5 pb-4 border-b border-rule flex flex-wrap items-start justify-between gap-4"
+      >
+        <div className="min-w-0">
+          <p className="text-mono uppercase tracking-[0.08em] text-fg-faint mb-2">
+            Redline · counter-proposal
+          </p>
+          <h2 className="font-serif text-[24px] font-semibold leading-tight text-fg m-0">
+            {editCount === 0
+              ? 'No edits yet'
+              : `${editCount} paragraph${editCount === 1 ? '' : 's'} edited`}
+          </h2>
+          <p className="font-serif italic text-fg-muted mt-1.5 max-w-[60ch]">
+            {editCount === 0
+              ? 'Start by editing any paragraph below — your changes will export as a redline document.'
+              : 'Original on the left, what you’d ask for on the right. Export as HTML or paste into your reply.'}
+          </p>
+        </div>
+        <div
+          role="group"
+          aria-label="redline bulk actions"
+          className="flex items-center gap-2 shrink-0"
+        >
+          <Button
+            type="button"
+            variant="subtle"
+            size="sm"
+            disabled={applyableCount === 0}
+            aria-label={
+              applyableCount === 0
+                ? 'apply all suggestions (none available)'
+                : `apply all ${applyableCount} suggestions`
+            }
+            onClick={() => {
+              for (const f of applyableFindings) {
+                const text = suggestedTextByRuleId?.[f.ruleId];
+                if (!text) continue;
+                void redline.applySuggestion({
+                  finding: f,
+                  paragraphIndex: f.paragraphIndex,
+                  suggestedText: text,
+                  doc,
+                });
+              }
+            }}
+          >
+            {applyableCount === 0 ? 'Apply all' : `Apply all (${applyableCount})`}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={editCount === 0}
+            aria-label={
+              editCount === 0 ? 'clear all edits (none to clear)' : `clear all ${editCount} edits`
+            }
+            onClick={() => {
+              if (editCount === 0) return;
+              if (
+                typeof window !== 'undefined' &&
+                !window.confirm(`Clear all ${editCount} redline edits?`)
+              ) {
+                return;
+              }
+              void redline.replaceAll([]);
+            }}
+          >
+            Clear all
+          </Button>
+        </div>
       </header>
       <RedlinePanel
         doc={doc}


### PR DESCRIPTION
## Summary
Wave 51-F shipped the redline header strip but not the bulk actions the handoff specifies. Add them:

- **Apply all (N)** — for every finding with a suggestedText AND no redline edit on its paragraph yet, calls \`applySuggestion(...)\`. The (N) badge surfaces the candidate count; disabled when zero. Idempotent
- **Clear all** — confirms via \`window.confirm\`, then \`replaceAll([])\`. Disabled when no edits

Header strip is now \`flex items-start justify-between\` (title/subtitle on left, bulk actions on right). \`aria-label="redline bulk actions"\` + \`aria-label="redline header"\` preserved.

Wires \`findings\` + \`suggestedTextByRuleId\` from App.tsx into the pane (AppCurrentPane already had these — redline pane just needed the same plumbing).

Wave 53 Part D — redline-side spillover (deferred from #210).

## Test plan
- [x] Local typecheck + lint + full vitest (1743/1743)
- [ ] CI verify
- [ ] CI smoke (redline-flow.spec.ts)
- [ ] Lighthouse a11y