### PR TITLE
wave56-b: empty + error states get proper copy and chrome

### DIFF
--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -219,6 +219,12 @@ describe('App', () => {
     const input = (await screen.findByLabelText(/upload lease/i)) as HTMLInputElement;
     await userEvent.upload(input, bogus);
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    // Wave 56-B — the analysis-error region offers a recovery affordance
+    // that resets the pipeline back to the idle UploadView.
+    await userEvent.click(screen.getByRole('button', { name: /try another file/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('region', { name: /upload/i })).toBeInTheDocument(),
+    );
   });
 
   it('clicking a finding opens the finding-detail modal', async () => {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -450,7 +450,34 @@ function AppContent(): JSX.Element {
           </Suspense>
         )}
         {view === 'current' && status.kind === 'error' && (
-          <p role="alert">Could not analyze this file: {status.message}</p>
+          <section
+            role="alert"
+            aria-label="analysis error"
+            className="grid w-full max-w-[680px] mx-auto gap-3 px-6 py-12 motion-fade-in"
+          >
+            <p className="font-sans text-small uppercase tracking-wide text-severity-high">
+              Couldn’t read this lease
+            </p>
+            <h2 className="font-serif text-[24px] font-semibold leading-tight text-fg m-0">
+              Something went wrong opening that file.
+            </h2>
+            <p className="font-display italic text-fg-body leading-relaxed max-w-[60ch]">
+              {status.message}
+            </p>
+            <p className="font-display text-fg-muted leading-relaxed max-w-[60ch] mt-1">
+              Try a different PDF, or reload the page if this keeps happening. Your lease never left
+              this device — nothing was uploaded.
+            </p>
+            <div className="mt-2">
+              <button
+                type="button"
+                onClick={() => pipeline.reset()}
+                className="h-8 px-4 rounded-sm font-sans text-[13px] tracking-[0.01em] border border-rule bg-paper-raised hover:bg-paper-sunken transition-colors focus-visible:focus-ring"
+              >
+                Try another file
+              </button>
+            </div>
+          </section>
         )}
         {view === 'current' && status.kind === 'analyzed' && (
           <AnalyzedPaneBoundary>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -471,7 +471,7 @@ function AppContent(): JSX.Element {
             <div className="mt-2">
               <button
                 type="button"
-                onClick={() => pipeline.reset()}
+                onClick={pipeline.reset}
                 className="h-8 px-4 rounded-sm font-sans text-[13px] tracking-[0.01em] border border-rule bg-paper-raised hover:bg-paper-sunken transition-colors focus-visible:focus-ring"
               >
                 Try another file

--- a/app/src/ui/FindingsPanel.test.tsx
+++ b/app/src/ui/FindingsPanel.test.tsx
@@ -40,7 +40,7 @@ describe('FindingsPanel', () => {
 
   it('renders an empty state when no findings', () => {
     render(<FindingsPanel findings={[]} onSelect={() => {}} />);
-    expect(screen.getByText(/no findings/i)).toBeInTheDocument();
+    expect(screen.getByText(/came back clean/i)).toBeInTheDocument();
   });
 
   it('calls onSelect with the finding when a row is clicked', async () => {

--- a/app/src/ui/FindingsPanel.tsx
+++ b/app/src/ui/FindingsPanel.tsx
@@ -139,8 +139,17 @@ export function FindingsPanel({
 
   if (findings.length === 0) {
     return (
-      <aside aria-label="findings" className="p-4">
-        <p className="text-body text-fg-muted">No findings yet. Upload a lease to analyze.</p>
+      <aside aria-label="findings" className="px-4 py-6 motion-fade-in">
+        <p className="font-sans text-small uppercase tracking-wide text-fg-muted mb-2">
+          Nothing flagged
+        </p>
+        <h2 className="font-serif text-[22px] font-semibold leading-tight text-fg m-0">
+          This lease came back clean.
+        </h2>
+        <p className="font-display italic text-fg-body leading-relaxed mt-2 max-w-[44ch]">
+          The rules ran across every paragraph and didn’t catch anything worth pushing back on.
+          That’s a good sign — most leases have at least one or two flags.
+        </p>
       </aside>
     );
   }

--- a/app/src/ui/PortfolioPanel.test.tsx
+++ b/app/src/ui/PortfolioPanel.test.tsx
@@ -46,7 +46,7 @@ async function gotoMatrix(): Promise<void> {
 describe('PortfolioPanel', () => {
   it('renders an empty state when no leases supplied', () => {
     render(<PortfolioPanel leases={[]} findingsByLease={new Map()} onOpenLease={() => {}} />);
-    expect(screen.getByText(/no leases in portfolio/i)).toBeInTheDocument();
+    expect(screen.getByText(/nothing here yet/i)).toBeInTheDocument();
   });
 
   it('renders a row per lease and a column per unique rule id', async () => {

--- a/app/src/ui/PortfolioPanel.tsx
+++ b/app/src/ui/PortfolioPanel.tsx
@@ -97,9 +97,16 @@ export function PortfolioPanel({
 
   if (visible.length === 0) {
     return (
-      <Section label="portfolio" className="space-y-2 px-4 py-4">
-        <h2 className="text-heading uppercase text-fg-muted">Portfolio</h2>
-        <p className="text-body text-fg-muted">No leases in portfolio yet.</p>
+      <Section label="portfolio" className="space-y-3 px-4 py-6 motion-fade-in">
+        <p className="font-sans text-small uppercase tracking-wide text-fg-muted">Portfolio</p>
+        <h2 className="font-serif text-[24px] font-semibold leading-tight text-fg m-0">
+          Nothing here yet.
+        </h2>
+        <p className="font-display italic text-fg-body leading-relaxed max-w-[60ch]">
+          Every lease you analyze gets saved on this device and shows up here. You’ll see them
+          side-by-side with the same rules applied — useful for comparing two units, or your current
+          lease against a renewal.
+        </p>
       </Section>
     );
   }


### PR DESCRIPTION
## Summary
- **FindingsPanel zero-findings** rewritten — was \"No findings yet. Upload a lease to analyze.\" which is wrong (the surface only renders post-analysis). Now: \"This lease came back clean. The rules ran across every paragraph and didn't catch anything worth pushing back on.\"
- **App.tsx analysis-error** upgraded from a bare \`<p role=\"alert\">\` to a proper error region with severity-high eyebrow, headline, the underlying error, a privacy reminder, and a \"Try another file\" recovery button that resets the pipeline.
- **PortfolioPanel empty** now explains what the surface is *for* instead of just stating it's empty.

All three fade in via the Wave 56-A motion vocabulary. Tests updated to match the new copy.

## Test plan
- [x] typecheck + lint clean
- [x] 1744/1744 vitest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)