### PR TITLE
wave56-a: motion pass — quiet fades on tab switch, accordion, dialog

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -380,7 +380,7 @@ function AppContent(): JSX.Element {
         hidden={view !== 'portfolio'}
       >
         {view === 'portfolio' && (
-          <>
+          <div className="motion-fade-in">
             <PortfolioPanel
               leases={library}
               findingsByLease={portfolioFindings}
@@ -399,7 +399,7 @@ function AppContent(): JSX.Element {
                 })();
               }}
             />
-          </>
+          </div>
         )}
       </div>
 
@@ -411,17 +411,19 @@ function AppContent(): JSX.Element {
       >
         {view === 'redline' && status.kind === 'analyzed' && (
           <Suspense fallback={null}>
-            <AppRedlinePane
-              doc={status.result.doc}
-              leaseName={status.fileName}
-              redline={redline}
-              versionHistory={versionHistory}
-              sideLetter={sideLetter}
-              findings={status.result.findings}
-              suggestedTextByRuleId={suggestedTextByRuleId}
-              sectionForParagraph={sectionForParagraph}
-              safeAudit={safeAudit}
-            />
+            <div className="motion-fade-in">
+              <AppRedlinePane
+                doc={status.result.doc}
+                leaseName={status.fileName}
+                redline={redline}
+                versionHistory={versionHistory}
+                sideLetter={sideLetter}
+                findings={status.result.findings}
+                suggestedTextByRuleId={suggestedTextByRuleId}
+                sectionForParagraph={sectionForParagraph}
+                safeAudit={safeAudit}
+              />
+            </div>
           </Suspense>
         )}
       </div>
@@ -452,50 +454,52 @@ function AppContent(): JSX.Element {
         )}
         {view === 'current' && status.kind === 'analyzed' && (
           <AnalyzedPaneBoundary>
-            <AppCurrentPane
-              status={status}
-              selected={selected}
-              selectedPage={selectedPage}
-              setSelected={setSelected}
-              setSelectedPage={setSelectedPage}
-              ocrState={ocrState}
-              ocrLanguage={ocrLanguage}
-              setOcrLanguage={setOcrLanguage}
-              ocrLanguages={ocrLanguages}
-              hasSigningKey={signingKey.publicKey !== null}
-              glossaryEntries={glossaryEntries}
-              templates={templates}
-              plainEnglishByRuleId={plainEnglishByRuleId}
-              suggestedTextByRuleId={suggestedTextByRuleId}
-              suggestedEditByRuleId={suggestedEditByRuleId}
-              redline={redline}
-              counters={counters}
-              annotationsApi={annotationsApi}
-              analyzedLeaseId={analyzedLeaseId}
-              onExportJson={onExportJson}
-              onExportSignedJson={() => void onExportSignedJson()}
-              onBuildIcs={onBuildIcs}
-              onAttemptOcr={() => {
-                setSelected(null);
-                void pipeline.ocr(ocrLanguage);
-              }}
-              onPromoteToStandard={(leaseId, paragraphIndex) => {
-                if (status.kind !== 'analyzed') return;
-                void (async (): Promise<void> => {
-                  const text = status.result.doc.paragraphs[paragraphIndex]?.text ?? '';
-                  const name = text.slice(0, 60).trim() || `Clause from ${leaseId}`;
-                  await promoteToStandard({
-                    name,
-                    sourceLeaseId: leaseId,
-                    sourceParagraphIndex: paragraphIndex,
-                    normalizedText: text,
-                  });
-                  await refreshStandardSuite();
-                  void refreshAuditLog();
-                })();
-              }}
-              setView={setView}
-            />
+            <div className="motion-fade-in">
+              <AppCurrentPane
+                status={status}
+                selected={selected}
+                selectedPage={selectedPage}
+                setSelected={setSelected}
+                setSelectedPage={setSelectedPage}
+                ocrState={ocrState}
+                ocrLanguage={ocrLanguage}
+                setOcrLanguage={setOcrLanguage}
+                ocrLanguages={ocrLanguages}
+                hasSigningKey={signingKey.publicKey !== null}
+                glossaryEntries={glossaryEntries}
+                templates={templates}
+                plainEnglishByRuleId={plainEnglishByRuleId}
+                suggestedTextByRuleId={suggestedTextByRuleId}
+                suggestedEditByRuleId={suggestedEditByRuleId}
+                redline={redline}
+                counters={counters}
+                annotationsApi={annotationsApi}
+                analyzedLeaseId={analyzedLeaseId}
+                onExportJson={onExportJson}
+                onExportSignedJson={() => void onExportSignedJson()}
+                onBuildIcs={onBuildIcs}
+                onAttemptOcr={() => {
+                  setSelected(null);
+                  void pipeline.ocr(ocrLanguage);
+                }}
+                onPromoteToStandard={(leaseId, paragraphIndex) => {
+                  if (status.kind !== 'analyzed') return;
+                  void (async (): Promise<void> => {
+                    const text = status.result.doc.paragraphs[paragraphIndex]?.text ?? '';
+                    const name = text.slice(0, 60).trim() || `Clause from ${leaseId}`;
+                    await promoteToStandard({
+                      name,
+                      sourceLeaseId: leaseId,
+                      sourceParagraphIndex: paragraphIndex,
+                      normalizedText: text,
+                    });
+                    await refreshStandardSuite();
+                    void refreshAuditLog();
+                  })();
+                }}
+                setView={setView}
+              />
+            </div>
           </AnalyzedPaneBoundary>
         )}
       </div>
@@ -507,23 +511,25 @@ function AppContent(): JSX.Element {
         hidden={view !== 'audit'}
       >
         {view === 'audit' && (
-          <AppAuditPane
-            entries={auditEntries}
-            verification={auditVerification}
-            onRefresh={() => void refreshAuditLog()}
-            onVerify={() => {
-              void (async (): Promise<void> => {
-                setAuditVerification(await verifyAuditChain());
-              })();
-            }}
-            onDownload={(entries, verification) => {
-              const json = buildAuditLogJson(entries, verification);
-              downloadAuditLogBlob(
-                json,
-                `leaseguard-audit-${new Date().toISOString().slice(0, 10)}.json`,
-              );
-            }}
-          />
+          <div className="motion-fade-in">
+            <AppAuditPane
+              entries={auditEntries}
+              verification={auditVerification}
+              onRefresh={() => void refreshAuditLog()}
+              onVerify={() => {
+                void (async (): Promise<void> => {
+                  setAuditVerification(await verifyAuditChain());
+                })();
+              }}
+              onDownload={(entries, verification) => {
+                const json = buildAuditLogJson(entries, verification);
+                downloadAuditLogBlob(
+                  json,
+                  `leaseguard-audit-${new Date().toISOString().slice(0, 10)}.json`,
+                );
+              }}
+            />
+          </div>
         )}
       </div>
 
@@ -534,7 +540,7 @@ function AppContent(): JSX.Element {
         hidden={view !== 'settings'}
       >
         {view === 'settings' && (
-          <>
+          <div className="motion-fade-in">
             <AppSettingsPane
               onExportArchive={() => void exportEncryptedArchiveFlow()}
               onImportArchive={(e) => void onImportArchiveFile(e)}
@@ -629,7 +635,7 @@ function AppContent(): JSX.Element {
               }
               onDeleteTemplate={(id) => void deleteTemplate(id).then(refreshTemplates)}
             />
-          </>
+          </div>
         )}
       </div>
     </main>

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -302,3 +302,77 @@ main:has(.results) > [id='viewmode-panel-current'] {
   border: 1px solid var(--color-rule);
   margin-bottom: 0.5rem;
 }
+
+/* Wave 56-A — motion. Quiet ease-out fades on tab switch, accordion
+   reveal, and dialog mount. Honors `prefers-reduced-motion`. No layout
+   properties animated; opacity + transform only. */
+:root {
+  --motion-fast: 120ms;
+  --motion-base: 180ms;
+  --motion-slow: 240ms;
+  --ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes lg-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes lg-rise-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes lg-dialog-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.motion-fade-in {
+  animation: lg-fade-in var(--motion-base) var(--ease-out-quart) both;
+}
+
+.motion-rise-in {
+  animation: lg-rise-in var(--motion-base) var(--ease-out-quart) both;
+}
+
+.motion-dialog-backdrop {
+  animation: lg-fade-in var(--motion-fast) var(--ease-out-quart) both;
+}
+
+.motion-dialog-in {
+  animation: lg-dialog-in var(--motion-slow) var(--ease-out-expo) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .motion-fade-in,
+  .motion-rise-in,
+  .motion-dialog-backdrop,
+  .motion-dialog-in {
+    animation: none !important;
+  }
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.001ms !important;
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/app/src/ui/system/Dialog.tsx
+++ b/app/src/ui/system/Dialog.tsx
@@ -108,7 +108,7 @@ export function Dialog({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-fg/40 p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-fg/40 p-4 motion-dialog-backdrop"
       onClick={onBackdropClick}
     >
       <div
@@ -118,7 +118,7 @@ export function Dialog({
         aria-labelledby={titleId}
         aria-describedby={descriptionId}
         tabIndex={-1}
-        className={`bg-paper-raised border border-rule rounded-sm shadow-paper p-4 max-w-lg w-full focus-visible:focus-ring ${className}`}
+        className={`bg-paper-raised border border-rule rounded-sm shadow-paper p-4 max-w-lg w-full focus-visible:focus-ring motion-dialog-in ${className}`}
       >
         {children}
       </div>

--- a/app/src/ui/system/SectionGroup.tsx
+++ b/app/src/ui/system/SectionGroup.tsx
@@ -100,7 +100,12 @@ export function SectionGroup({
         landmark-unique violation). aria-labelledby is retained so
         readers still announce the group title when focus enters.
       */}
-      <div id={panelId} aria-labelledby={headerId} hidden={!open} className={open ? bodyPad : ''}>
+      <div
+        id={panelId}
+        aria-labelledby={headerId}
+        hidden={!open}
+        className={open ? `${bodyPad} motion-rise-in` : ''}
+      >
         {open && children}
       </div>
     </Card>


### PR DESCRIPTION
## Summary
- Add motion tokens (`--motion-fast/base/slow`, `--ease-out-quart/expo`), three keyframes, and four utility classes; honors \`prefers-reduced-motion: reduce\`.
- Tabpanels cross-fade on switch; SectionGroup body rises + fades on expand; Dialog fades backdrop and rises the dialog box on mount.
- No layout properties animated, no bounce; opacity ± small translate only, per impeccable shared-design-laws.

## Test plan
- [x] typecheck + lint clean
- [x] 1744/1744 vitest tests pass
- [ ] visual smoke after merge (verify reduced-motion users see no animation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)