### PR TITLE
wave58a-slice1: StatusMessage primitive

### DIFF
--- a/app/src/ui/primitives/StatusMessage.stories.tsx
+++ b/app/src/ui/primitives/StatusMessage.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StatusMessage } from './StatusMessage';
+
+const meta: Meta<typeof StatusMessage> = {
+  title: 'Primitives/StatusMessage',
+  component: StatusMessage,
+};
+export default meta;
+type Story = StoryObj<typeof StatusMessage>;
+
+export const Success: Story = {
+  args: { tone: 'success', children: 'Saved. The pack is now active.' },
+};
+
+export const ErrorTone: Story = {
+  name: 'Error',
+  args: {
+    tone: 'error',
+    children: 'Verification failed: signature did not match.',
+  },
+};
+
+export const Info: Story = {
+  args: {
+    tone: 'info',
+    children: 'No signing key yet — generate one to enable signed exports.',
+  },
+};
+
+export const Warn: Story = {
+  args: {
+    tone: 'warn',
+    children: 'This pack is unsigned. Findings will be flagged accordingly.',
+  },
+};

--- a/app/src/ui/primitives/StatusMessage.test.tsx
+++ b/app/src/ui/primitives/StatusMessage.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { expectAxeClean } from '../../test/axe';
+import { StatusMessage, type StatusTone } from './StatusMessage';
+
+describe('StatusMessage', () => {
+  it.each<[StatusTone, string]>([
+    ['success', 'status'],
+    ['error', 'alert'],
+    ['info', 'status'],
+    ['warn', 'status'],
+  ])('renders tone=%s with role=%s', (tone, role) => {
+    render(<StatusMessage tone={tone}>Saved.</StatusMessage>);
+    const node = screen.getByRole(role);
+    expect(node).toHaveTextContent('Saved.');
+    expect(node.tagName).toBe('P');
+  });
+
+  it('forwards extra props (id, data-testid, aria-live override)', () => {
+    render(
+      <StatusMessage tone="info" id="hint" data-testid="hint" aria-live="off">
+        hint
+      </StatusMessage>,
+    );
+    const node = screen.getByTestId('hint');
+    expect(node).toHaveAttribute('id', 'hint');
+    expect(node).toHaveAttribute('aria-live', 'off');
+  });
+
+  it('merges className with tone classes', () => {
+    render(
+      <StatusMessage tone="success" className="mt-2">
+        ok
+      </StatusMessage>,
+    );
+    const node = screen.getByRole('status');
+    expect(node.className).toContain('mt-2');
+    expect(node.className).toContain('text-positive');
+  });
+
+  it('is axe-clean across every tone', async () => {
+    const tones: StatusTone[] = ['success', 'error', 'info', 'warn'];
+    for (const tone of tones) {
+      const { container, unmount } = render(
+        <StatusMessage tone={tone}>Status text for {tone}.</StatusMessage>,
+      );
+      await expectAxeClean(container);
+      unmount();
+    }
+  });
+});

--- a/app/src/ui/primitives/StatusMessage.tsx
+++ b/app/src/ui/primitives/StatusMessage.tsx
@@ -1,0 +1,48 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+
+// Wave 58a Slice 1 — `<StatusMessage>` primitive.
+// Codifies the ~17 ad-hoc `<p role="status|alert">` one-liners scattered
+// across panels into a single, audit-friendly surface. No new tokens —
+// every tone reuses an existing color from `app/src/index.css` so a
+// migration to this primitive is a pure recipe-swap.
+//
+// Role mapping per WAI-ARIA: `error` is assertive (`role="alert"`), every
+// other tone is the polite live region (`role="status"`). Components that
+// need a non-default `aria-live` can pass it through as a regular prop.
+
+export type StatusTone = 'success' | 'error' | 'info' | 'warn';
+
+interface StatusMessageProps extends HTMLAttributes<HTMLParagraphElement> {
+  tone: StatusTone;
+  children: ReactNode;
+}
+
+const TONE_CLASSES: Record<StatusTone, string> = {
+  // success → positive ink (Wave 45-A token, used by OpenReviewPanel /
+  // PackManagerPanel today).
+  success: 'text-small text-positive',
+  // error → severity-high ink. Matches PackManagerPanel + ScannedPdfNotice
+  // one-liners.
+  error: 'text-small text-severity-high',
+  // info → muted ink for low-stakes status (e.g. SigningKeyPanel hint
+  // lines, BulkImportPanel summary).
+  info: 'text-small text-fg-muted',
+  // warn → severity-medium ink for warning-grade status that doesn't yet
+  // warrant a full severity surface.
+  warn: 'text-small text-severity-medium',
+};
+
+export function StatusMessage({
+  tone,
+  className = '',
+  children,
+  ...rest
+}: StatusMessageProps): JSX.Element {
+  const role = tone === 'error' ? 'alert' : 'status';
+  const toneClass = TONE_CLASSES[tone];
+  return (
+    <p role={role} className={`${toneClass} ${className}`.trim()} {...rest}>
+      {children}
+    </p>
+  );
+}

--- a/docs/plans/wave58a-status-confirm-primitives.md
+++ b/docs/plans/wave58a-status-confirm-primitives.md
@@ -1,0 +1,124 @@
+# Wave 58a — `StatusMessage` + `ConfirmDialog` primitives
+
+**Track**: Wave 48 Slice 3a (BACKLOG.md:684)
+**Status**: 📋 Planned
+**Risk**: Low (additive primitives, mechanical migrations)
+**Estimated PRs**: 3 small, sequential
+
+## Goal
+
+Consolidate two repeated UI recipes into single primitives:
+
+1. The ~17 ad-hoc `<p role="status|alert">` one-liners (success/error/info)
+   sprinkled across panels.
+2. The 5 non-crypto `window.confirm` / `window.prompt` callsites that bypass
+   our chrome and accessibility tokens.
+
+Defer the 4 crypto-passphrase prompts (`SigningKeyPanel`, `useAppCallbacks`,
+`appHelpers`) — they need a memory-zeroing pattern specced first; tracked in
+the deferral row.
+
+## Non-goals
+
+- No restyling of existing panels beyond swapping the recipe.
+- No new visual variants — primitives codify what already ships.
+- No crypto-passphrase migration this wave.
+
+## Slice plan
+
+### Slice 1 — `<StatusMessage>` primitive (PR A)
+
+**Surface:**
+
+```tsx
+<StatusMessage tone="success" | "error" | "info" | "warn">{children}</StatusMessage>
+```
+
+- Renders `<p role={tone === 'error' ? 'alert' : 'status'}>` with the right
+  Tailwind classes from existing tokens (no new colors).
+- Lives at `app/src/ui/primitives/StatusMessage.tsx` with stories +
+  `vitest-axe` smoke test.
+- File: 1 new component + 1 test + 1 story.
+
+**Migration scope:** all in-tree `<p role="status|alert">` callsites that are
+plain one-liners. Skip composite cases (where the `<p>` is nested inside a
+larger live region pattern) — list each skip in the PR description.
+
+**Verify:**
+
+- `npm run test` green; existing snapshot tests unchanged.
+- `npx playwright test tests/e2e/a11y.spec.ts` clean.
+- Visual: spot-check the 3 noisiest panels (LibraryPanel, AppRedlinePane,
+  PackManagerPanel) in the dev server.
+
+### Slice 2 — `<ConfirmDialog>` primitive (PR B)
+
+**Surface:**
+
+```tsx
+<ConfirmDialog
+  open={...}
+  title="Clear all 12 redline edits?"
+  body={...}                  // optional
+  confirmLabel="Clear all"
+  confirmTone="destructive" | "default"
+  onConfirm={...}
+  onCancel={...}
+/>
+```
+
+- Built on whatever Dialog primitive AppRedlinePane already uses (see
+  `FindingDetailModal` for shape — focus trap, Escape-to-close, scrim).
+- Lives at `app/src/ui/primitives/ConfirmDialog.tsx`.
+- Imperative helper `useConfirm()` for callsites that prefer the
+  `await confirm({...})` shape over JSX state plumbing.
+
+**Migration order (safest first):**
+
+1. `LibraryPanel.tsx:84` — rename prompt → input field inside ConfirmDialog
+   (this is the row-prompt, not a confirm; needs `<InputDialog>` variant or
+   inline input slot — propose at review).
+2. `AppRedlinePane.tsx:113` — clear-all confirm. Already destructive-tone in
+   Negative Red per Wave 54-A; pattern-match that.
+3. `appHelpers.ts:209` (archive overwrite) + `appHelpers.ts:232` (delete-all
+   leases) — destructive confirms with the same chrome.
+
+**Defer:** `SigningKeyPanel.tsx:219/237`, `useAppCallbacks.ts:118`,
+`appHelpers.ts:178/203` — passphrase prompts, blocked on memory-zeroing
+spec.
+
+**Verify:**
+
+- Each migration: existing test continues to pass with the new primitive
+  (mocked confirm replaced with `userEvent.click` on the dialog button).
+- e2e a11y spec stays green.
+- Manual: walk each replaced callsite once in dev, confirm Escape + scrim
+  click + focus return all behave.
+
+### Slice 3 — `<InputDialog>` (only if Slice 2 review asks for it) (PR C)
+
+If LibraryPanel rename feels wrong inside `ConfirmDialog` at review time,
+extract `<InputDialog>` as a sibling primitive — same chrome, adds a labeled
+text field. Otherwise close out without this slice.
+
+## Files touched
+
+- New: `app/src/ui/primitives/StatusMessage.tsx` + `.test.tsx` + `.stories.tsx`
+- New: `app/src/ui/primitives/ConfirmDialog.tsx` + `.test.tsx` + `.stories.tsx`
+- Possibly new: `app/src/ui/primitives/InputDialog.tsx` (Slice 3 only)
+- Migrations across: `LibraryPanel`, `AppRedlinePane`, `appHelpers`, plus
+  ~17 status-recipe sites identified by `grep -rE 'role="(status|alert)"'`.
+
+## Coverage / gates
+
+- Coverage thresholds stay at 97/90/93/97; new primitives must land with
+  tests that don't drop the floor.
+- `vitest-axe` per primitive.
+- Playwright `tests/e2e/a11y.spec.ts` must stay green after each slice.
+
+## Closeout
+
+- Promote backlog row "Wave 48 Slice 3 — `<StatusMessage>` + `<ConfirmDialog>`
+  primitives" to `[x]` with PR refs.
+- Add a Wave 58 entry under Phase 20 closeout in BACKLOG.md.
+- File any deferred status-recipe migrations that didn't fit cleanly.


### PR DESCRIPTION
## Summary

Slice 1 of [Wave 58a plan](docs/plans/wave58a-status-confirm-primitives.md) — the `<StatusMessage>` primitive, no migrations.

- 4-tone surface: `success` / `error` / `info` / `warn`
- Role mapping per WAI-ARIA: `error` → `role="alert"`, all other tones → `role="status"`
- Tailwind classes drawn entirely from existing tokens (`text-positive`, `text-severity-high`, `text-fg-muted`, `text-severity-medium`) — no new colors

## Files

- `app/src/ui/primitives/StatusMessage.tsx` — primitive
- `app/src/ui/primitives/StatusMessage.test.tsx` — vitest + vitest-axe smoke (tone × role × a11y)
- `app/src/ui/primitives/StatusMessage.stories.tsx` — Storybook story per tone
- `docs/plans/wave58a-status-confirm-primitives.md` — plan promoted from untracked

Slice 1 only — migrations of the ~17 existing callsites are deferred to a follow-up wave per dispatch contract.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 warnings
- [x] `npm test` all 1755 tests green (7 new)
- [x] `npm run test:coverage` 97.49 / 90.87 / 93.11 / 97.49 — floors hold