### PR TITLE
wave56-c: narrow-viewport adapt — header, reader, marginalia

### DIFF
--- a/app/src/ui/AppHeader.tsx
+++ b/app/src/ui/AppHeader.tsx
@@ -47,7 +47,7 @@ export function AppHeader({
   const { t } = useI18n();
   const hasLease = Boolean(fileName);
   return (
-    <header className="bg-paper-raised border-b border-rule px-5 h-[52px] flex items-center gap-4">
+    <header className="bg-paper-raised border-b border-rule px-5 h-[52px] flex items-center gap-4 overflow-x-auto">
       <div className="flex items-center gap-2.5">
         <svg width="22" height="22" viewBox="0 0 22 22" aria-hidden="true" className="shrink-0">
           <rect
@@ -78,10 +78,10 @@ export function AppHeader({
 
       {hasLease && fileName && (
         <>
-          <span aria-hidden="true" className="h-[22px] w-px bg-rule" />
+          <span aria-hidden="true" className="hidden sm:inline-block h-[22px] w-px bg-rule" />
           <span
             aria-label="lease file name"
-            className="font-display italic text-small text-fg-muted truncate max-w-[36ch] min-w-0 flex-1"
+            className="hidden sm:inline-block font-display italic text-small text-fg-muted truncate max-w-[36ch] min-w-0 flex-1"
           >
             {fileName}
           </span>

--- a/app/src/ui/MarginaliaReader.tsx
+++ b/app/src/ui/MarginaliaReader.tsx
@@ -91,8 +91,8 @@ export function MarginaliaReader({
       role="region"
       aria-label={t('reader.region.label')}
     >
-      <div className="mx-auto grid max-w-[1080px] grid-cols-[1fr_220px] gap-x-10 px-6 pb-32 pt-10">
-        <div className="col-span-2 mb-8 border-b border-rule pb-4">
+      <div className="mx-auto grid max-w-[1080px] grid-cols-1 md:grid-cols-[1fr_220px] gap-x-10 px-6 pb-32 pt-10">
+        <div className="md:col-span-2 mb-8 border-b border-rule pb-4">
           <h1 className="font-serif text-[26px] font-semibold leading-tight text-fg">{fileName}</h1>
           <p className="mt-1.5 text-mono uppercase tracking-[0.08em] text-fg-faint">
             {t('reader.header.document', { count: String(doc.pages.length) })}
@@ -105,7 +105,7 @@ export function MarginaliaReader({
             <div key={idx} className="contents">
               <div className="relative" data-paragraph-index={idx}>
                 <div
-                  className="mono absolute -left-8 top-1 select-none text-[10px] tracking-wider text-fg-faint"
+                  className="mono hidden md:block absolute -left-8 top-1 select-none text-[10px] tracking-wider text-fg-faint"
                   aria-hidden="true"
                 >
                   {String(idx + 1).padStart(2, '0')}
@@ -114,7 +114,7 @@ export function MarginaliaReader({
                   {renderParagraph(p.text, paraFindings, selectedKey, onSelectFinding)}
                 </p>
               </div>
-              <div className="border-l border-rule-subtle pl-3">
+              <div className="md:border-l md:border-rule-subtle md:pl-3 mb-5 md:mb-0">
                 {paraFindings.map((f) => {
                   const key = findingKey(f);
                   const active = key === selectedKey;


### PR DESCRIPTION
## Summary
The 3-pane analyzed view assumed desktop. Below ~640px the AppHeader pushed the lease filename out of layout, MarginaliaReader's \`1fr 220px\` grid squeezed paragraphs, the marginalia border-l rendered awkwardly when stacked, and absolute paragraph numbers (\`-left-8\`) hung off the viewport.

- **AppHeader**: filename + divider hidden below \`sm\`; \`overflow-x-auto\` so tabs/actions scroll on tight screens.
- **MarginaliaReader**: \`grid-cols-1 md:grid-cols-[1fr_220px]\` — each paragraph + its marginalia stack vertically on narrow; absolute paragraph-number markers hidden when there's no left margin; the \`border-l\` only renders on \`md+\` (it would otherwise be a stray left border on a top-stacked block); \`mb-5\` added for breathing room when stacked.
- The \`.split\` CSS already collapsed FindingRail + reader + FindingsPanel to one column below 960px so AppCurrentPane gets the rest of the narrow story for free.

## Test plan
- [x] typecheck + lint clean
- [x] 1744/1744 vitest tests pass
- [ ] visual smoke at 360px, 768px, 1280px after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)