### PR TITLE
wave54-b: kill the native file-chooser leak in UploadView

### DIFF
--- a/app/src/ui/UploadView.test.tsx
+++ b/app/src/ui/UploadView.test.tsx
@@ -50,4 +50,14 @@ describe('UploadView', () => {
     await userEvent.click(screen.getByRole('button', { name: /try a sample lease/i }));
     expect(onTrySample).toHaveBeenCalledTimes(1);
   });
+
+  it('Choose PDF button clicks the hidden file input', async () => {
+    // Wave 54-B — the visible affordance triggers the now-hidden input
+    // via ref. Spy on the input's click() to verify the wiring.
+    renderView();
+    const input = screen.getByLabelText(/upload lease/i) as HTMLInputElement;
+    const clickSpy = vi.spyOn(input, 'click');
+    await userEvent.click(screen.getByRole('button', { name: /choose pdf/i }));
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/app/src/ui/UploadView.tsx
+++ b/app/src/ui/UploadView.tsx
@@ -1,4 +1,4 @@
-import { useState, type DragEvent } from 'react';
+import { useRef, useState, type DragEvent } from 'react';
 import { Button } from './system/Button';
 import { useI18n } from '../i18n/I18nContext';
 
@@ -54,6 +54,13 @@ const SAMPLE_PREVIEW: ReadonlyArray<{
 export function UploadView({ onUpload, onTrySample }: UploadViewProps): JSX.Element {
   const { t } = useI18n();
   const [drag, setDrag] = useState(false);
+  // Wave 54-B — the visible affordance is the styled "Choose PDF" Button;
+  // the underlying <input type="file"> stays in the DOM (so existing
+  // findByLabelText("upload lease") test probes keep working) but is
+  // hidden from layout via display:none. This kills the dark-mode native
+  // "Choose File / No file chosen" platform leak that surfaced in the
+  // post-Wave-52 polish walk.
+  const inputRef = useRef<HTMLInputElement>(null);
 
   function onDrop(e: DragEvent<HTMLDivElement>): void {
     e.preventDefault();
@@ -96,21 +103,28 @@ export function UploadView({ onUpload, onTrySample }: UploadViewProps): JSX.Elem
             drag ? 'border-ink bg-paper-sunken' : 'border-rule bg-paper-raised/60'
           }`}
         >
-          <label className="inline-flex items-center cursor-pointer">
-            <span className="visually-hidden">{t('header.upload.label')}</span>
-            <input
-              type="file"
-              accept="application/pdf"
-              aria-label="upload lease"
-              className="text-small"
-              onChange={async (e) => {
-                const file = e.target.files?.[0];
-                if (!file) return;
-                await onUpload(file);
-              }}
-            />
-          </label>
-          <Button type="button" variant="default" size="sm" onClick={() => void onTrySample()}>
+          <Button
+            type="button"
+            variant="default"
+            size="sm"
+            onClick={() => inputRef.current?.click()}
+          >
+            Choose PDF
+          </Button>
+          <input
+            ref={inputRef}
+            type="file"
+            accept="application/pdf"
+            aria-label="upload lease"
+            tabIndex={-1}
+            style={{ display: 'none' }}
+            onChange={async (e) => {
+              const file = e.target.files?.[0];
+              if (!file) return;
+              await onUpload(file);
+            }}
+          />
+          <Button type="button" variant="ghost" size="sm" onClick={() => void onTrySample()}>
             {t('header.trySample')}
           </Button>
           <span className="font-display italic text-small text-fg-muted">


### PR DESCRIPTION
## Summary
The dark-mode polish walk flagged that the dropzone leaks the platform's native "Choose File / No file chosen" text — the inline \`<input type="file">\` was rendering with default browser styling instead of being hidden behind a styled control.

Hide the input via \`display: none\` and front it with a styled "Choose PDF" Button that triggers \`inputRef.current.click()\` when activated. The input stays in the DOM with \`aria-label="upload lease"\` intact so every existing \`findByLabelText("upload lease")\` test selector keeps working — same wiring as the system \`FileButton\`, just inlined here so the dropzone keeps its drag-and-drop surface.

Wave 54 Part B.

## Test plan
- [x] typecheck + lint + full vitest 1743/1743
- [ ] CI verify
- [ ] CI smoke
- [ ] Manual confirm dark-mode dropzone: only "Choose PDF" button + "Try sample" + drag hint visible; no "Choose File / No file chosen"