### PR TITLE
wave54-c: fill the empty-home-state with a quiet privacy line

### DIFF
--- a/app/src/ui/UploadView.tsx
+++ b/app/src/ui/UploadView.tsx
@@ -138,6 +138,18 @@ export function UploadView({ onUpload, onTrySample }: UploadViewProps): JSX.Elem
           <span>● Ed25519-signed exports</span>
           <span>● Hash-chained audit log</span>
         </div>
+
+        {/* Wave 54-C — fill the lower-viewport gap on the idle landing
+            with a quiet privacy line. Restrained tone (DESIGN.md "One
+            Voice"), no exclamations, references the existing CSP +
+            IndexedDB facts already documented in Settings → Privacy. */}
+        <p className="mt-8 font-display italic text-fg-muted leading-relaxed max-w-[60ch]">
+          <span className="not-italic font-display font-semibold text-fg">
+            Local-first by construction.
+          </span>{' '}
+          Your PDF parses on this device, stays in IndexedDB, and never crosses an origin boundary.
+          Strict CSP enforces it.
+        </p>
       </div>
 
       {/* Right: "what you'll see" sample preview */}


### PR DESCRIPTION
## Summary
The polish walk flagged that the lower 60% of the idle landing reads as "broken, not calm." Add a single restrained sentence below the existing footer chip row.

> **Local-first by construction.** Your PDF parses on this device, stays in IndexedDB, and never crosses an origin boundary. Strict CSP enforces it.

Headline phrase in non-italic semibold, body in serif italic fg-muted at \`max-w-[60ch]\`. References facts already documented under Settings → Privacy — no new claims, no exclamations, restrained tone per DESIGN.md "One Voice."

Wave 54 Part C (variant 3 from the three proposed candidates).

## Test plan
- [x] typecheck + lint + UploadView vitest
- [ ] CI verify
- [ ] Manual confirm: idle landing reads calm, not broken; line wraps cleanly at 60ch