### PR TITLE
wave59-slice3: audit-log rotation + CSP frame-ancestors header

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,9 +3,18 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      Wave 59 Slice 3 — `frame-ancestors` was stripped from this <meta>.
+      Per W3C CSP 3 §1.1.4 / §4 it is not enforced via meta and was a
+      no-op as a clickjacking defense; it must be set as an HTTP response
+      header. Dev: see `app/vite.config.ts` `server.headers`. Prod: see
+      `docs/DEPLOY.md` (production hosting must emit
+      `Content-Security-Policy: frame-ancestors 'none'`). The remaining
+      directives below are still effective via meta.
+    -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; font-src 'self'; connect-src 'self' blob:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'"
+      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; font-src 'self'; connect-src 'self' blob:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'none'"
     />
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <title>LeaseGuard</title>

--- a/app/src/audit/auditLog.quota.test.ts
+++ b/app/src/audit/auditLog.quota.test.ts
@@ -1,0 +1,133 @@
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
+import {
+  _resetAuditDbForTests,
+  appendAuditEntry,
+  listAuditEntries,
+  openAuditDb,
+  verifyAuditChain,
+  AUDIT_DB_NAME,
+  CHAIN_TRUNCATED_KIND,
+  QUOTA_ROTATION_DROP_COUNT,
+} from './auditLog';
+
+async function wipe(): Promise<void> {
+  _resetAuditDbForTests();
+  await Promise.resolve();
+  await new Promise<void>((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(AUDIT_DB_NAME);
+    req.onsuccess = (): void => resolve();
+    req.onerror = (): void => reject(req.error);
+    req.onblocked = (): void => resolve();
+  });
+}
+
+function makeQuotaError(): DOMException {
+  // jsdom + fake-indexeddb don't actually throw QuotaExceededError, so
+  // we forge one with the name the spec mandates.
+  const e = new Error('quota exceeded');
+  (e as { name: string }).name = 'QuotaExceededError';
+  return e as unknown as DOMException;
+}
+
+describe('appendAuditEntry: quota rotation policy (Wave 59 Slice 3)', () => {
+  beforeEach(async () => {
+    await wipe();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rotates oldest entries and writes a chain-truncated sentinel when QuotaExceededError fires', async () => {
+    // Seed enough entries that we have some to drop.
+    const totalSeed = QUOTA_ROTATION_DROP_COUNT + 5;
+    for (let i = 0; i < totalSeed; i++) {
+      await appendAuditEntry({ kind: 'analyze', payload: { i } });
+    }
+    expect((await listAuditEntries()).length).toBe(totalSeed);
+
+    // Force the next put to throw QuotaExceededError once. The implementation
+    // should catch it, drop QUOTA_ROTATION_DROP_COUNT oldest entries, write
+    // a `chain-truncated` sentinel, then retry the original put.
+    const db = await openAuditDb();
+    let throws = 1;
+    const realPut = db.put.bind(db);
+    const spy = vi.spyOn(db, 'put').mockImplementation(async (...args: Parameters<typeof db.put>) => {
+      if (throws > 0) {
+        throws--;
+        throw makeQuotaError();
+      }
+      return realPut(...args);
+    });
+
+    const final = await appendAuditEntry({ kind: 'export', payload: { final: true } });
+    spy.mockRestore();
+
+    const entries = await listAuditEntries();
+    // Policy is "drop all + sentinel + retried entry" — see rotateOnQuota.
+    expect(entries.length).toBe(2);
+
+    const sentinel = entries[0];
+    expect(sentinel?.kind).toBe(CHAIN_TRUNCATED_KIND);
+    expect(sentinel?.prevHash).toBe('');
+    const droppedMeta = sentinel?.payload as {
+      droppedCount: number;
+      firstDroppedSeq: number;
+      lastDroppedSeq: number;
+    };
+    expect(droppedMeta.droppedCount).toBe(totalSeed);
+    expect(droppedMeta.firstDroppedSeq).toBe(1);
+    expect(droppedMeta.lastDroppedSeq).toBe(totalSeed);
+
+    // The retried put landed and is the chain tail.
+    expect(entries[entries.length - 1]).toEqual(final);
+    expect(final.kind).toBe('export');
+    // Sanity: QUOTA_ROTATION_DROP_COUNT is still exported as a hint; we
+    // seeded above it to ensure rotation has work to do.
+    expect(totalSeed).toBeGreaterThan(QUOTA_ROTATION_DROP_COUNT);
+
+    // Chain verifies — a chain-truncated entry with empty prevHash is
+    // treated as a legitimate restart point.
+    const v = await verifyAuditChain();
+    expect(v.ok).toBe(true);
+  });
+
+  it('does NOT rotate on non-quota errors (re-throws)', async () => {
+    await appendAuditEntry({ kind: 'analyze', payload: {} });
+
+    const db = await openAuditDb();
+    const spy = vi.spyOn(db, 'put').mockImplementationOnce(async () => {
+      throw new Error('some other failure');
+    });
+
+    await expect(
+      appendAuditEntry({ kind: 'export', payload: {} }),
+    ).rejects.toThrow('some other failure');
+    spy.mockRestore();
+
+    // No sentinel written.
+    const entries = await listAuditEntries();
+    expect(entries.length).toBe(1);
+    expect(entries[0]?.kind).toBe('analyze');
+  });
+
+  it('if rotation cannot free space (still QuotaExceededError after retry), surfaces the error', async () => {
+    // Seed minimal entries.
+    for (let i = 0; i < QUOTA_ROTATION_DROP_COUNT + 2; i++) {
+      await appendAuditEntry({ kind: 'analyze', payload: { i } });
+    }
+
+    const db = await openAuditDb();
+    // Throw on every put — rotation can't help; implementation should give up
+    // after one retry rather than spin forever.
+    const spy = vi.spyOn(db, 'put').mockImplementation(async () => {
+      throw makeQuotaError();
+    });
+
+    await expect(
+      appendAuditEntry({ kind: 'export', payload: {} }),
+    ).rejects.toMatchObject({ name: 'QuotaExceededError' });
+    spy.mockRestore();
+  });
+});

--- a/app/src/audit/auditLog.ts
+++ b/app/src/audit/auditLog.ts
@@ -51,6 +51,31 @@ export interface AuditEntry {
  */
 export const DEFAULT_KEY_ID = 'k0';
 
+/**
+ * Wave 59 Slice 3 — quota-rotation policy. When IndexedDB throws
+ * `QuotaExceededError` on append, the rotation pass drops ALL existing
+ * entries (their `prevHash` linkages reference each other and would no
+ * longer verify after a partial drop), writes a `chain-truncated` sentinel
+ * recording the dropped seq range, then retries the original put once. If
+ * quota still fails after rotation, the error propagates.
+ *
+ * Exported as a constant so tests can describe the policy in one place.
+ * The numeric value is informational — actual policy is "drop all" — but
+ * we keep the symbol so the seed-and-rotate test reads naturally and the
+ * lower bound for "enough seed entries to exercise rotation" is explicit.
+ */
+export const QUOTA_ROTATION_DROP_COUNT = 100;
+
+/**
+ * Sentinel `kind` written after a quota-rotation pass. Its `prevHash` is
+ * intentionally empty so the chain verifier treats it as a legitimate
+ * restart point: rehashing pre-truncation entries is impossible (they're
+ * gone) and we don't want a single quota event to permanently red-flag
+ * the audit log. The sentinel's payload records the dropped seq range so
+ * verifiers can still reason about completeness.
+ */
+export const CHAIN_TRUNCATED_KIND = 'chain-truncated';
+
 interface AuditSchema extends DBSchema {
   [ENTRIES]: {
     key: number;
@@ -211,9 +236,112 @@ export async function appendAuditEntry(input: AppendInput): Promise<AuditEntry> 
     typeof explicit === 'string' ? explicit : DEFAULT_KEY_ID;
   const entry: AuditEntry = { ...base, entryHash, signedByKeyId };
 
-  // 4. Write.
-  await db.put(ENTRIES, entry);
+  // 4. Write — with quota-rotation fallback. If IDB rejects with
+  // QuotaExceededError, drop the oldest QUOTA_ROTATION_DROP_COUNT entries,
+  // write a `chain-truncated` sentinel that records the dropped range, then
+  // retry the put once. The sentinel's prevHash is '' by design — it acts
+  // as a chain restart so the verifier doesn't permanently red-flag the log
+  // after a quota event. If the retry still throws (rotation didn't help),
+  // the error propagates to the caller — the previous behavior was to lose
+  // the write silently inside `safeAudit`'s catch, which let the caller
+  // think the audit landed when it didn't.
+  try {
+    await db.put(ENTRIES, entry);
+  } catch (err) {
+    if (!isQuotaExceeded(err)) throw err;
+    await rotateOnQuota(db);
+    // After rotation, the chain restarts at the sentinel (prevHash ''), so
+    // recompute this entry's seq + prevHash + entryHash relative to the
+    // new tail. The sentinel's seq is `seq` (the seq we originally claimed),
+    // so our retry seq is `seq + 1`.
+    const tail = await readChainTail(db);
+    const retrySeq = tail.lastSeq + 1;
+    const retryBase = {
+      seq: retrySeq,
+      timestamp,
+      kind: input.kind,
+      payload: input.payload,
+      prevHash: tail.prevHash,
+    };
+    const retryHash = await computeEntryHash(retryBase);
+    const retryEntry: AuditEntry = { ...retryBase, entryHash: retryHash, signedByKeyId };
+    await db.put(ENTRIES, retryEntry);
+    return retryEntry;
+  }
   return entry;
+}
+
+function isQuotaExceeded(err: unknown): boolean {
+  if (err == null || typeof err !== 'object') return false;
+  const name = (err as { name?: unknown }).name;
+  return name === 'QuotaExceededError';
+}
+
+async function readChainTail(
+  db: IDBPDatabase<AuditSchema>,
+): Promise<{ lastSeq: number; prevHash: string }> {
+  const tx = db.transaction(ENTRIES, 'readonly');
+  const cursor = await tx.objectStore(ENTRIES).openCursor(null, 'prev');
+  let lastSeq = 0;
+  let prevHash = '';
+  if (cursor) {
+    lastSeq = cursor.value.seq;
+    prevHash = cursor.value.entryHash;
+  }
+  await tx.done;
+  return { lastSeq, prevHash };
+}
+
+/**
+ * Drop ALL existing entries and append a `chain-truncated` sentinel that
+ * records the dropped seq range. The sentinel carries `prevHash = ''` so
+ * `verifyAuditChain` treats it as a legitimate chain restart.
+ *
+ * Why drop everything rather than just the oldest N? Because the prevHash
+ * chain is densely linked — if we drop entries 1..N but keep N+1..M, the
+ * survivor at seq N+1 still references the (now-deleted) entry N's hash in
+ * its prevHash field, and that linkage no longer verifies. The honest
+ * semantics for a quota event are "the chain to date is gone; here's the
+ * sentinel marking the truncation; new entries chain from the sentinel."
+ * Audit history is best-effort under quota pressure (safeAudit already
+ * swallows append failures); this trades partial-history-with-broken-links
+ * for clean-chain-with-clear-truncation-marker.
+ */
+async function rotateOnQuota(db: IDBPDatabase<AuditSchema>): Promise<void> {
+  const keys = (await db.getAllKeys(ENTRIES)).slice().sort((a, b) => a - b);
+  if (keys.length === 0) return; // Nothing to drop.
+
+  const droppedCount = keys.length;
+  const firstDroppedSeq = keys[0] ?? 0;
+  const lastDroppedSeq = keys[keys.length - 1] ?? firstDroppedSeq;
+
+  // Wipe the store in a single rw tx.
+  {
+    const tx = db.transaction(ENTRIES, 'readwrite');
+    await tx.objectStore(ENTRIES).clear();
+    await tx.done;
+  }
+
+  // Sentinel anchors at `lastDroppedSeq + 1` so seq stays strictly
+  // increasing across the truncation event.
+  const sentinelSeq = lastDroppedSeq + 1;
+  const base = {
+    seq: sentinelSeq,
+    timestamp: new Date().toISOString(),
+    kind: CHAIN_TRUNCATED_KIND,
+    payload: {
+      droppedCount,
+      firstDroppedSeq,
+      lastDroppedSeq,
+      reason: 'QuotaExceededError',
+    },
+    prevHash: '',
+  };
+  const entryHash = await computeEntryHash(base);
+  const sentinel: AuditEntry = { ...base, entryHash, signedByKeyId: DEFAULT_KEY_ID };
+  // If the sentinel write itself trips quota, surface the error. We do NOT
+  // recurse: a single rotation pass is the contract.
+  await db.put(ENTRIES, sentinel);
 }
 
 export async function listAuditEntries(): Promise<AuditEntry[]> {
@@ -239,26 +367,60 @@ export interface ChainVerification {
 /**
  * Re-hash every entry and check each `prevHash` linkage. Returns the lowest
  * seq that fails verification; returns `{ ok: true }` for an empty or intact
- * chain. A missing seq (gap) is reported at the position the gap starts.
+ * chain.
+ *
+ * Wave 59 Slice 3 — `chain-truncated` sentinels (written by the quota-
+ * rotation policy in `appendAuditEntry`) act as legitimate chain restarts:
+ * their `prevHash` is '' and the seq jumps past the dropped block, but the
+ * sentinel's own hash is intact and subsequent entries link from it
+ * normally. Strict seq-equals-index from 1 was relaxed to "strictly
+ * increasing"; the sentinel records the dropped seq range in its payload
+ * for verifiers that want to reason about completeness.
  */
 export async function verifyAuditChain(): Promise<ChainVerification> {
   const entries = await listAuditEntries();
   let expectedPrev = '';
+  let lastSeq = 0;
+  // Genesis-or-restart-allowed flag: at the start of the chain, and
+  // immediately after a `chain-truncated` sentinel, the next non-sentinel
+  // entry's seq is allowed to skip past the dropped block.
+  let allowSeqJump = true;
   for (let i = 0; i < entries.length; i++) {
     const e = entries[i];
     if (!e) continue;
-    const expectedSeq = i + 1;
-    if (e.seq !== expectedSeq) {
-      return { ok: false, firstBadSeq: expectedSeq };
-    }
-    if (e.prevHash !== expectedPrev) {
-      return { ok: false, firstBadSeq: e.seq };
+    const isRestart = e.kind === CHAIN_TRUNCATED_KIND && e.prevHash === '';
+    if (isRestart) {
+      // Sentinel may also live mid-chain (post-rotation): its seq must be
+      // greater than the prior tail. After it, the next entry chains from
+      // the sentinel's hash and may also skip seq.
+      if (e.seq <= lastSeq) {
+        return { ok: false, firstBadSeq: e.seq };
+      }
+    } else if (allowSeqJump) {
+      // First real entry of the chain (or first after a sentinel): seq just
+      // needs to be > lastSeq.
+      if (e.seq <= lastSeq) {
+        return { ok: false, firstBadSeq: e.seq };
+      }
+      if (e.prevHash !== expectedPrev) {
+        return { ok: false, firstBadSeq: e.seq };
+      }
+    } else {
+      // Normal mid-chain: seq must be exactly lastSeq + 1 (gap detection).
+      if (e.seq !== lastSeq + 1) {
+        return { ok: false, firstBadSeq: lastSeq + 1 };
+      }
+      if (e.prevHash !== expectedPrev) {
+        return { ok: false, firstBadSeq: e.seq };
+      }
     }
     const rehash = await computeEntryHash(e);
     if (rehash !== e.entryHash) {
       return { ok: false, firstBadSeq: e.seq };
     }
     expectedPrev = e.entryHash;
+    lastSeq = e.seq;
+    allowSeqJump = isRestart;
   }
   return { ok: true };
 }

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -10,6 +10,20 @@ export default defineConfig({
   // the worker chunk can participate in code-splitting (iife — the Vite
   // default for workers — cannot).
   worker: { format: 'es' },
+  // Wave 59 Slice 3 — `frame-ancestors` must be an HTTP response header per
+  // W3C CSP 3; setting it via <meta http-equiv> is silently ignored. We
+  // emit it from the dev server here. Production hosting is responsible
+  // for emitting an equivalent header — see `docs/DEPLOY.md`.
+  server: {
+    headers: {
+      'Content-Security-Policy': "frame-ancestors 'none'",
+    },
+  },
+  preview: {
+    headers: {
+      'Content-Security-Policy': "frame-ancestors 'none'",
+    },
+  },
   plugins: [
     tailwindcss(),
     react(),

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,83 @@
+# Deployment notes
+
+LeaseGuard ships as a static SPA built by Vite (`cd app && npm run build` →
+`app/dist/`). Production hosting is currently undecided / out-of-tree; this
+note exists to record the security headers that must accompany any host
+config when one is added.
+
+## Required HTTP response headers (production)
+
+The host **MUST** emit the following on every HTML response:
+
+```
+Content-Security-Policy: frame-ancestors 'none'
+```
+
+### Why a header (and not the existing `<meta>`)
+
+Per [W3C CSP Level 3 §1.1.4 / §4](https://www.w3.org/TR/CSP3/#meta-element)
+the `frame-ancestors` directive is **explicitly ignored** when delivered
+via `<meta http-equiv="Content-Security-Policy">`. Browsers honor it only
+on the HTTP response. Wave 59 Slice 3 dropped that no-op meta directive
+and moved enforcement into the Vite dev server (`app/vite.config.ts`
+`server.headers` and `preview.headers`).
+
+### Other CSP directives
+
+The remaining directives (`default-src`, `script-src`, `style-src`,
+`img-src`, `font-src`, `connect-src`, `worker-src`, `object-src`,
+`base-uri`, `form-action`) **are** effective via `<meta>` and remain in
+`app/index.html`. Production hosts may optionally upgrade them to a
+header for defense-in-depth, but they're not strictly required to.
+
+## Host-specific snippets
+
+When a host is selected, drop the snippet here.
+
+### Netlify (`netlify.toml`)
+
+```toml
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "frame-ancestors 'none'"
+```
+
+### Vercel (`vercel.json`)
+
+```json
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Content-Security-Policy", "value": "frame-ancestors 'none'" }
+      ]
+    }
+  ]
+}
+```
+
+### Cloudflare Pages / generic `_headers`
+
+```
+/*
+  Content-Security-Policy: frame-ancestors 'none'
+```
+
+### nginx
+
+```
+add_header Content-Security-Policy "frame-ancestors 'none'" always;
+```
+
+## Verification
+
+After deploy, confirm:
+
+```bash
+curl -sI https://<host>/ | grep -i content-security-policy
+```
+
+The response must include `frame-ancestors 'none'`. If absent, the page is
+embeddable in arbitrary iframes — clickjacking defense is missing.


### PR DESCRIPTION
## Summary
- **Audit-log quota rotation** — `appendAuditEntry` now catches `QuotaExceededError`, drops all existing entries (a partial drop would break `prevHash` linkages), writes a `chain-truncated` sentinel recording the dropped seq range, and retries the put once. `verifyAuditChain` treats the sentinel as a legitimate chain restart (`prevHash === ''`, seq jumps allowed). Non-quota errors propagate; quota-after-retry surfaces too. Closes the Wave 50 deferral where `safeAudit` silently swallowed quota errors and lost subsequent writes.
- **CSP `frame-ancestors`** — moved off `<meta http-equiv>` (no-op per W3C CSP 3) into `vite.config.ts` `server.headers` + `preview.headers`. Production hosting must emit the header itself; documented with copy-paste snippets in `docs/DEPLOY.md` (Netlify, Vercel, Cloudflare, nginx). Other CSP directives stay in `<meta>` (effective there).

## Files
- `app/src/audit/auditLog.ts` — quota rotation + sentinel + relaxed chain verifier
- `app/src/audit/auditLog.quota.test.ts` — new (3 cases: rotate-and-retry, non-quota passthrough, quota-after-retry)
- `app/index.html` — strip `frame-ancestors`, leave other CSP directives
- `app/vite.config.ts` — `server.headers` + `preview.headers` CSP
- `docs/DEPLOY.md` — new, host-config reference

## Test plan
- [x] `npm test -- --run` (1784 passed, 1 todo)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] Coverage on `auditLog.ts`: 97.15% lines / 100% funcs / 81.66% branches
- [ ] Manual: `npm run dev` and verify response headers include `Content-Security-Policy: frame-ancestors 'none'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)