### PR TITLE
wave48-slice2: vocabulary normalization — last lawyerly residue

### DIFF
--- a/app/src/ui/AppAuditPane.test.tsx
+++ b/app/src/ui/AppAuditPane.test.tsx
@@ -27,8 +27,8 @@ describe('AppAuditPane', () => {
     );
     // AuditLogPanel is lazy; resolves async.
     expect(await screen.findByRole('table', { name: /audit entries/i })).toBeInTheDocument();
-    expect(screen.getByText('analyze')).toBeInTheDocument();
-    expect(screen.getByText('export')).toBeInTheDocument();
+    expect(screen.getByText(/analyzed lease/i)).toBeInTheDocument();
+    expect(screen.getByText(/exported findings/i)).toBeInTheDocument();
   });
 
   it('renders the empty state when no entries', async () => {

--- a/app/src/ui/AuditLogPanel.test.tsx
+++ b/app/src/ui/AuditLogPanel.test.tsx
@@ -44,8 +44,8 @@ describe('AuditLogPanel', () => {
     const rows = screen.getAllByRole('row');
     // header + 2 entries
     expect(rows).toHaveLength(3);
-    expect(screen.getByText('analyze')).toBeInTheDocument();
-    expect(screen.getByText('export')).toBeInTheDocument();
+    expect(screen.getByText(/analyzed lease/i)).toBeInTheDocument();
+    expect(screen.getByText(/exported findings/i)).toBeInTheDocument();
   });
 
   it('shows chain-intact status when verification.ok=true', () => {

--- a/app/src/ui/AuditLogPanel.tsx
+++ b/app/src/ui/AuditLogPanel.tsx
@@ -127,7 +127,7 @@ export function AuditLogPanel({
                       <td className="py-1 pr-3 font-mono text-mono text-fg-muted whitespace-nowrap">
                         {e.timestamp}
                       </td>
-                      <td className="py-1 pr-3 text-fg-body">{e.kind}</td>
+                      <td className="py-1 pr-3 text-fg-body">{kindLabel(e.kind)}</td>
                       <td className="py-1">
                         {subject ? (
                           <span className="font-serif italic text-fg-body">{subject}</span>
@@ -188,4 +188,38 @@ function extractSubject(payload: Record<string, unknown>): string | null {
     if (typeof v === 'string' && v.length > 0) return v;
   }
   return null;
+}
+
+/**
+ * Wave 48 Slice 2 — render audit `kind` strings in plain English. The
+ * kind values are stable wire ids (used in the hash-chained log) so we
+ * keep them unchanged on disk; this map only governs the visible label
+ * in the Activity table. Unknown kinds fall through verbatim so future
+ * audit kinds remain visible without a code change.
+ */
+const KIND_LABELS: Readonly<Record<string, string>> = {
+  analyze: 'Analyzed lease',
+  export: 'Exported findings',
+  'signed-export': 'Exported (signed)',
+  'parse-analyze': 'Parsed and analyzed',
+  'save-lease': 'Saved lease',
+  'delete-lease': 'Deleted lease',
+  'bulk-import': 'Bulk imported',
+  'import-pack': 'Imported rule pack',
+  'pack-signature-verified': 'Pack signature verified',
+  'pack-signature-invalid': 'Pack signature invalid',
+  'custom-rule-save': 'Saved custom rule',
+  'redline-edit': 'Edited paragraph',
+  'version-save': 'Saved version',
+  'version-restore': 'Restored version',
+  'version-delete': 'Deleted version',
+  'patch-applied': 'Applied counter-sign patch',
+  'standard-promote': 'Promoted to standard',
+  'standard-delete': 'Deleted standard clause',
+  'llm-classify': 'AI classified clause',
+  'hybrid-feedback': 'Marked finding not relevant',
+};
+
+function kindLabel(kind: string): string {
+  return KIND_LABELS[kind] ?? kind;
 }

--- a/app/src/ui/OnboardingTour.tsx
+++ b/app/src/ui/OnboardingTour.tsx
@@ -31,7 +31,7 @@ const STEPS: readonly Step[] = [
   {
     title: 'Findings: severity + click-to-highlight',
     body:
-      'Each finding is tagged Critical / Warning / Info and links back to ' +
+      'Each finding is tagged High / Medium / Low / Info and links back to ' +
       'the page and clause that triggered it. Click a finding to jump to the ' +
       'matching span in the PDF viewer; filter the list by category or severity.',
   },

--- a/app/src/ui/PackManagerPanel.test.tsx
+++ b/app/src/ui/PackManagerPanel.test.tsx
@@ -156,7 +156,7 @@ describe('PackManagerPanel', () => {
     expect(onImport).not.toHaveBeenCalled();
   });
 
-  it('renders a "Community" badge by default when signatureStatusByPackId is omitted', () => {
+  it('renders an "Unsigned" badge by default when signatureStatusByPackId is omitted', () => {
     render(
       <PackManagerPanel
         builtInName="Built-in"
@@ -167,7 +167,7 @@ describe('PackManagerPanel', () => {
         onDelete={() => {}}
       />,
     );
-    expect(screen.getByLabelText(/signature status: community/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/signature status: unsigned/i)).toBeInTheDocument();
   });
 
   it('renders the supplied signature badge per pack', () => {
@@ -188,7 +188,7 @@ describe('PackManagerPanel', () => {
     );
     expect(screen.getByLabelText(/signature status: verified/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/signature status: invalid signature/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/signature status: community/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/signature status: unsigned/i)).toBeInTheDocument();
   });
 
   it('renders an "unknown" badge for unknown status', () => {

--- a/app/src/ui/PackManagerPanel.tsx
+++ b/app/src/ui/PackManagerPanel.tsx
@@ -17,11 +17,14 @@ import { FileButton } from './system/FileButton';
 
 /**
  * Signature trust vocabulary surfaced in the panel. Intentionally a
- * superset of the storage-layer statuses: "community" covers packs that
- * were imported without an envelope (storage calls those "unsigned"),
- * while "verified" and "invalid" mean exactly what they do on disk.
+ * superset of the storage-layer statuses: "community" (badge label
+ * "Unsigned" post-Wave 48 Slice 2) covers packs that were imported
+ * without an envelope (storage calls those "unsigned"), while
+ * "verified" and "invalid" mean exactly what they do on disk.
  * Anything outside this set (including missing) falls back to
- * "community" so legacy callers keep rendering.
+ * "community" so legacy callers keep rendering. The discriminant key
+ * stays `community` for storage / wire compat; only the visible label
+ * is renamed to "Unsigned".
  */
 export type PackSignatureBadge = 'verified' | 'community' | 'invalid' | 'unknown';
 
@@ -56,7 +59,7 @@ function badgeLabel(status: PackSignatureBadge): string {
       return 'Unknown';
     case 'community':
     default:
-      return 'Community';
+      return 'Unsigned';
   }
 }
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -131,7 +131,7 @@ and +10 MB of language data once `eng.traineddata.gz` is dropped into
       OS on every PR. Decision: closed — the CI matrix is the gate;
       code-signing / notarization tracked separately in the risk
       register (2026-04-25).
-- [ ] Onboarding tour (sample lease button exists; full walkthrough pending)
+- [x] Onboarding tour — decided 2026-05-01: the "Try a sample lease" button on UploadView is the walkthrough; the inline `OnboardingTour` modal stays as a one-time first-run primer but no separate guided tour ships. Closing this row.
 
 ## Phase 7 — Observability & hygiene
 
@@ -675,7 +675,7 @@ Slice 3 of `docs/audits/perf-probe-2026-04-29.md` was deferred when Wave 50 ship
 
 - [ ] **VersionHistoryPanel destructive-confirm.** `aria-label="delete version {label}"` + plain "Delete" button at `VersionHistoryPanel.tsx:105-110` triggers irreversible delete with no confirm. Add Dialog confirm naming the version + edit count. Severity M.
 - [ ] **`MIN_PASSPHRASE_LEN` client-side validation.** Wave 47 added "16+ characters" helper text on passphrase fields; promoting to actual client-side `pattern` / disabled-submit-until-valid is the next step. Severity L.
-- [ ] **Wave 48 Slice 2 — audit-log + onboarding vocabulary normalization** (clarify-inventory). 1H / 6M. Includes: `AuditLogPanel` kind→plain-label adapter, OnboardingTour step 2 severity vocab fix ("Critical/Warning/Info" → "High/Medium/Low/Info"), `PackManager` "Community" badge → "Unsigned" rename. Touches Wave 45-D-edited surfaces; preserve preamble verbatim.
+- [x] **Wave 48 Slice 2 — audit-log + onboarding vocabulary normalization** (clarify-inventory). Shipped 2026-05-01: `AuditLogPanel.kindLabel()` adapter renders the 19 well-known kinds in plain English (unknown kinds fall through verbatim); `OnboardingTour` severity vocab corrected to "High/Medium/Low/Info"; `PackManagerPanel` badge label renamed "Community" → "Unsigned" (discriminant key kept as `community` for storage / wire compat).
 - [ ] **Wave 48 Slice 3 — empty states + helper text + jargon plain-readings** (clarify-inventory). 1H / 6M / 8L across ~10 panels (AnnotationsPanel, LibraryPanel, JurisdictionPickerPanel, StandardSuitePanel, HybridPrecisionPanel, ClauseSimilarityPanel, RedlinePanel, ShareReviewPanel, SideLetterPanel, CustomRuleBuilderPanel intro + preview labels). Polish-pass scope; lowest per-string ROI.
 
 **From `docs/audits/extract-inventory-2026-04-29.md` (deferred from Wave 48 Slice 1):**


### PR DESCRIPTION
## Summary

Three small renames promised by Wave 48 Slice 2, never landed. Shipped together as the final renter-vocabulary sweep before v1.0.

- **AuditLogPanel** gains a \`kindLabel()\` adapter — 19 well-known audit kinds (\`analyze\`, \`export\`, \`import-pack\`, \`redline-edit\`, \`version-save\`, \`pack-signature-verified\`, \`llm-classify\`, …) render in plain English (\"Analyzed lease\", \"Exported findings\", \"Imported rule pack\", \"Edited paragraph\", …). Unknown kinds pass through verbatim. The on-disk hash-chained log still uses the wire ids unchanged.
- **OnboardingTour** step 2 severity vocab corrected from \"Critical / Warning / Info\" → \"High / Medium / Low / Info\" to match the actual \`Severity\` union used everywhere else in the app.
- **PackManagerPanel** badge label renamed \"Community\" → \"Unsigned\". Discriminant key stays \`community\` for storage / wire compat — only the visible label + aria-label change.

BACKLOG closeouts:
- Phase 6 onboarding-tour row resolved as **won't build a separate tour** — the \"Try a sample lease\" button on UploadView is the walkthrough.
- Wave 48 Slice 2 row flipped to shipped.

## Test plan
- [x] typecheck + lint clean
- [x] 1744/1744 vitest tests pass (PackManagerPanel + AuditLogPanel + AppAuditPane test selectors updated for the new labels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)