### PR TITLE
wave58a-slice3: InputDialog primitive + LibraryPanel rename migration

### DIFF
--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -267,16 +267,18 @@ describe('App', () => {
     fetchMock.mockRestore();
   });
 
-  it('renames a library entry via prompt', async () => {
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('Renamed.pdf');
+  it('renames a library entry via the InputDialog', async () => {
     render(<App />);
     await uploadLease('Original.pdf');
     await gotoSettings();
     await userEvent.click(screen.getByRole('button', { name: /rename original\.pdf/i }));
+    const input = await screen.findByLabelText('New name');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'Renamed.pdf');
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /open renamed\.pdf/i })).toBeInTheDocument();
     });
-    promptSpy.mockRestore();
   });
 
   it('deletes a library entry', async () => {

--- a/app/src/ui/LibraryPanel.test.tsx
+++ b/app/src/ui/LibraryPanel.test.tsx
@@ -105,9 +105,9 @@ describe('LibraryPanel', () => {
     ).toBeInTheDocument();
   });
 
-  it('fires onRename with the new name when user confirms the prompt', async () => {
+  it('fires onRename with the new name when user confirms in the InputDialog', async () => {
     const onRename = vi.fn();
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('Renamed.pdf');
+    const user = userEvent.setup();
     render(
       <LibraryPanel
         leases={[meta({ id: 'r', name: 'Old.pdf' })]}
@@ -118,14 +118,17 @@ describe('LibraryPanel', () => {
         onRename={onRename}
       />,
     );
-    await userEvent.click(screen.getByRole('button', { name: /rename old\.pdf/i }));
+    await user.click(screen.getByRole('button', { name: /rename old\.pdf/i }));
+    const input = screen.getByLabelText('New name');
+    await user.clear(input);
+    await user.type(input, 'Renamed.pdf');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
     expect(onRename).toHaveBeenCalledWith('r', 'Renamed.pdf');
-    promptSpy.mockRestore();
   });
 
-  it('does not fire onRename if user cancels the prompt', async () => {
+  it('does not fire onRename if user cancels the dialog', async () => {
     const onRename = vi.fn();
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue(null);
+    const user = userEvent.setup();
     render(
       <LibraryPanel
         leases={[meta({ id: 'r', name: 'Old.pdf' })]}
@@ -136,9 +139,27 @@ describe('LibraryPanel', () => {
         onRename={onRename}
       />,
     );
-    await userEvent.click(screen.getByRole('button', { name: /rename old\.pdf/i }));
+    await user.click(screen.getByRole('button', { name: /rename old\.pdf/i }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(onRename).not.toHaveBeenCalled();
-    promptSpy.mockRestore();
+  });
+
+  it('does not fire onRename when the user saves an unchanged name', async () => {
+    const onRename = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <LibraryPanel
+        leases={[meta({ id: 'r', name: 'Old.pdf' })]}
+        standardId={null}
+        onOpen={noop}
+        onDelete={noop}
+        onSetStandard={noop}
+        onRename={onRename}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /rename old\.pdf/i }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onRename).not.toHaveBeenCalled();
   });
 
   it('fires onSetStandard with the lease id', async () => {

--- a/app/src/ui/LibraryPanel.tsx
+++ b/app/src/ui/LibraryPanel.tsx
@@ -1,4 +1,5 @@
 // Wave 27-C — design pass rewrite.
+// Wave 58a Slice 3 — rename prompt migrated from window.prompt to <InputDialog>.
 // Semantic attributes preserved verbatim (e2e critical):
 //   aria-label="library"                (section, both branches)
 //   aria-label={`Open ${l.name}`}       (button — save-and-library.spec.ts + annotation-flow.spec.ts)
@@ -7,10 +8,12 @@
 //   aria-label={`Rename ${l.name}`}     (button)
 //   aria-label={`Delete ${l.name}`}     (button)
 //
+import { useState } from 'react';
 import type { LeaseMetadata } from '../storage/storage';
 import { Section } from './system/Section';
 import { Button } from './system/Button';
 import { EmptyState } from './system/EmptyState';
+import { InputDialog } from './primitives/InputDialog';
 
 interface LibraryPanelProps {
   leases: LeaseMetadata[];
@@ -29,6 +32,8 @@ export function LibraryPanel({
   onSetStandard,
   onRename,
 }: LibraryPanelProps): JSX.Element {
+  const [renameTarget, setRenameTarget] = useState<LeaseMetadata | null>(null);
+
   if (leases.length === 0) {
     return (
       <Section label="library" className="space-y-2 px-4 py-4">
@@ -80,10 +85,7 @@ export function LibraryPanel({
                   type="button"
                   variant="ghost"
                   size="sm"
-                  onClick={() => {
-                    const next = window.prompt('New name:', l.name)?.trim();
-                    if (next && next !== l.name) onRename(l.id, next);
-                  }}
+                  onClick={() => setRenameTarget(l)}
                   aria-label={`Rename ${l.name}`}
                 >
                   Rename
@@ -102,6 +104,21 @@ export function LibraryPanel({
           );
         })}
       </ul>
+      <InputDialog
+        open={renameTarget !== null}
+        title="Rename lease"
+        inputLabel="New name"
+        initialValue={renameTarget?.name ?? ''}
+        confirmLabel="Save"
+        onConfirm={(next) => {
+          const trimmed = next.trim();
+          if (renameTarget && trimmed && trimmed !== renameTarget.name) {
+            onRename(renameTarget.id, trimmed);
+          }
+          setRenameTarget(null);
+        }}
+        onCancel={() => setRenameTarget(null)}
+      />
     </Section>
   );
 }

--- a/app/src/ui/primitives/InputDialog.stories.tsx
+++ b/app/src/ui/primitives/InputDialog.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { InputDialog } from './InputDialog';
+
+const meta: Meta<typeof InputDialog> = {
+  title: 'Primitives/InputDialog',
+  component: InputDialog,
+};
+export default meta;
+type Story = StoryObj<typeof InputDialog>;
+
+function Demo({
+  title,
+  body,
+  inputLabel,
+  initialValue,
+  confirmLabel,
+}: {
+  title: string;
+  body?: string;
+  inputLabel: string;
+  initialValue?: string;
+  confirmLabel: string;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <button type="button" onClick={() => setOpen(true)}>
+        open input
+      </button>
+      <InputDialog
+        open={open}
+        title={title}
+        body={body}
+        inputLabel={inputLabel}
+        initialValue={initialValue}
+        confirmLabel={confirmLabel}
+        onConfirm={() => setOpen(false)}
+        onCancel={() => setOpen(false)}
+      />
+    </div>
+  );
+}
+
+export const RenameLease: Story = {
+  render: () => (
+    <Demo
+      title="Rename lease"
+      inputLabel="New name"
+      initialValue="downtown-loft.pdf"
+      confirmLabel="Save"
+    />
+  ),
+};
+
+export const WithBody: Story = {
+  render: () => (
+    <Demo
+      title="Rename lease"
+      body="The new name shows up in the library and in audit log entries."
+      inputLabel="New name"
+      initialValue="downtown-loft.pdf"
+      confirmLabel="Save"
+    />
+  ),
+};

--- a/app/src/ui/primitives/InputDialog.test.tsx
+++ b/app/src/ui/primitives/InputDialog.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useState } from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { expectAxeClean } from '../../test/axe';
+import { InputDialog } from './InputDialog';
+
+function Harness({
+  initialValue = 'old.pdf',
+  onConfirm,
+  onCancel,
+  body,
+}: {
+  initialValue?: string;
+  onConfirm?: (v: string) => void;
+  onCancel?: () => void;
+  body?: string;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <button type="button" onClick={() => setOpen(true)}>
+        open input
+      </button>
+      <InputDialog
+        open={open}
+        title="Rename lease"
+        body={body}
+        inputLabel="New name"
+        initialValue={initialValue}
+        confirmLabel="Save"
+        onConfirm={(v) => {
+          onConfirm?.(v);
+          setOpen(false);
+        }}
+        onCancel={() => {
+          onCancel?.();
+          setOpen(false);
+        }}
+      />
+    </div>
+  );
+}
+
+describe('InputDialog', () => {
+  it('renders nothing when open is false', () => {
+    render(<Harness />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders title, label, input seeded with initialValue, and buttons', async () => {
+    const user = userEvent.setup();
+    render(<Harness body="Choose a new display name." />);
+    await user.click(screen.getByRole('button', { name: 'open input' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Rename lease')).toBeInTheDocument();
+    expect(screen.getByText('Choose a new display name.')).toBeInTheDocument();
+    const input = screen.getByLabelText('New name') as HTMLInputElement;
+    expect(input.value).toBe('old.pdf');
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('omits the descriptionId association when body is not provided', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('button', { name: 'open input' }));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-labelledby');
+    expect(dialog).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('Save fires onConfirm with the current value', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    render(<Harness onConfirm={onConfirm} />);
+    await user.click(screen.getByRole('button', { name: 'open input' }));
+    const input = screen.getByLabelText('New name');
+    await user.clear(input);
+    await user.type(input, 'New.pdf');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onConfirm).toHaveBeenCalledWith('New.pdf');
+  });
+
+  it('Enter inside the input submits the form (onConfirm)', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    render(<Harness onConfirm={onConfirm} />);
+    await user.click(screen.getByRole('button', { name: 'open input' }));
+    const input = screen.getByLabelText('New name');
+    await user.clear(input);
+    await user.type(input, 'Renamed.pdf{Enter}');
+    expect(onConfirm).toHaveBeenCalledWith('Renamed.pdf');
+  });
+
+  it('Cancel fires onCancel', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    render(<Harness onCancel={onCancel} />);
+    await user.click(screen.getByRole('button', { name: 'open input' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape fires onCancel', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    render(<Harness onCancel={onCancel} />);
+    await user.click(screen.getByRole('button', { name: 'open input' }));
+    await user.keyboard('{Escape}');
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('lands initial focus on the input', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('button', { name: 'open input' }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(document.activeElement).toBe(screen.getByLabelText('New name'));
+  });
+
+  it('resets value to initialValue when re-opened after a cancel', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('button', { name: 'open input' }));
+    const input1 = screen.getByLabelText('New name') as HTMLInputElement;
+    await user.clear(input1);
+    await user.type(input1, 'WIP');
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await user.click(screen.getByRole('button', { name: 'open input' }));
+    const input2 = screen.getByLabelText('New name') as HTMLInputElement;
+    expect(input2.value).toBe('old.pdf');
+  });
+
+  it('is axe-clean', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Harness body="Choose a new display name." />);
+    await user.click(screen.getByRole('button', { name: 'open input' }));
+    await expectAxeClean(container);
+  });
+});

--- a/app/src/ui/primitives/InputDialog.tsx
+++ b/app/src/ui/primitives/InputDialog.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useId, useRef, useState, type ReactNode } from 'react';
+import { Dialog } from '../system/Dialog';
+import { Button } from '../system/Button';
+
+// Wave 58a Slice 3 — `<InputDialog>` primitive.
+//
+// Sibling to `<ConfirmDialog>`: same chrome (focus trap, Escape, scrim,
+// WAI-ARIA APG dialog contract) but adds a labeled text field. Replaces
+// ad-hoc `window.prompt(...)` calls — currently only LibraryPanel's
+// rename flow.
+//
+// Initial focus lands on the input (with the seed value selected) so a
+// keyboard user can immediately type a replacement or press Enter to
+// keep the seed.
+
+interface InputDialogProps {
+  open: boolean;
+  title: string;
+  /** Optional supporting body copy. Renders below the title. */
+  body?: ReactNode;
+  /** Visible label for the text field. */
+  inputLabel: string;
+  /** Initial input value when the dialog opens. */
+  initialValue?: string;
+  confirmLabel: string;
+  /** Defaults to 'Cancel'. */
+  cancelLabel?: string;
+  onConfirm: (value: string) => void;
+  onCancel: () => void;
+}
+
+export function InputDialog({
+  open,
+  title,
+  body,
+  inputLabel,
+  initialValue = '',
+  confirmLabel,
+  cancelLabel = 'Cancel',
+  onConfirm,
+  onCancel,
+}: InputDialogProps): JSX.Element | null {
+  const titleId = useId();
+  const descriptionId = useId();
+  const labelId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [value, setValue] = useState(initialValue);
+
+  // Reset the input each time the dialog re-opens so a stale prior edit
+  // never leaks into a fresh rename.
+  useEffect(() => {
+    if (open) setValue(initialValue);
+  }, [open, initialValue]);
+
+  // Select-on-focus so the user can immediately overtype the seed.
+  useEffect(() => {
+    if (!open) return;
+    Promise.resolve().then(() => inputRef.current?.select());
+  }, [open]);
+
+  if (!open) return null;
+
+  function handleSubmit(e: React.FormEvent): void {
+    e.preventDefault();
+    onConfirm(value);
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onDismiss={onCancel}
+      titleId={titleId}
+      descriptionId={body ? descriptionId : undefined}
+      initialFocusRef={inputRef}
+      closeOnEscape
+    >
+      <h2
+        id={titleId}
+        className="font-serif text-[20px] font-semibold leading-snug text-fg m-0 mb-2"
+      >
+        {title}
+      </h2>
+      {body && (
+        <div
+          id={descriptionId}
+          className="font-serif text-body text-fg-body m-0 mb-4"
+        >
+          {body}
+        </div>
+      )}
+      <form onSubmit={handleSubmit}>
+        <label
+          id={labelId}
+          htmlFor={`${labelId}-input`}
+          className="block text-small text-fg-muted mb-1"
+        >
+          {inputLabel}
+        </label>
+        <input
+          id={`${labelId}-input`}
+          ref={inputRef}
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          className="w-full border border-rule rounded-sm px-2 py-1 text-body bg-paper text-fg focus-visible:focus-ring"
+        />
+        <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
+          <Button type="button" variant="subtle" size="sm" onClick={onCancel}>
+            {cancelLabel}
+          </Button>
+          <Button type="submit" variant="default" size="sm">
+            {confirmLabel}
+          </Button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary

- New `<InputDialog>` primitive (focus trap, Escape, scrim, select-on-focus, resets seed on re-open).
- `LibraryPanel` rename flow: `window.prompt` → `<InputDialog>`. Last non-crypto prompt callsite closed.
- `LibraryPanel.test` + `App.test` rewritten to drive the dialog instead of mocking `window.prompt`.

## Plan

`docs/plans/wave58a-status-confirm-primitives.md` (Slice 3 — conditional, asked for at Slice 2 review).

## Files

- New: `app/src/ui/primitives/InputDialog.{tsx,test.tsx,stories.tsx}`
- Edit: `app/src/ui/LibraryPanel.tsx`
- Edit: `app/src/ui/LibraryPanel.test.tsx`, `app/src/App.test.tsx`

## Deferred (per plan)

- 4 crypto-passphrase prompts (`SigningKeyPanel`, `useAppCallbacks`, `appHelpers`) — still blocked on memory-zeroing pattern.
- `appHelpers` confirm calls — `useConfirm` plumbing too costly.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 1781 passing, 1 todo (was 1768)
- [x] `npm run test:coverage` — 96.47 / 90.89 / 92.98 / 96.47 (floors 96/90/92/96)
- [x] vitest-axe clean on InputDialog (focus trap, label association, Escape, Enter-to-submit)
- [x] LibraryPanel aria-labels preserved verbatim for e2e contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)